### PR TITLE
feat: per-sensor data retention policies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -255,5 +255,6 @@ __debug*
 # Compiled binaries
 sensor-hub-arm64
 sensorHub
+*.test
 
 docs/plans

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -58,10 +58,10 @@ This means changes take effect without restarting the service.
 | `sensor.collection.interval`           | `300`                              | Seconds between sensor polling cycles                                              |
 | `sensor.discovery.skip`                | `true`                             | When set to `true`, skips automatic sensor discovery on startup                    |
 | `openapi.yaml.location`                | `./docker_tests/openapi.yaml`      | Path to openapi.yaml file for auto-discovery of sensors (used in development)      |
-| `health.history.retention.days`        | `180`                              | Number of days to retain sensor health history records                             |
-| `sensor.data.retention.days`           | `365`                              | Number of days to retain temperature reading data                                  |
+| `health.history.retention.days`        | `30`                               | Number of days to retain sensor health history records                             |
+| `sensor.data.retention.days`           | `90`                               | Number of days to retain temperature reading data                                  |
 | `failed.login.retention.days`          | `2`                                | Number of days to retain failed login attempt records                              |
-| `data.cleanup.interval.hours`          | `24`                               | Hours between data cleanup runs                                                    |
+| `data.cleanup.interval.hours`          | `1`                                | Hours between data cleanup runs                                                    |
 | `auth.bcrypt.cost`                     | `12`                               | Bcrypt cost factor for password hashing (higher values are more secure but slower) |
 | `auth.session.ttl.minutes`             | `43200`                            | Session duration in minutes (default is 30 days)                                   |
 | `auth.session.cookie.name`             | `sensor_hub_session`               | Name of the session cookie                                                         |

--- a/docs/docs/managing-sensors.md
+++ b/docs/docs/managing-sensors.md
@@ -57,7 +57,22 @@ Health history is retained for a configurable period (default: 180 days), contro
 
 ## Data retention
 
-Temperature readings are retained for a configurable period (default: 365 days), controlled by the `sensor.data.retention.days` property. A cleanup task runs at a configurable interval (default: every 24 hours) to remove expired data.
+Sensor readings are retained for a configurable period (default: 90 days), controlled by the `sensor.data.retention.days` property. A cleanup task runs at a configurable interval (default: every 1 hour) to remove expired data.
+
+### Per-sensor retention
+
+Individual sensors can override the global retention period with a custom value in hours. This is useful when some sensors produce high-volume data that should be kept for a shorter period, or when critical sensors need longer retention.
+
+Per-sensor retention can be configured:
+
+- Through the web UI on the individual Sensor page, using the Data Retention card (requires `manage_sensors` permission).
+- Through the Data Retention overview page, which shows all sensors and their retention settings.
+- Through the REST API by sending a `PUT` request to `/sensors/:id` with `retention_hours` in the body. Set to a positive integer to override, or `null` to revert to the global default. See the [Sensors and Readings API reference](api/sensors-and-readings) for details.
+- Through the CLI: `sensor-hub sensors update <id> --retention-hours <hours>` or `sensor-hub sensors update <id> --retention-hours null`
+
+When a per-sensor retention is set, it always takes precedence over the global default. The cleanup task processes sensors with custom retention first, then applies the global retention to all remaining sensors.
+
+The effective retention for a sensor can be seen via the `GET /sensors/:name` endpoint, which returns an `effective_retention_hours` field showing the retention that will actually be applied during cleanup.
 
 ## Managing sensors in the UI
 

--- a/sensor_hub/api/mocks_test.go
+++ b/sensor_hub/api/mocks_test.go
@@ -162,6 +162,14 @@ func (m *MockSensorService) ServiceGetSensorByName(ctx context.Context, name str
 	return args.Get(0).(*types.Sensor), args.Error(1)
 }
 
+func (m *MockSensorService) ServiceGetSensorById(ctx context.Context, id int) (*types.Sensor, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*types.Sensor), args.Error(1)
+}
+
 func (m *MockSensorService) ServiceGetAllSensors(ctx context.Context) ([]types.Sensor, error) {
 	args := m.Called(ctx)
 	return args.Get(0).([]types.Sensor), args.Error(1)

--- a/sensor_hub/api/openapi.yaml
+++ b/sensor_hub/api/openapi.yaml
@@ -3410,6 +3410,23 @@ components:
           description: >-
             Lifecycle status. Push-based sensors start as "pending" until
             approved. "dismissed" sensors are hidden but can be restored.
+        retention_hours:
+          type: integer
+          nullable: true
+          minimum: 1
+          description: >-
+            Per-sensor data retention override, in hours. When set, this
+            overrides the global `sensor.data.retention.days` configuration
+            for this sensor's readings. Set to null to revert to the global
+            default. Absent on list endpoints when not configured.
+        effective_retention_hours:
+          type: integer
+          readOnly: true
+          description: >-
+            Computed retention in hours that will actually be applied during
+            cleanup: the sensor's own `retention_hours` if set, otherwise
+            `sensor.data.retention.days × 24`. Only returned on the single-
+            sensor GET endpoint.
       required:
         - id
         - name
@@ -3425,6 +3442,8 @@ components:
         health_reason: "ok"
         enabled: true
         status: "active"
+        retention_hours: null
+        effective_retention_hours: 2160
 
     ConfigFieldSpec:
       type: object

--- a/sensor_hub/api/sensor_api.go
+++ b/sensor_hub/api/sensor_api.go
@@ -19,6 +19,21 @@ func InitSensorAPI(s service.SensorServiceInterface) {
 	sensorService = s
 }
 
+// sensorDetailResponse extends types.Sensor with computed fields for the single-sensor endpoint.
+type sensorDetailResponse struct {
+	types.Sensor
+	EffectiveRetentionHours int `json:"effective_retention_hours"`
+}
+
+// computeEffectiveRetentionHours returns the sensor's custom retention if set, otherwise
+// the global default (sensor.data.retention.days × 24 hours).
+func computeEffectiveRetentionHours(sensor types.Sensor) int {
+	if sensor.RetentionHours != nil {
+		return *sensor.RetentionHours
+	}
+	return appProps.AppConfig.SensorDataRetentionDays * 24
+}
+
 func addSensorHandler(c *gin.Context) {
 	ctx := c.Request.Context()
 	var sensor types.Sensor
@@ -47,16 +62,22 @@ func updateSensorHandler(c *gin.Context) {
 		return
 	}
 
-	// Parse as raw map to support merge-patch semantics on config
+	// Parse as raw map to support merge-patch semantics
 	var body map[string]interface{}
 	if err := c.BindJSON(&body); err != nil {
 		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid request body"})
 		return
 	}
 
-	// Build sensor from body fields
-	var sensor types.Sensor
-	sensor.Id = idInt
+	// Load existing sensor so partial updates (e.g. retention_hours only) don't clobber other fields.
+	existing, err := sensorService.ServiceGetSensorById(ctx, idInt)
+	if err != nil {
+		c.IndentedJSON(http.StatusNotFound, gin.H{"message": "Sensor not found", "error": err.Error()})
+		return
+	}
+
+	// Start from the existing state and overlay whatever the caller provided.
+	sensor := *existing
 	if name, ok := body["name"].(string); ok {
 		sensor.Name = name
 	}
@@ -69,11 +90,15 @@ func updateSensorHandler(c *gin.Context) {
 
 	// Handle config with merge-patch semantics
 	if rawConfig, exists := body["config"]; exists {
-		sensor.Config = make(map[string]string)
+		merged := make(map[string]string)
+		for k, v := range existing.Config {
+			merged[k] = v
+		}
 		if configMap, ok := rawConfig.(map[string]interface{}); ok {
 			for k, v := range configMap {
 				if v == nil {
-					// null means delete key — skip it
+					// null means delete key
+					delete(merged, k)
 					continue
 				}
 				if strVal, ok := v.(string); ok {
@@ -81,9 +106,29 @@ func updateSensorHandler(c *gin.Context) {
 					if strVal == "****" {
 						continue
 					}
-					sensor.Config[k] = strVal
+					merged[k] = strVal
 				}
 			}
+		}
+		sensor.Config = merged
+	}
+
+	// Handle retention_hours with explicit-presence semantics:
+	// absent = no-op, null = clear custom value, positive integer = set custom value.
+	if rawRetention, exists := body["retention_hours"]; exists {
+		sensor.RetentionHoursPresent = true
+		if rawRetention == nil {
+			sensor.RetentionHours = nil
+		} else if hours, ok := rawRetention.(float64); ok {
+			if hours <= 0 {
+				c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "retention_hours must be a positive integer"})
+				return
+			}
+			h := int(hours)
+			sensor.RetentionHours = &h
+		} else {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "retention_hours must be a positive integer or null"})
+			return
 		}
 	}
 
@@ -127,7 +172,11 @@ func getSensorByNameHandler(c *gin.Context) {
 		c.IndentedJSON(http.StatusNotFound, gin.H{"message": "Sensor not found"})
 		return
 	}
-	c.IndentedJSON(http.StatusOK, maskSensitiveConfig(*sensor))
+	masked := maskSensitiveConfig(*sensor)
+	c.IndentedJSON(http.StatusOK, sensorDetailResponse{
+		Sensor:                  masked,
+		EffectiveRetentionHours: computeEffectiveRetentionHours(masked),
+	})
 }
 
 func getAllSensorsHandler(c *gin.Context) {

--- a/sensor_hub/api/sensor_api_test.go
+++ b/sensor_hub/api/sensor_api_test.go
@@ -76,13 +76,15 @@ func TestUpdateSensorHandler(t *testing.T) {
 	router, api, mockService := setupSensorRouter()
 	api.PUT("/sensors/:id", updateSensorHandler)
 
-	sensor := types.Sensor{Name: "s1-updated", SensorDriver: "sensor-hub-http-temperature", Config: map[string]string{"url": "http://localhost:8080"}}
-	jsonBody, _ := json.Marshal(sensor)
-	
-	expectedSensor := sensor
-	expectedSensor.Id = 1
+	existing := types.Sensor{Id: 1, Name: "s1", SensorDriver: "sensor-hub-http-temperature", Config: map[string]string{"url": "http://localhost:8080"}, Enabled: true}
+	update := map[string]interface{}{"name": "s1-updated", "sensor_driver": "sensor-hub-http-temperature", "config": map[string]interface{}{"url": "http://localhost:8080"}}
+	jsonBody, _ := json.Marshal(update)
 
-	mockService.On("ServiceUpdateSensorById", mock.Anything, expectedSensor).Return(nil)
+	expected := existing
+	expected.Name = "s1-updated"
+
+	mockService.On("ServiceGetSensorById", mock.Anything, 1).Return(&existing, nil)
+	mockService.On("ServiceUpdateSensorById", mock.Anything, expected).Return(nil)
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("PUT", "/api/sensors/1", bytes.NewBuffer(jsonBody))
@@ -292,13 +294,15 @@ func TestUpdateSensorHandler_ServiceError(t *testing.T) {
 	router, api, mockService := setupSensorRouter()
 	api.PUT("/sensors/:id", updateSensorHandler)
 
-	sensor := types.Sensor{Name: "s1-updated", SensorDriver: "sensor-hub-http-temperature", Config: map[string]string{"url": "http://localhost:8080"}}
-	jsonBody, _ := json.Marshal(sensor)
-	
-	expectedSensor := sensor
-	expectedSensor.Id = 1
+	existing := types.Sensor{Id: 1, Name: "s1", SensorDriver: "sensor-hub-http-temperature", Config: map[string]string{"url": "http://localhost:8080"}}
+	update := map[string]interface{}{"name": "s1-updated", "sensor_driver": "sensor-hub-http-temperature", "config": map[string]interface{}{"url": "http://localhost:8080"}}
+	jsonBody, _ := json.Marshal(update)
 
-	mockService.On("ServiceUpdateSensorById", mock.Anything, expectedSensor).Return(errors.New("db error"))
+	expected := existing
+	expected.Name = "s1-updated"
+
+	mockService.On("ServiceGetSensorById", mock.Anything, 1).Return(&existing, nil)
+	mockService.On("ServiceUpdateSensorById", mock.Anything, expected).Return(errors.New("db error"))
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("PUT", "/api/sensors/1", bytes.NewBuffer(jsonBody))

--- a/sensor_hub/application_properties/application_configuration.go
+++ b/sensor_hub/application_properties/application_configuration.go
@@ -9,10 +9,10 @@ type ApplicationConfiguration struct {
 	SensorCollectionInterval           int    `prop:"sensor.collection.interval" default:"300" file:"application" validate:"positive"`
 	SensorDiscoverySkip                bool   `prop:"sensor.discovery.skip" default:"true" file:"application"`
 	OpenAPILocation                    string `prop:"openapi.yaml.location" default:"./docker_tests/openapi.yaml" file:"application"`
-	HealthHistoryRetentionDays         int    `prop:"health.history.retention.days" default:"180" file:"application" validate:"non_negative"`
-	SensorDataRetentionDays            int    `prop:"sensor.data.retention.days" default:"365" file:"application" validate:"non_negative"`
+	HealthHistoryRetentionDays         int    `prop:"health.history.retention.days" default:"30" file:"application" validate:"non_negative"`
+	SensorDataRetentionDays            int    `prop:"sensor.data.retention.days" default:"90" file:"application" validate:"non_negative"`
 	FailedLoginRetentionDays           int    `prop:"failed.login.retention.days" default:"2" file:"application" validate:"non_negative"`
-	DataCleanupIntervalHours           int    `prop:"data.cleanup.interval.hours" default:"24" file:"application" validate:"positive"`
+	DataCleanupIntervalHours           int    `prop:"data.cleanup.interval.hours" default:"1" file:"application" validate:"positive"`
 	HealthHistoryDefaultResponseNumber int    `prop:"health.history.default.response.number" default:"1000" file:"application" validate:"positive"`
 
 	SMTPUser string `prop:"smtp.user" default:"" file:"smtp"`

--- a/sensor_hub/db/migrations/000015_sensor_retention.down.sql
+++ b/sensor_hub/db/migrations/000015_sensor_retention.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sensors DROP COLUMN retention_hours;

--- a/sensor_hub/db/migrations/000015_sensor_retention.up.sql
+++ b/sensor_hub/db/migrations/000015_sensor_retention.up.sql
@@ -1,0 +1,4 @@
+-- Migration 000015: Per-sensor data retention
+-- Adds nullable retention_hours column to sensors table.
+-- NULL means use the global default (sensor.data.retention.days config).
+ALTER TABLE sensors ADD COLUMN retention_hours INTEGER DEFAULT NULL;

--- a/sensor_hub/db/readings_repository.go
+++ b/sensor_hub/db/readings_repository.go
@@ -7,6 +7,7 @@ import (
 	"example/sensorHub/utils"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 )
 
@@ -141,6 +142,65 @@ func (r *ReadingsRepositoryImpl) DeleteReadingsOlderThan(ctx context.Context, cu
 	for _, table := range []string{types.TableReadings, types.TableHourlyAverages, types.TableHourlyEvents} {
 		query := fmt.Sprintf("DELETE FROM %s WHERE time < ?", table)
 		if _, err := tx.ExecContext(ctx, query, cutoffDateTime); err != nil {
+			return fmt.Errorf("error deleting old readings from %s: %w", table, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+	return nil
+}
+
+// DeleteReadingsOlderThanForSensor deletes readings older than cutoff for a specific sensor.
+// All three reading tables (readings, hourly_averages, hourly_events) are cleaned atomically.
+func (r *ReadingsRepositoryImpl) DeleteReadingsOlderThanForSensor(ctx context.Context, cutoffDateTime time.Time, sensorId int) error {
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	for _, table := range []string{types.TableReadings, types.TableHourlyAverages, types.TableHourlyEvents} {
+		query := fmt.Sprintf("DELETE FROM %s WHERE sensor_id = ? AND time < ?", table)
+		if _, err := tx.ExecContext(ctx, query, sensorId, cutoffDateTime); err != nil {
+			return fmt.Errorf("error deleting old readings from %s for sensor %d: %w", table, sensorId, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+	return nil
+}
+
+// DeleteReadingsOlderThanExcludingSensors deletes readings older than cutoff for all sensors
+// except those in the excludedSensorIds list (which have custom per-sensor retention applied separately).
+// If excludedSensorIds is empty, all sensors are cleaned (same as DeleteReadingsOlderThan).
+func (r *ReadingsRepositoryImpl) DeleteReadingsOlderThanExcludingSensors(ctx context.Context, cutoffDateTime time.Time, excludedSensorIds []int) error {
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	for _, table := range []string{types.TableReadings, types.TableHourlyAverages, types.TableHourlyEvents} {
+		var query string
+		var args []any
+		if len(excludedSensorIds) == 0 {
+			query = fmt.Sprintf("DELETE FROM %s WHERE time < ?", table)
+			args = []any{cutoffDateTime}
+		} else {
+			placeholders := strings.Repeat("?,", len(excludedSensorIds))
+			placeholders = placeholders[:len(placeholders)-1] // trim trailing comma
+			query = fmt.Sprintf("DELETE FROM %s WHERE time < ? AND sensor_id NOT IN (%s)", table, placeholders)
+			args = make([]any, 0, 1+len(excludedSensorIds))
+			args = append(args, cutoffDateTime)
+			for _, id := range excludedSensorIds {
+				args = append(args, id)
+			}
+		}
+		if _, err := tx.ExecContext(ctx, query, args...); err != nil {
 			return fmt.Errorf("error deleting old readings from %s: %w", table, err)
 		}
 	}

--- a/sensor_hub/db/readings_repository_interface.go
+++ b/sensor_hub/db/readings_repository_interface.go
@@ -12,6 +12,8 @@ type ReadingsRepository interface {
 	GetLatest(ctx context.Context) ([]types.Reading, error)
 	GetTotalReadingsBySensorId(ctx context.Context, sensorId int) (int, error)
 	DeleteReadingsOlderThan(ctx context.Context, cutoffDate time.Time) error
+	DeleteReadingsOlderThanForSensor(ctx context.Context, cutoffDate time.Time, sensorId int) error
+	DeleteReadingsOlderThanExcludingSensors(ctx context.Context, cutoffDate time.Time, excludedSensorIds []int) error
 	ComputeHourlyAverages(ctx context.Context) error
 	ComputeHourlyEvents(ctx context.Context) error
 }

--- a/sensor_hub/db/sensor_repository.go
+++ b/sensor_hub/db/sensor_repository.go
@@ -179,7 +179,7 @@ func (s *SensorRepository) DeleteSensorByName(ctx context.Context, name string) 
 }
 
 func (s *SensorRepository) GetSensorsByDriver(ctx context.Context, sensorDriver string) ([]types.Sensor, error) {
-	query := "SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status FROM sensors WHERE LOWER(sensor_driver) = LOWER(?)"
+	query := "SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status, retention_hours FROM sensors WHERE LOWER(sensor_driver) = LOWER(?)"
 	rows, err := s.db.QueryContext(ctx, query, sensorDriver)
 	if err != nil {
 		return nil, fmt.Errorf("error querying sensors by driver: %w", err)
@@ -205,8 +205,16 @@ func (s *SensorRepository) UpdateSensorById(ctx context.Context, sensor types.Se
 	if err != nil {
 		return fmt.Errorf("error marshalling sensor config: %w", err)
 	}
-	query := "UPDATE sensors SET name = ?, sensor_driver = ?, config = ? WHERE id = ?"
-	result, err := s.db.ExecContext(ctx, query, sensor.Name, sensor.SensorDriver, string(configJSON), sensor.Id)
+
+	var result sql.Result
+	if sensor.RetentionHoursPresent {
+		// Include retention_hours in the same UPDATE so both changes are atomic.
+		query := "UPDATE sensors SET name = ?, sensor_driver = ?, config = ?, retention_hours = ? WHERE id = ?"
+		result, err = s.db.ExecContext(ctx, query, sensor.Name, sensor.SensorDriver, string(configJSON), sensor.RetentionHours, sensor.Id)
+	} else {
+		query := "UPDATE sensors SET name = ?, sensor_driver = ?, config = ? WHERE id = ?"
+		result, err = s.db.ExecContext(ctx, query, sensor.Name, sensor.SensorDriver, string(configJSON), sensor.Id)
+	}
 	if err != nil {
 		return fmt.Errorf("error updating sensor: %w", err)
 	}
@@ -245,8 +253,20 @@ func (s *SensorRepository) AddSensor(ctx context.Context, sensor types.Sensor) e
 	return nil
 }
 
+func (s *SensorRepository) GetSensorById(ctx context.Context, id int) (*types.Sensor, error) {
+	query := "SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status, retention_hours FROM sensors WHERE id = ?"
+	sensor, err := scanSensorRow(s.db.QueryRowContext(ctx, query, id))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("no sensor found with id %d", id)
+		}
+		return nil, fmt.Errorf("error querying sensor by id: %w", err)
+	}
+	return &sensor, nil
+}
+
 func (s *SensorRepository) GetSensorByName(ctx context.Context, name string) (*types.Sensor, error) {
-	query := "SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status FROM sensors WHERE LOWER(name) = LOWER(?)"
+	query := "SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status, retention_hours FROM sensors WHERE LOWER(name) = LOWER(?)"
 	sensor, err := scanSensorRow(s.db.QueryRowContext(ctx, query, name))
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -258,7 +278,7 @@ func (s *SensorRepository) GetSensorByName(ctx context.Context, name string) (*t
 }
 
 func (s *SensorRepository) GetSensorByExternalId(ctx context.Context, externalId string) (*types.Sensor, error) {
-	query := "SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status FROM sensors WHERE LOWER(external_id) = LOWER(?)"
+	query := "SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status, retention_hours FROM sensors WHERE LOWER(external_id) = LOWER(?)"
 	sensor, err := scanSensorRow(s.db.QueryRowContext(ctx, query, externalId))
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -280,7 +300,7 @@ func (s *SensorRepository) SensorExistsByExternalId(ctx context.Context, externa
 }
 
 func (s *SensorRepository) GetAllSensors(ctx context.Context) ([]types.Sensor, error) {
-	query := "SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status FROM sensors"
+	query := "SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status, retention_hours FROM sensors"
 	rows, err := s.db.QueryContext(ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf("error querying all sensors: %w", err)
@@ -329,18 +349,24 @@ type scannable interface {
 	Scan(dest ...any) error
 }
 
-// scanSensorRow scans a sensor row (columns: id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status)
-// and unmarshals the JSON config column into the Config map.
+// scanSensorRow scans a sensor row (columns: id, name, external_id, sensor_driver, config,
+// health_status, health_reason, enabled, status, retention_hours) and unmarshals the JSON
+// config column into the Config map.
 func scanSensorRow(row scannable) (types.Sensor, error) {
 	var s types.Sensor
 	var configJSON string
 	var externalId sql.NullString
-	err := row.Scan(&s.Id, &s.Name, &externalId, &s.SensorDriver, &configJSON, &s.HealthStatus, &s.HealthReason, &s.Enabled, &s.Status)
+	var retentionHours sql.NullInt64
+	err := row.Scan(&s.Id, &s.Name, &externalId, &s.SensorDriver, &configJSON, &s.HealthStatus, &s.HealthReason, &s.Enabled, &s.Status, &retentionHours)
 	if err != nil {
 		return s, err
 	}
 	if externalId.Valid {
 		s.ExternalId = &externalId.String
+	}
+	if retentionHours.Valid {
+		v := int(retentionHours.Int64)
+		s.RetentionHours = &v
 	}
 	if configJSON != "" {
 		if err := json.Unmarshal([]byte(configJSON), &s.Config); err != nil {
@@ -354,10 +380,33 @@ func scanSensorRow(row scannable) (types.Sensor, error) {
 }
 
 func (sr *SensorRepository) GetSensorsByStatus(ctx context.Context, status string) ([]types.Sensor, error) {
-	query := "SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status FROM sensors WHERE LOWER(status) = LOWER(?)"
+	query := "SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status, retention_hours FROM sensors WHERE LOWER(status) = LOWER(?)"
 	rows, err := sr.db.QueryContext(ctx, query, status)
 	if err != nil {
 		return nil, fmt.Errorf("error querying sensors by status: %w", err)
+	}
+	defer rows.Close()
+
+	var sensors []types.Sensor
+	for rows.Next() {
+		sensor, err := scanSensorRow(rows)
+		if err != nil {
+			return nil, fmt.Errorf("error scanning sensor row: %w", err)
+		}
+		sensors = append(sensors, sensor)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating over sensor rows: %w", err)
+	}
+	return sensors, nil
+}
+
+// GetSensorsWithRetention returns all sensors that have a custom retention_hours set.
+func (sr *SensorRepository) GetSensorsWithRetention(ctx context.Context) ([]types.Sensor, error) {
+	query := "SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status, retention_hours FROM sensors WHERE retention_hours IS NOT NULL"
+	rows, err := sr.db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("error querying sensors with custom retention: %w", err)
 	}
 	defer rows.Close()
 

--- a/sensor_hub/db/sensor_repository_interface.go
+++ b/sensor_hub/db/sensor_repository_interface.go
@@ -13,6 +13,7 @@ type SensorRepositoryInterface[T any] interface {
 	DeleteSensorByName(ctx context.Context, name string) error
 	GetSensorByName(ctx context.Context, name string) (*T, error)
 	GetSensorByExternalId(ctx context.Context, externalId string) (*T, error)
+	GetSensorById(ctx context.Context, id int) (*T, error)
 	SetEnabledSensorByName(ctx context.Context, name string, enabled bool) error
 	GetAllSensors(ctx context.Context) ([]T, error)
 	GetSensorsByDriver(ctx context.Context, sensorDriver string) ([]T, error)
@@ -24,4 +25,5 @@ type SensorRepositoryInterface[T any] interface {
 	UpdateSensorStatus(ctx context.Context, sensorId int, status string) error
 	GetSensorHealthHistoryById(ctx context.Context, sensorId int, limit int) ([]types.SensorHealthHistory, error)
 	DeleteHealthHistoryOlderThan(ctx context.Context, cutoffDate time.Time) error
+	GetSensorsWithRetention(ctx context.Context) ([]types.Sensor, error)
 }

--- a/sensor_hub/db/sensor_repository_test.go
+++ b/sensor_hub/db/sensor_repository_test.go
@@ -138,10 +138,10 @@ func TestSensorRepository_GetSensorByName_Success(t *testing.T) {
 	db, mock := newMockDB(t)
 	repo := NewSensorRepository(db, slog.Default())
 
-	mock.ExpectQuery("SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status FROM sensors WHERE LOWER\\(name\\) = LOWER\\(\\?\\)").
+	mock.ExpectQuery("SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status, retention_hours FROM sensors WHERE LOWER\\(name\\) = LOWER\\(\\?\\)").
 		WithArgs("test-sensor").
 		WillReturnRows(sqlmock.NewRows(sensorColumns).
-			AddRow(1, "test-sensor", nil, "temperature", `{"url":"http://localhost:8080"}`, "good", "ok", true, "active"))
+			AddRow(1, "test-sensor", nil, "temperature", `{"url":"http://localhost:8080"}`, "good", "ok", true, "active", nil))
 
 	sensor, err := repo.GetSensorByName(context.Background(), "test-sensor")
 
@@ -160,7 +160,7 @@ func TestSensorRepository_GetSensorByName_NotFound(t *testing.T) {
 	db, mock := newMockDB(t)
 	repo := NewSensorRepository(db, slog.Default())
 
-	mock.ExpectQuery("SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status FROM sensors WHERE LOWER\\(name\\) = LOWER\\(\\?\\)").
+	mock.ExpectQuery("SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status, retention_hours FROM sensors WHERE LOWER\\(name\\) = LOWER\\(\\?\\)").
 		WithArgs("nonexistent").
 		WillReturnError(sql.ErrNoRows)
 
@@ -176,7 +176,7 @@ func TestSensorRepository_GetSensorByName_DBError(t *testing.T) {
 	db, mock := newMockDB(t)
 	repo := NewSensorRepository(db, slog.Default())
 
-	mock.ExpectQuery("SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status FROM sensors WHERE LOWER\\(name\\) = LOWER\\(\\?\\)").
+	mock.ExpectQuery("SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status, retention_hours FROM sensors WHERE LOWER\\(name\\) = LOWER\\(\\?\\)").
 		WithArgs("test-sensor").
 		WillReturnError(errors.New("connection error"))
 
@@ -196,10 +196,10 @@ func TestSensorRepository_GetAllSensors_Success(t *testing.T) {
 	db, mock := newMockDB(t)
 	repo := NewSensorRepository(db, slog.Default())
 
-	mock.ExpectQuery("SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status FROM sensors").
+	mock.ExpectQuery("SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status, retention_hours FROM sensors").
 		WillReturnRows(sqlmock.NewRows(sensorColumns).
-			AddRow(1, "sensor-1", nil, "temperature", `{"url":"http://localhost:8081"}`, "good", "ok", true, "active").
-			AddRow(2, "sensor-2", nil, "temperature", `{"url":"http://localhost:8082"}`, "bad", "timeout", false, "active"))
+			AddRow(1, "sensor-1", nil, "temperature", `{"url":"http://localhost:8081"}`, "good", "ok", true, "active", nil).
+			AddRow(2, "sensor-2", nil, "temperature", `{"url":"http://localhost:8082"}`, "bad", "timeout", false, "active", nil))
 
 	sensors, err := repo.GetAllSensors(context.Background())
 
@@ -214,7 +214,7 @@ func TestSensorRepository_GetAllSensors_EmptyTable(t *testing.T) {
 	db, mock := newMockDB(t)
 	repo := NewSensorRepository(db, slog.Default())
 
-	mock.ExpectQuery("SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status FROM sensors").
+	mock.ExpectQuery("SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status, retention_hours FROM sensors").
 		WillReturnRows(sqlmock.NewRows(sensorColumns))
 
 	sensors, err := repo.GetAllSensors(context.Background())
@@ -228,7 +228,7 @@ func TestSensorRepository_GetAllSensors_DBError(t *testing.T) {
 	db, mock := newMockDB(t)
 	repo := NewSensorRepository(db, slog.Default())
 
-	mock.ExpectQuery("SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status FROM sensors").
+	mock.ExpectQuery("SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status, retention_hours FROM sensors").
 		WillReturnError(errors.New("database error"))
 
 	sensors, err := repo.GetAllSensors(context.Background())
@@ -247,11 +247,11 @@ func TestSensorRepository_GetSensorsByDriver_Success(t *testing.T) {
 	db, mock := newMockDB(t)
 	repo := NewSensorRepository(db, slog.Default())
 
-	mock.ExpectQuery("SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status FROM sensors WHERE LOWER\\(sensor_driver\\) = LOWER\\(\\?\\)").
+	mock.ExpectQuery("SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status, retention_hours FROM sensors WHERE LOWER\\(sensor_driver\\) = LOWER\\(\\?\\)").
 		WithArgs("sensor-hub-http-temperature").
 		WillReturnRows(sqlmock.NewRows(sensorColumns).
-			AddRow(1, "temp-sensor-1", nil, "sensor-hub-http-temperature", `{"url":"http://localhost:8081"}`, "good", "ok", true, "active").
-			AddRow(2, "temp-sensor-2", nil, "sensor-hub-http-temperature", `{"url":"http://localhost:8082"}`, "good", "ok", true, "active"))
+			AddRow(1, "temp-sensor-1", nil, "sensor-hub-http-temperature", `{"url":"http://localhost:8081"}`, "good", "ok", true, "active", nil).
+			AddRow(2, "temp-sensor-2", nil, "sensor-hub-http-temperature", `{"url":"http://localhost:8082"}`, "good", "ok", true, "active", nil))
 
 	sensors, err := repo.GetSensorsByDriver(context.Background(), "sensor-hub-http-temperature")
 
@@ -264,7 +264,7 @@ func TestSensorRepository_GetSensorsByDriver_NoMatches(t *testing.T) {
 	db, mock := newMockDB(t)
 	repo := NewSensorRepository(db, slog.Default())
 
-	mock.ExpectQuery("SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status FROM sensors WHERE LOWER\\(sensor_driver\\) = LOWER\\(\\?\\)").
+	mock.ExpectQuery("SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status, retention_hours FROM sensors WHERE LOWER\\(sensor_driver\\) = LOWER\\(\\?\\)").
 		WithArgs("humidity").
 		WillReturnRows(sqlmock.NewRows(sensorColumns))
 
@@ -279,7 +279,7 @@ func TestSensorRepository_GetSensorsByDriver_DBError(t *testing.T) {
 	db, mock := newMockDB(t)
 	repo := NewSensorRepository(db, slog.Default())
 
-	mock.ExpectQuery("SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status FROM sensors WHERE LOWER\\(sensor_driver\\) = LOWER\\(\\?\\)").
+	mock.ExpectQuery("SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status, retention_hours FROM sensors WHERE LOWER\\(sensor_driver\\) = LOWER\\(\\?\\)").
 		WithArgs("sensor-hub-http-temperature").
 		WillReturnError(errors.New("database error"))
 
@@ -788,8 +788,8 @@ func TestSensorRepository_GetSensorsByStatus_Success(t *testing.T) {
 	mock.ExpectQuery("SELECT .* FROM sensors WHERE LOWER\\(status\\) = LOWER\\(\\?\\)").
 		WithArgs("pending").
 		WillReturnRows(sqlmock.NewRows(sensorColumns).
-			AddRow(1, "mqtt-sensor-1", "mqtt-sensor-1", "mqtt-zigbee2mqtt", "{}", "healthy", "", true, "pending").
-			AddRow(2, "mqtt-sensor-2", "mqtt-sensor-2", "mqtt-zigbee2mqtt", "{}", "unknown", "", true, "pending"))
+			AddRow(1, "mqtt-sensor-1", "mqtt-sensor-1", "mqtt-zigbee2mqtt", "{}", "healthy", "", true, "pending", nil).
+			AddRow(2, "mqtt-sensor-2", "mqtt-sensor-2", "mqtt-zigbee2mqtt", "{}", "unknown", "", true, "pending", nil))
 
 	sensors, err := repo.GetSensorsByStatus(context.Background(), "pending")
 

--- a/sensor_hub/db/test_helpers_test.go
+++ b/sensor_hub/db/test_helpers_test.go
@@ -130,7 +130,7 @@ func testSensorHealthHistory() types.SensorHealthHistory {
 
 // Column definitions for sqlmock rows
 
-var sensorColumns = []string{"id", "name", "external_id", "sensor_driver", "config", "health_status", "health_reason", "enabled", "status"}
+var sensorColumns = []string{"id", "name", "external_id", "sensor_driver", "config", "health_status", "health_reason", "enabled", "status", "retention_hours"}
 
 var userColumns = []string{"id", "username", "email", "must_change_password", "disabled", "created_at", "updated_at"}
 

--- a/sensor_hub/docker/openapi.yaml
+++ b/sensor_hub/docker/openapi.yaml
@@ -3410,6 +3410,23 @@ components:
           description: >-
             Lifecycle status. Push-based sensors start as "pending" until
             approved. "dismissed" sensors are hidden but can be restored.
+        retention_hours:
+          type: integer
+          nullable: true
+          minimum: 1
+          description: >-
+            Per-sensor data retention override, in hours. When set, this
+            overrides the global `sensor.data.retention.days` configuration
+            for this sensor's readings. Set to null to revert to the global
+            default. Absent on list endpoints when not configured.
+        effective_retention_hours:
+          type: integer
+          readOnly: true
+          description: >-
+            Computed retention in hours that will actually be applied during
+            cleanup: the sensor's own `retention_hours` if set, otherwise
+            `sensor.data.retention.days × 24`. Only returned on the single-
+            sensor GET endpoint.
       required:
         - id
         - name
@@ -3425,6 +3442,8 @@ components:
         health_reason: "ok"
         enabled: true
         status: "active"
+        retention_hours: null
+        effective_retention_hours: 2160
 
     ConfigFieldSpec:
       type: object

--- a/sensor_hub/docker_tests/openapi.yaml
+++ b/sensor_hub/docker_tests/openapi.yaml
@@ -3410,6 +3410,23 @@ components:
           description: >-
             Lifecycle status. Push-based sensors start as "pending" until
             approved. "dismissed" sensors are hidden but can be restored.
+        retention_hours:
+          type: integer
+          nullable: true
+          minimum: 1
+          description: >-
+            Per-sensor data retention override, in hours. When set, this
+            overrides the global `sensor.data.retention.days` configuration
+            for this sensor's readings. Set to null to revert to the global
+            default. Absent on list endpoints when not configured.
+        effective_retention_hours:
+          type: integer
+          readOnly: true
+          description: >-
+            Computed retention in hours that will actually be applied during
+            cleanup: the sensor's own `retention_hours` if set, otherwise
+            `sensor.data.retention.days × 24`. Only returned on the single-
+            sensor GET endpoint.
       required:
         - id
         - name
@@ -3425,6 +3442,8 @@ components:
         health_reason: "ok"
         enabled: true
         status: "active"
+        retention_hours: null
+        effective_retention_hours: 2160
 
     ConfigFieldSpec:
       type: object

--- a/sensor_hub/integration/sensor_crud_test.go
+++ b/sensor_hub/integration/sensor_crud_test.go
@@ -94,3 +94,78 @@ func TestSensor_ConfigReadback(t *testing.T) {
 	require.NotNil(t, got.Config)
 	assert.Equal(t, mockSensorURLs[0], got.Config["url"])
 }
+
+func TestSensor_SetRetentionHours(t *testing.T) {
+	sensor := types.Sensor{
+		Name:         "Retention Test Sensor",
+		SensorDriver: "sensor-hub-http-temperature",
+		Config:       map[string]string{"url": mockSensorURLs[0]},
+	}
+	_, status := client.AddSensor(sensor)
+	require.Equal(t, http.StatusCreated, status)
+	defer client.DeleteSensor("Retention Test Sensor")
+
+	got, status := client.GetSensorDetail("Retention Test Sensor")
+	require.Equal(t, http.StatusOK, status)
+	assert.Nil(t, got.RetentionHours, "retention_hours should be nil before setting")
+	assert.Greater(t, got.EffectiveRetentionHours, 0, "effective_retention_hours should fall back to global default")
+
+	retentionHours := 48
+	status = client.UpdateSensorRetentionHours(got.Id, &retentionHours)
+	assert.Equal(t, http.StatusOK, status)
+
+	got, status = client.GetSensorDetail("Retention Test Sensor")
+	require.Equal(t, http.StatusOK, status)
+	require.NotNil(t, got.RetentionHours)
+	assert.Equal(t, 48, *got.RetentionHours)
+	assert.Equal(t, 48, got.EffectiveRetentionHours)
+}
+
+func TestSensor_ClearRetentionHours(t *testing.T) {
+	sensor := types.Sensor{
+		Name:         "Retention Clear Sensor",
+		SensorDriver: "sensor-hub-http-temperature",
+		Config:       map[string]string{"url": mockSensorURLs[0]},
+	}
+	_, status := client.AddSensor(sensor)
+	require.Equal(t, http.StatusCreated, status)
+	defer client.DeleteSensor("Retention Clear Sensor")
+
+	got, status := client.GetSensorDetail("Retention Clear Sensor")
+	require.Equal(t, http.StatusOK, status)
+	globalDefault := got.EffectiveRetentionHours
+
+	retentionHours := 72
+	status = client.UpdateSensorRetentionHours(got.Id, &retentionHours)
+	require.Equal(t, http.StatusOK, status)
+
+	status = client.UpdateSensorRetentionHours(got.Id, nil)
+	require.Equal(t, http.StatusOK, status)
+
+	got, status = client.GetSensorDetail("Retention Clear Sensor")
+	require.Equal(t, http.StatusOK, status)
+	assert.Nil(t, got.RetentionHours, "retention_hours should be nil after clearing")
+	assert.Equal(t, globalDefault, got.EffectiveRetentionHours, "effective_retention_hours should revert to global default")
+}
+
+func TestSensor_InvalidRetentionHours(t *testing.T) {
+	sensor := types.Sensor{
+		Name:         "Retention Invalid Sensor",
+		SensorDriver: "sensor-hub-http-temperature",
+		Config:       map[string]string{"url": mockSensorURLs[0]},
+	}
+	_, status := client.AddSensor(sensor)
+	require.Equal(t, http.StatusCreated, status)
+	defer client.DeleteSensor("Retention Invalid Sensor")
+
+	got, status := client.GetSensorDetail("Retention Invalid Sensor")
+	require.Equal(t, http.StatusOK, status)
+
+	zero := 0
+	status = client.UpdateSensorRetentionHours(got.Id, &zero)
+	assert.Equal(t, http.StatusBadRequest, status)
+
+	negative := -10
+	status = client.UpdateSensorRetentionHours(got.Id, &negative)
+	assert.Equal(t, http.StatusBadRequest, status)
+}

--- a/sensor_hub/mqtt/connection_manager_test.go
+++ b/sensor_hub/mqtt/connection_manager_test.go
@@ -117,6 +117,13 @@ func (m *MockSensorService) ServiceGetSensorByExternalId(ctx context.Context, ex
 	}
 	return args.Get(0).(*types.Sensor), args.Error(1)
 }
+func (m *MockSensorService) ServiceGetSensorById(ctx context.Context, id int) (*types.Sensor, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*types.Sensor), args.Error(1)
+}
 func (m *MockSensorService) ServiceSensorExistsByExternalId(ctx context.Context, externalId string) (bool, error) {
 	args := m.Called(ctx, externalId)
 	return args.Bool(0), args.Error(1)

--- a/sensor_hub/service/cleanup_service.go
+++ b/sensor_hub/service/cleanup_service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 
 	appProps "example/sensorHub/application_properties"
 	database "example/sensorHub/db"
@@ -59,11 +60,31 @@ func (cs *cleanupService) StartPeriodicCleanup(ctx context.Context) {
 func (cs *cleanupService) performCleanup(ctx context.Context, healthHistoryRetentionDays int, sensorDataRetentionDays int, failedLoginRetentionDays int) error {
 	if sensorDataRetentionDays > 0 {
 		cs.logger.Debug("cleaning up old sensor readings", "retention_days", sensorDataRetentionDays)
-		err := cs.readingsRepo.DeleteReadingsOlderThan(ctx, time.Now().AddDate(0, 0, -sensorDataRetentionDays))
+
+		// Apply per-sensor retention first, collecting the IDs of sensors that have a custom value.
+		customSensors, err := cs.sensorRepo.GetSensorsWithRetention(ctx)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to fetch sensors with custom retention: %w", err)
 		}
-		cs.logger.Info("deleted old sensor readings", "retention_days", sensorDataRetentionDays)
+
+		customSensorIds := make([]int, 0, len(customSensors))
+		for _, sensor := range customSensors {
+			if sensor.RetentionHours == nil {
+				continue
+			}
+			cutoff := time.Now().Add(-time.Duration(*sensor.RetentionHours) * time.Hour)
+			if err := cs.readingsRepo.DeleteReadingsOlderThanForSensor(ctx, cutoff, sensor.Id); err != nil {
+				return fmt.Errorf("failed per-sensor cleanup for sensor %d: %w", sensor.Id, err)
+			}
+			customSensorIds = append(customSensorIds, sensor.Id)
+		}
+
+		// Apply global retention to all remaining sensors (excluding those already handled above).
+		globalCutoff := time.Now().AddDate(0, 0, -sensorDataRetentionDays)
+		if err := cs.readingsRepo.DeleteReadingsOlderThanExcludingSensors(ctx, globalCutoff, customSensorIds); err != nil {
+			return fmt.Errorf("failed global cleanup: %w", err)
+		}
+		cs.logger.Info("deleted old sensor readings", "retention_days", sensorDataRetentionDays, "custom_sensors", len(customSensorIds))
 	}
 	cs.logger.Info("sensor readings cleanup completed")
 

--- a/sensor_hub/service/cleanup_service_test.go
+++ b/sensor_hub/service/cleanup_service_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"example/sensorHub/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -36,9 +37,10 @@ func setupCleanupService() (*cleanupService, *MockSensorRepository, *MockReading
 func TestCleanupService_PerformCleanup_AllEnabled(t *testing.T) {
 	service, sensorRepo, readingsRepo, failedRepo := setupCleanupService()
 
-	readingsRepo.On("DeleteReadingsOlderThan", mock.Anything,  mock.AnythingOfType("time.Time")).Return(nil)
-	sensorRepo.On("DeleteHealthHistoryOlderThan", mock.Anything,  mock.AnythingOfType("time.Time")).Return(nil)
-	failedRepo.On("DeleteAttemptsOlderThan", mock.Anything,  mock.AnythingOfType("time.Time")).Return(nil)
+	sensorRepo.On("GetSensorsWithRetention", mock.Anything).Return([]types.Sensor{}, nil)
+	readingsRepo.On("DeleteReadingsOlderThanExcludingSensors", mock.Anything, mock.AnythingOfType("time.Time"), []int{}).Return(nil)
+	sensorRepo.On("DeleteHealthHistoryOlderThan", mock.Anything, mock.AnythingOfType("time.Time")).Return(nil)
+	failedRepo.On("DeleteAttemptsOlderThan", mock.Anything, mock.AnythingOfType("time.Time")).Return(nil)
 
 	err := service.performCleanup(context.Background(), 30, 90, 7)
 
@@ -60,9 +62,8 @@ func TestCleanupService_PerformCleanup_AllDisabled(t *testing.T) {
 func TestCleanupService_PerformCleanup_OnlyTemperature(t *testing.T) {
 	service, sensorRepo, readingsRepo, _ := setupCleanupService()
 
-	readingsRepo.On("DeleteReadingsOlderThan", mock.Anything,  mock.AnythingOfType("time.Time")).Return(nil)
-	// Health history not cleaned when retention is 0
-	// Failed logins not cleaned when retention is 0
+	sensorRepo.On("GetSensorsWithRetention", mock.Anything).Return([]types.Sensor{}, nil)
+	readingsRepo.On("DeleteReadingsOlderThanExcludingSensors", mock.Anything, mock.AnythingOfType("time.Time"), []int{}).Return(nil)
 
 	err := service.performCleanup(context.Background(), 0, 30, 0)
 
@@ -74,7 +75,7 @@ func TestCleanupService_PerformCleanup_OnlyTemperature(t *testing.T) {
 func TestCleanupService_PerformCleanup_OnlyHealthHistory(t *testing.T) {
 	service, sensorRepo, _, _ := setupCleanupService()
 
-	sensorRepo.On("DeleteHealthHistoryOlderThan", mock.Anything,  mock.AnythingOfType("time.Time")).Return(nil)
+	sensorRepo.On("DeleteHealthHistoryOlderThan", mock.Anything, mock.AnythingOfType("time.Time")).Return(nil)
 
 	err := service.performCleanup(context.Background(), 30, 0, 0)
 
@@ -85,7 +86,7 @@ func TestCleanupService_PerformCleanup_OnlyHealthHistory(t *testing.T) {
 func TestCleanupService_PerformCleanup_OnlyFailedLogins(t *testing.T) {
 	service, _, _, failedRepo := setupCleanupService()
 
-	failedRepo.On("DeleteAttemptsOlderThan", mock.Anything,  mock.AnythingOfType("time.Time")).Return(nil)
+	failedRepo.On("DeleteAttemptsOlderThan", mock.Anything, mock.AnythingOfType("time.Time")).Return(nil)
 
 	err := service.performCleanup(context.Background(), 0, 0, 7)
 
@@ -93,10 +94,22 @@ func TestCleanupService_PerformCleanup_OnlyFailedLogins(t *testing.T) {
 	failedRepo.AssertExpectations(t)
 }
 
-func TestCleanupService_PerformCleanup_TemperatureError(t *testing.T) {
-	service, _, readingsRepo, _ := setupCleanupService()
+func TestCleanupService_PerformCleanup_TemperatureError_GetSensors(t *testing.T) {
+	service, sensorRepo, _, _ := setupCleanupService()
 
-	readingsRepo.On("DeleteReadingsOlderThan", mock.Anything,  mock.AnythingOfType("time.Time")).Return(errors.New("database error"))
+	sensorRepo.On("GetSensorsWithRetention", mock.Anything).Return(nil, errors.New("database error"))
+
+	err := service.performCleanup(context.Background(), 30, 90, 7)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "database error")
+}
+
+func TestCleanupService_PerformCleanup_TemperatureError_GlobalDelete(t *testing.T) {
+	service, sensorRepo, readingsRepo, _ := setupCleanupService()
+
+	sensorRepo.On("GetSensorsWithRetention", mock.Anything).Return([]types.Sensor{}, nil)
+	readingsRepo.On("DeleteReadingsOlderThanExcludingSensors", mock.Anything, mock.AnythingOfType("time.Time"), []int{}).Return(errors.New("database error"))
 
 	err := service.performCleanup(context.Background(), 30, 90, 7)
 
@@ -107,8 +120,9 @@ func TestCleanupService_PerformCleanup_TemperatureError(t *testing.T) {
 func TestCleanupService_PerformCleanup_HealthHistoryError(t *testing.T) {
 	service, sensorRepo, readingsRepo, _ := setupCleanupService()
 
-	readingsRepo.On("DeleteReadingsOlderThan", mock.Anything,  mock.AnythingOfType("time.Time")).Return(nil)
-	sensorRepo.On("DeleteHealthHistoryOlderThan", mock.Anything,  mock.AnythingOfType("time.Time")).Return(errors.New("health history error"))
+	sensorRepo.On("GetSensorsWithRetention", mock.Anything).Return([]types.Sensor{}, nil)
+	readingsRepo.On("DeleteReadingsOlderThanExcludingSensors", mock.Anything, mock.AnythingOfType("time.Time"), []int{}).Return(nil)
+	sensorRepo.On("DeleteHealthHistoryOlderThan", mock.Anything, mock.AnythingOfType("time.Time")).Return(errors.New("health history error"))
 
 	err := service.performCleanup(context.Background(), 30, 90, 7)
 
@@ -119,9 +133,10 @@ func TestCleanupService_PerformCleanup_HealthHistoryError(t *testing.T) {
 func TestCleanupService_PerformCleanup_FailedLoginError(t *testing.T) {
 	service, sensorRepo, readingsRepo, failedRepo := setupCleanupService()
 
-	readingsRepo.On("DeleteReadingsOlderThan", mock.Anything,  mock.AnythingOfType("time.Time")).Return(nil)
-	sensorRepo.On("DeleteHealthHistoryOlderThan", mock.Anything,  mock.AnythingOfType("time.Time")).Return(nil)
-	failedRepo.On("DeleteAttemptsOlderThan", mock.Anything,  mock.AnythingOfType("time.Time")).Return(errors.New("failed login error"))
+	sensorRepo.On("GetSensorsWithRetention", mock.Anything).Return([]types.Sensor{}, nil)
+	readingsRepo.On("DeleteReadingsOlderThanExcludingSensors", mock.Anything, mock.AnythingOfType("time.Time"), []int{}).Return(nil)
+	sensorRepo.On("DeleteHealthHistoryOlderThan", mock.Anything, mock.AnythingOfType("time.Time")).Return(nil)
+	failedRepo.On("DeleteAttemptsOlderThan", mock.Anything, mock.AnythingOfType("time.Time")).Return(errors.New("failed login error"))
 
 	err := service.performCleanup(context.Background(), 30, 90, 7)
 
@@ -137,10 +152,11 @@ func TestCleanupService_PerformCleanup_RetentionDaysCalculation(t *testing.T) {
 	expectedHealthThreshold := now.AddDate(0, 0, -30)
 	expectedFailedThreshold := now.AddDate(0, 0, -7)
 
-	readingsRepo.On("DeleteReadingsOlderThan", mock.Anything, mock.MatchedBy(func(t time.Time) bool {
-		// Check that threshold is within 1 second of expected
+	sensorRepo.On("GetSensorsWithRetention", mock.Anything).Return([]types.Sensor{}, nil)
+
+	readingsRepo.On("DeleteReadingsOlderThanExcludingSensors", mock.Anything, mock.MatchedBy(func(t time.Time) bool {
 		return t.Sub(expectedTempThreshold).Abs() < time.Second
-	})).Return(nil)
+	}), []int{}).Return(nil)
 
 	sensorRepo.On("DeleteHealthHistoryOlderThan", mock.Anything, mock.MatchedBy(func(t time.Time) bool {
 		return t.Sub(expectedHealthThreshold).Abs() < time.Second
@@ -153,6 +169,65 @@ func TestCleanupService_PerformCleanup_RetentionDaysCalculation(t *testing.T) {
 	err := service.performCleanup(context.Background(), 30, 90, 7)
 
 	assert.NoError(t, err)
+}
+
+func TestCleanupService_PerformCleanup_PerSensorRetention(t *testing.T) {
+	service, sensorRepo, readingsRepo, failedRepo := setupCleanupService()
+
+	retentionHours := 48
+	customSensor := types.Sensor{Id: 42, Name: "sensor-co2", RetentionHours: &retentionHours}
+
+	sensorRepo.On("GetSensorsWithRetention", mock.Anything).Return([]types.Sensor{customSensor}, nil)
+	readingsRepo.On("DeleteReadingsOlderThanForSensor", mock.Anything, mock.MatchedBy(func(t time.Time) bool {
+		expected := time.Now().Add(-time.Duration(retentionHours) * time.Hour)
+		return t.Sub(expected).Abs() < time.Second
+	}), 42).Return(nil)
+	readingsRepo.On("DeleteReadingsOlderThanExcludingSensors", mock.Anything, mock.AnythingOfType("time.Time"), []int{42}).Return(nil)
+	sensorRepo.On("DeleteHealthHistoryOlderThan", mock.Anything, mock.AnythingOfType("time.Time")).Return(nil)
+	failedRepo.On("DeleteAttemptsOlderThan", mock.Anything, mock.AnythingOfType("time.Time")).Return(nil)
+
+	err := service.performCleanup(context.Background(), 30, 90, 7)
+
+	assert.NoError(t, err)
+	readingsRepo.AssertCalled(t, "DeleteReadingsOlderThanForSensor", mock.Anything, mock.AnythingOfType("time.Time"), 42)
+	readingsRepo.AssertCalled(t, "DeleteReadingsOlderThanExcludingSensors", mock.Anything, mock.AnythingOfType("time.Time"), []int{42})
+}
+
+func TestCleanupService_PerformCleanup_PerSensorRetentionError(t *testing.T) {
+	service, sensorRepo, readingsRepo, _ := setupCleanupService()
+
+	retentionHours := 24
+	customSensor := types.Sensor{Id: 7, Name: "sensor-co", RetentionHours: &retentionHours}
+
+	sensorRepo.On("GetSensorsWithRetention", mock.Anything).Return([]types.Sensor{customSensor}, nil)
+	readingsRepo.On("DeleteReadingsOlderThanForSensor", mock.Anything, mock.AnythingOfType("time.Time"), 7).Return(errors.New("per-sensor delete error"))
+
+	err := service.performCleanup(context.Background(), 30, 90, 7)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "per-sensor delete error")
+}
+
+func TestCleanupService_PerformCleanup_MultipleCustomSensors(t *testing.T) {
+	service, sensorRepo, readingsRepo, failedRepo := setupCleanupService()
+
+	h1, h2 := 24, 720
+	sensors := []types.Sensor{
+		{Id: 1, Name: "sensor-a", RetentionHours: &h1},
+		{Id: 2, Name: "sensor-b", RetentionHours: &h2},
+	}
+
+	sensorRepo.On("GetSensorsWithRetention", mock.Anything).Return(sensors, nil)
+	readingsRepo.On("DeleteReadingsOlderThanForSensor", mock.Anything, mock.AnythingOfType("time.Time"), 1).Return(nil)
+	readingsRepo.On("DeleteReadingsOlderThanForSensor", mock.Anything, mock.AnythingOfType("time.Time"), 2).Return(nil)
+	readingsRepo.On("DeleteReadingsOlderThanExcludingSensors", mock.Anything, mock.AnythingOfType("time.Time"), []int{1, 2}).Return(nil)
+	sensorRepo.On("DeleteHealthHistoryOlderThan", mock.Anything, mock.AnythingOfType("time.Time")).Return(nil)
+	failedRepo.On("DeleteAttemptsOlderThan", mock.Anything, mock.AnythingOfType("time.Time")).Return(nil)
+
+	err := service.performCleanup(context.Background(), 30, 90, 7)
+
+	assert.NoError(t, err)
+	readingsRepo.AssertExpectations(t)
 }
 
 // ============================================================================

--- a/sensor_hub/service/sensor_service.go
+++ b/sensor_hub/service/sensor_service.go
@@ -150,6 +150,10 @@ func (s *SensorService) ServiceGetSensorByName(ctx context.Context, name string)
 	return sensor, nil
 }
 
+func (s *SensorService) ServiceGetSensorById(ctx context.Context, id int) (*types.Sensor, error) {
+	return s.sensorRepo.GetSensorById(ctx, id)
+}
+
 func (s *SensorService) ServiceGetAllSensors(ctx context.Context) ([]types.Sensor, error) {
 	sensors, err := s.sensorRepo.GetAllSensors(ctx)
 	if err != nil {

--- a/sensor_hub/service/sensor_service_interface.go
+++ b/sensor_hub/service/sensor_service_interface.go
@@ -11,6 +11,7 @@ type SensorServiceInterface interface {
 	ServiceDeleteSensorByName(ctx context.Context, name string) error
 	ServiceGetSensorByName(ctx context.Context, name string) (*types.Sensor, error)
 	ServiceGetSensorByExternalId(ctx context.Context, externalId string) (*types.Sensor, error)
+	ServiceGetSensorById(ctx context.Context, id int) (*types.Sensor, error)
 	ServiceGetAllSensors(ctx context.Context) ([]types.Sensor, error)
 	ServiceGetSensorsByDriver(ctx context.Context, sensorDriver string) ([]types.Sensor, error)
 	ServiceGetSensorIdByName(ctx context.Context, name string) (int, error)

--- a/sensor_hub/service/test_mocks_test.go
+++ b/sensor_hub/service/test_mocks_test.go
@@ -244,6 +244,14 @@ func (m *MockSensorRepository) GetSensorByName(ctx context.Context, name string)
 	return args.Get(0).(*types.Sensor), args.Error(1)
 }
 
+func (m *MockSensorRepository) GetSensorById(ctx context.Context, id int) (*types.Sensor, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*types.Sensor), args.Error(1)
+}
+
 func (m *MockSensorRepository) GetSensorsByDriver(ctx context.Context, sensorDriver string) ([]types.Sensor, error) {
 	args := m.Called(ctx, sensorDriver)
 	return args.Get(0).([]types.Sensor), args.Error(1)
@@ -301,6 +309,14 @@ func (m *MockSensorRepository) UpdateSensorStatus(ctx context.Context, sensorId 
 	return m.Called(ctx, sensorId, status).Error(0)
 }
 
+func (m *MockSensorRepository) GetSensorsWithRetention(ctx context.Context) ([]types.Sensor, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]types.Sensor), args.Error(1)
+}
+
 func (m *MockSensorRepository) GetSensorByExternalId(ctx context.Context, externalId string) (*types.Sensor, error) {
 	args := m.Called(ctx, externalId)
 	if args.Get(0) == nil {
@@ -344,6 +360,16 @@ func (m *MockReadingsRepository) GetTotalReadingsBySensorId(ctx context.Context,
 
 func (m *MockReadingsRepository) DeleteReadingsOlderThan(ctx context.Context, cutoffDate time.Time) error {
 	args := m.Called(ctx, cutoffDate)
+	return args.Error(0)
+}
+
+func (m *MockReadingsRepository) DeleteReadingsOlderThanForSensor(ctx context.Context, cutoffDate time.Time, sensorId int) error {
+	args := m.Called(ctx, cutoffDate, sensorId)
+	return args.Error(0)
+}
+
+func (m *MockReadingsRepository) DeleteReadingsOlderThanExcludingSensors(ctx context.Context, cutoffDate time.Time, excludedSensorIds []int) error {
+	args := m.Called(ctx, cutoffDate, excludedSensorIds)
 	return args.Error(0)
 }
 

--- a/sensor_hub/skills/claude.md
+++ b/sensor_hub/skills/claude.md
@@ -40,6 +40,8 @@ sensor-hub sensors exists "Living Room"              # Check if exists
 sensor-hub sensors list-by-driver sensor-hub-http-temperature  # List by driver
 sensor-hub sensors add --name X --driver sensor-hub-http-temperature --config url=Z  # Create sensor
 sensor-hub sensors update 1 --name X --config url=Z  # Update by ID
+sensor-hub sensors update 1 --retention-hours 48     # Set per-sensor retention (hours)
+sensor-hub sensors update 1 --retention-hours 0      # Clear per-sensor retention (use global default)
 sensor-hub sensors delete "Living Room"              # Delete by name
 sensor-hub sensors enable "Living Room"              # Enable sensor
 sensor-hub sensors disable "Living Room"             # Disable sensor
@@ -53,6 +55,10 @@ sensor-hub sensors pending                           # List pending (auto-discov
 sensor-hub sensors approve 5                         # Approve a pending sensor by ID
 sensor-hub sensors dismiss 5                         # Dismiss a pending sensor by ID
 ```
+
+**Sensor response fields (GET /api/sensors/:name):**
+- `retention_hours` — nullable integer; per-sensor data retention override in hours. Null means use the global default.
+- `effective_retention_hours` — read-only integer; the retention period in hours that actually applies (per-sensor value if set, otherwise the global default).
 
 ### MQTT Brokers
 ```bash

--- a/sensor_hub/skills/copilot.md
+++ b/sensor_hub/skills/copilot.md
@@ -40,6 +40,8 @@ sensor-hub sensors exists "Living Room"              # Check if exists
 sensor-hub sensors list-by-driver sensor-hub-http-temperature  # List by driver
 sensor-hub sensors add --name X --driver sensor-hub-http-temperature --config url=Z  # Create sensor
 sensor-hub sensors update 1 --name X --config url=Z  # Update by ID
+sensor-hub sensors update 1 --retention-hours 48     # Set per-sensor retention (hours)
+sensor-hub sensors update 1 --retention-hours 0      # Clear per-sensor retention (use global default)
 sensor-hub sensors delete "Living Room"              # Delete by name
 sensor-hub sensors enable "Living Room"              # Enable sensor
 sensor-hub sensors disable "Living Room"             # Disable sensor
@@ -53,6 +55,10 @@ sensor-hub sensors pending                           # List pending (auto-discov
 sensor-hub sensors approve 5                         # Approve a pending sensor by ID
 sensor-hub sensors dismiss 5                         # Dismiss a pending sensor by ID
 ```
+
+**Sensor response fields (GET /api/sensors/:name):**
+- `retention_hours` — nullable integer; per-sensor data retention override in hours. Null means use the global default.
+- `effective_retention_hours` — read-only integer; the retention period in hours that actually applies (per-sensor value if set, otherwise the global default).
 
 ### MQTT Brokers
 ```bash

--- a/sensor_hub/testharness/client.go
+++ b/sensor_hub/testharness/client.go
@@ -101,8 +101,29 @@ func (c *Client) GetSensorByName(name string) (types.Sensor, int) {
 	return result, status
 }
 
+// SensorDetail extends types.Sensor with computed fields returned by the single-sensor endpoint.
+type SensorDetail struct {
+	types.Sensor
+	EffectiveRetentionHours int `json:"effective_retention_hours"`
+}
+
+// GetSensorDetail fetches a single sensor and decodes the enriched detail response.
+func (c *Client) GetSensorDetail(name string) (SensorDetail, int) {
+	var result SensorDetail
+	status := c.getDecode("/api/sensors/"+name, &result)
+	return result, status
+}
+
 func (c *Client) DeleteSensor(name string) int {
 	_, status := c.doRequest("DELETE", "/api/sensors/"+name, nil)
+	return status
+}
+
+// UpdateSensorRetentionHours sets or clears the per-sensor retention override.
+// retentionHours nil marshals as JSON null, which clears the override.
+func (c *Client) UpdateSensorRetentionHours(id int, retentionHours *int) int {
+	body := map[string]interface{}{"retention_hours": retentionHours}
+	_, status := c.doRequest("PUT", fmt.Sprintf("/api/sensors/%d", id), jsonBytes(body))
 	return status
 }
 

--- a/sensor_hub/types/types.go
+++ b/sensor_hub/types/types.go
@@ -25,6 +25,12 @@ type Sensor struct {
 	HealthReason string            `json:"health_reason"`
 	Enabled      bool              `json:"enabled"`
 	Status       SensorStatus      `json:"status"`
+	RetentionHours *int            `json:"retention_hours,omitempty"`
+
+	// RetentionHoursPresent indicates whether retention_hours was explicitly
+	// included in an update request (distinguishes "not sent" from "set to null").
+	// Not serialised to JSON.
+	RetentionHoursPresent bool `json:"-"`
 }
 
 type SensorStatus string

--- a/sensor_hub/ui/sensor_hub_ui/src/api/Sensors.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/api/Sensors.ts
@@ -20,6 +20,8 @@ function mapSensorJson(s: SensorJson): Sensor {
     healthReason: s.health_reason ?? null,
     enabled: Boolean(s.enabled),
     status: s.status || 'active',
+    retentionHours: s.retention_hours ?? null,
+    effectiveRetentionHours: s.effective_retention_hours,
   };
 }
 
@@ -33,6 +35,7 @@ type SensorPayloadUpdate = {
   name?: string;
   sensor_driver?: string;
   config?: Record<string, string | null>;
+  retention_hours?: number | null;
 };
 
 export const SensorsApi = {

--- a/sensor_hub/ui/sensor_hub_ui/src/components/AddNewSensor.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/components/AddNewSensor.tsx
@@ -7,14 +7,14 @@ function AddNewSensor() {
 
   if (user === undefined) {
     return (
-      <LayoutCard variant={"secondary"} changes={{alignItems: "center", height: "100%", width: "100%"}}>
+      <LayoutCard variant={"secondary"} changes={{height: "100%", width: "100%"}}>
         Loading...
       </LayoutCard>
     )
   }
 
   return (
-    <LayoutCard id="add-sensor-form" variant={"secondary"} changes={{alignItems: "center", height: "100%", width: "100%"}}>
+    <LayoutCard id="add-sensor-form" variant={"secondary"} changes={{height: "100%", width: "100%"}}>
       <SensorForm mode="create" user={ user }/>
     </LayoutCard>
   )

--- a/sensor_hub/ui/sensor_hub_ui/src/components/AddNewSensor.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/components/AddNewSensor.tsx
@@ -7,14 +7,14 @@ function AddNewSensor() {
 
   if (user === undefined) {
     return (
-      <LayoutCard variant={"secondary"} changes={{height: "100%", width: "100%"}}>
+      <LayoutCard variant={"secondary"} changes={{height: "100%", width: "100%", minHeight: 400}}>
         Loading...
       </LayoutCard>
     )
   }
 
   return (
-    <LayoutCard id="add-sensor-form" variant={"secondary"} changes={{height: "100%", width: "100%"}}>
+    <LayoutCard id="add-sensor-form" variant={"secondary"} changes={{height: "100%", width: "100%", minHeight: 400}}>
       <SensorForm mode="create" user={ user }/>
     </LayoutCard>
   )

--- a/sensor_hub/ui/sensor_hub_ui/src/components/DataRetentionCard.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/components/DataRetentionCard.tsx
@@ -1,33 +1,45 @@
+import { useState } from 'react';
 import type { Sensor } from '../types/types';
+import type { GridRowParams } from '@mui/x-data-grid';
 import LayoutCard from '../tools/LayoutCard';
 import { TypographyH2 } from '../tools/Typography';
 import { DataGrid, type GridColDef } from '@mui/x-data-grid';
 import { useIsMobile } from '../hooks/useMobile';
 import { useSensorContext } from '../hooks/useSensorContext';
 import { useProperties } from '../hooks/useProperties';
-import { Typography, Chip, Box } from '@mui/material';
-import { useNavigate } from 'react-router';
-
-function formatRetention(hours: number): string {
-  if (hours >= 168 && hours % 168 === 0) return `${hours / 168} week${hours / 168 !== 1 ? 's' : ''}`;
-  if (hours >= 24 && hours % 24 === 0) return `${hours / 24} day${hours / 24 !== 1 ? 's' : ''}`;
-  return `${hours} hour${hours !== 1 ? 's' : ''}`;
-}
+import { useAuth } from '../providers/AuthContext';
+import { hasPerm } from '../tools/Utils';
+import { Typography, Chip, Box, Menu, MenuItem } from '@mui/material';
+import { formatRetention } from './SensorRetentionCard';
+import EditRetentionDialog from './EditRetentionDialog';
 
 function DataRetentionCard() {
   const { sensors } = useSensorContext();
   const properties = useProperties();
+  const { user } = useAuth();
   const isMobile = useIsMobile();
-  const navigate = useNavigate();
 
   const globalRetentionDays = parseInt(properties['sensor.data.retention.days'] || '90', 10);
   const globalRetentionHours = globalRetentionDays * 24;
 
   const activeSensors = sensors.filter((s) => s.status === 'active');
 
+  const [menuAnchorEl, setMenuAnchorEl] = useState<null | HTMLElement>(null);
+  const [selectedSensor, setSelectedSensor] = useState<Sensor | null>(null);
+  const [openEditDialog, setOpenEditDialog] = useState(false);
+
+  const handleRowClick = (params: GridRowParams, event: React.MouseEvent) => {
+    const found = activeSensors.find((s) => s.id === params.row.id);
+    setSelectedSensor(found ?? (params.row as Sensor));
+    setMenuAnchorEl(event.currentTarget as HTMLElement);
+  };
+
+  const closeMenu = () => setMenuAnchorEl(null);
+  const canManage = user && hasPerm(user, 'manage_sensors');
+
   const columns: GridColDef[] = [
     { field: 'name', headerName: 'Sensor', flex: 1, minWidth: 140 },
-    { field: 'sensorDriver', headerName: 'Driver', flex: 1, minWidth: 120, hideable: true },
+    { field: 'sensorDriver', headerName: 'Driver', flex: 1, minWidth: 120 },
     {
       field: 'retentionHours',
       headerName: 'Retention',
@@ -53,42 +65,54 @@ function DataRetentionCard() {
     },
   ];
 
-  if (isMobile) {
-    const hiddenFields = ['sensorDriver'];
-    columns.forEach((col) => {
-      if (hiddenFields.includes(col.field)) col.hideable = false;
-    });
-  }
-
   return (
-    <LayoutCard variant="secondary" changes={{ alignItems: 'center', height: '100%', width: '100%' }}>
-      <Box sx={{ width: '100%' }}>
-        <TypographyH2>Sensor Retention Overview</TypographyH2>
-        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-          Global default: {formatRetention(globalRetentionHours)}. Sensors with custom retention override this value.
-        </Typography>
-        <DataGrid
-          rows={activeSensors}
-          columns={columns}
-          initialState={{
-            pagination: { paginationModel: { pageSize: 10 } },
-            columns: {
-              columnVisibilityModel: isMobile ? { sensorDriver: false } : {},
-            },
-          }}
-          pageSizeOptions={[5, 10, 25]}
-          disableRowSelectionOnClick
-          onRowClick={(params) => navigate(`/sensor/${params.row.id}`)}
-          autoHeight
-          sx={{
-            border: 0,
-            '& .MuiDataGrid-cell': { fontSize: isMobile ? '0.9rem' : '1rem' },
-            '& .MuiDataGrid-columnHeaders': { fontWeight: 'bold' },
-            '.MuiDataGrid-row:hover': { cursor: 'pointer' },
-          }}
-        />
-      </Box>
-    </LayoutCard>
+    <>
+      <LayoutCard variant="secondary" changes={{ alignItems: 'stretch', height: '100%', width: '100%' }}>
+        <Box sx={{ width: '100%' }}>
+          <TypographyH2>Sensor Retention Overview</TypographyH2>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            Global default: {formatRetention(globalRetentionHours)}. Click a sensor to edit its retention policy.
+          </Typography>
+          <DataGrid
+            rows={activeSensors}
+            columns={columns}
+            initialState={{
+              pagination: { paginationModel: { pageSize: 10 } },
+              columns: {
+                columnVisibilityModel: isMobile ? { sensorDriver: false } : {},
+              },
+            }}
+            pageSizeOptions={[5, 10, 25]}
+            disableRowSelectionOnClick
+            onRowClick={handleRowClick}
+            autoHeight
+            sx={{
+              border: 0,
+              '& .MuiDataGrid-cell': { fontSize: isMobile ? '0.9rem' : '1rem' },
+              '& .MuiDataGrid-columnHeaders': { fontWeight: 'bold' },
+              '.MuiDataGrid-row:hover': { cursor: 'pointer' },
+            }}
+          />
+        </Box>
+
+        <Menu anchorEl={menuAnchorEl} open={Boolean(menuAnchorEl)} onClose={closeMenu}>
+          <MenuItem
+            disabled={!canManage}
+            onClick={() => { closeMenu(); setOpenEditDialog(true); }}
+          >
+            Edit Retention
+          </MenuItem>
+        </Menu>
+      </LayoutCard>
+
+      <EditRetentionDialog
+        open={openEditDialog}
+        onClose={() => setOpenEditDialog(false)}
+        onSaved={() => {}}
+        sensor={selectedSensor}
+        globalRetentionHours={globalRetentionHours}
+      />
+    </>
   );
 }
 

--- a/sensor_hub/ui/sensor_hub_ui/src/components/DataRetentionCard.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/components/DataRetentionCard.tsx
@@ -27,9 +27,17 @@ function DataRetentionCard() {
   const [menuAnchorEl, setMenuAnchorEl] = useState<null | HTMLElement>(null);
   const [selectedSensor, setSelectedSensor] = useState<Sensor | null>(null);
   const [openEditDialog, setOpenEditDialog] = useState(false);
+  const [retentionOverrides, setRetentionOverrides] = useState<Record<number, number | null>>({});
+
+  const displaySensors = activeSensors.map((s) => {
+    if (s.id in retentionOverrides) {
+      return { ...s, retentionHours: retentionOverrides[s.id] };
+    }
+    return s;
+  });
 
   const handleRowClick = (params: GridRowParams, event: React.MouseEvent) => {
-    const found = activeSensors.find((s) => s.id === params.row.id);
+    const found = displaySensors.find((s) => s.id === params.row.id);
     setSelectedSensor(found ?? (params.row as Sensor));
     setMenuAnchorEl(event.currentTarget as HTMLElement);
   };
@@ -50,7 +58,7 @@ function DataRetentionCard() {
         if (sensor.retentionHours !== null) {
           return <Chip label={formatRetention(sensor.retentionHours)} color="primary" size="small" variant="outlined" />;
         }
-        return <Typography variant="body2" color="text.secondary">Global default</Typography>;
+        return <Typography variant="body2" color="text.secondary" sx={{ display: 'flex', alignItems: 'center', height: '100%' }}>Global default</Typography>;
       },
     },
     {
@@ -74,7 +82,7 @@ function DataRetentionCard() {
             Global default: {formatRetention(globalRetentionHours)}. Click a sensor to edit its retention policy.
           </Typography>
           <DataGrid
-            rows={activeSensors}
+            rows={displaySensors}
             columns={columns}
             initialState={{
               pagination: { paginationModel: { pageSize: 10 } },
@@ -108,7 +116,9 @@ function DataRetentionCard() {
       <EditRetentionDialog
         open={openEditDialog}
         onClose={() => setOpenEditDialog(false)}
-        onSaved={() => {}}
+        onSaved={(sensorId, retentionHours) => {
+          setRetentionOverrides((prev) => ({ ...prev, [sensorId]: retentionHours }));
+        }}
         sensor={selectedSensor}
         globalRetentionHours={globalRetentionHours}
       />

--- a/sensor_hub/ui/sensor_hub_ui/src/components/DataRetentionCard.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/components/DataRetentionCard.tsx
@@ -1,0 +1,95 @@
+import type { Sensor } from '../types/types';
+import LayoutCard from '../tools/LayoutCard';
+import { TypographyH2 } from '../tools/Typography';
+import { DataGrid, type GridColDef } from '@mui/x-data-grid';
+import { useIsMobile } from '../hooks/useMobile';
+import { useSensorContext } from '../hooks/useSensorContext';
+import { useProperties } from '../hooks/useProperties';
+import { Typography, Chip, Box } from '@mui/material';
+import { useNavigate } from 'react-router';
+
+function formatRetention(hours: number): string {
+  if (hours >= 168 && hours % 168 === 0) return `${hours / 168} week${hours / 168 !== 1 ? 's' : ''}`;
+  if (hours >= 24 && hours % 24 === 0) return `${hours / 24} day${hours / 24 !== 1 ? 's' : ''}`;
+  return `${hours} hour${hours !== 1 ? 's' : ''}`;
+}
+
+function DataRetentionCard() {
+  const { sensors } = useSensorContext();
+  const properties = useProperties();
+  const isMobile = useIsMobile();
+  const navigate = useNavigate();
+
+  const globalRetentionDays = parseInt(properties['sensor.data.retention.days'] || '90', 10);
+  const globalRetentionHours = globalRetentionDays * 24;
+
+  const activeSensors = sensors.filter((s) => s.status === 'active');
+
+  const columns: GridColDef[] = [
+    { field: 'name', headerName: 'Sensor', flex: 1, minWidth: 140 },
+    { field: 'sensorDriver', headerName: 'Driver', flex: 1, minWidth: 120, hideable: true },
+    {
+      field: 'retentionHours',
+      headerName: 'Retention',
+      flex: 1,
+      minWidth: 140,
+      renderCell: (params) => {
+        const sensor = params.row as Sensor;
+        if (sensor.retentionHours !== null) {
+          return <Chip label={formatRetention(sensor.retentionHours)} color="primary" size="small" variant="outlined" />;
+        }
+        return <Typography variant="body2" color="text.secondary">Global default</Typography>;
+      },
+    },
+    {
+      field: 'effective',
+      headerName: 'Effective',
+      flex: 1,
+      minWidth: 120,
+      valueGetter: (_value: unknown, row: Sensor) => {
+        const hours = row.retentionHours ?? globalRetentionHours;
+        return formatRetention(hours);
+      },
+    },
+  ];
+
+  if (isMobile) {
+    const hiddenFields = ['sensorDriver'];
+    columns.forEach((col) => {
+      if (hiddenFields.includes(col.field)) col.hideable = false;
+    });
+  }
+
+  return (
+    <LayoutCard variant="secondary" changes={{ alignItems: 'center', height: '100%', width: '100%' }}>
+      <Box sx={{ width: '100%' }}>
+        <TypographyH2>Sensor Retention Overview</TypographyH2>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          Global default: {formatRetention(globalRetentionHours)}. Sensors with custom retention override this value.
+        </Typography>
+        <DataGrid
+          rows={activeSensors}
+          columns={columns}
+          initialState={{
+            pagination: { paginationModel: { pageSize: 10 } },
+            columns: {
+              columnVisibilityModel: isMobile ? { sensorDriver: false } : {},
+            },
+          }}
+          pageSizeOptions={[5, 10, 25]}
+          disableRowSelectionOnClick
+          onRowClick={(params) => navigate(`/sensor/${params.row.id}`)}
+          autoHeight
+          sx={{
+            border: 0,
+            '& .MuiDataGrid-cell': { fontSize: isMobile ? '0.9rem' : '1rem' },
+            '& .MuiDataGrid-columnHeaders': { fontWeight: 'bold' },
+            '.MuiDataGrid-row:hover': { cursor: 'pointer' },
+          }}
+        />
+      </Box>
+    </LayoutCard>
+  );
+}
+
+export default DataRetentionCard;

--- a/sensor_hub/ui/sensor_hub_ui/src/components/DataRetentionCard.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/components/DataRetentionCard.tsx
@@ -10,7 +10,7 @@ import { useProperties } from '../hooks/useProperties';
 import { useAuth } from '../providers/AuthContext';
 import { hasPerm } from '../tools/Utils';
 import { Typography, Chip, Box, Menu, MenuItem } from '@mui/material';
-import { formatRetention } from './SensorRetentionCard';
+import { formatRetention } from '../tools/retention';
 import EditRetentionDialog from './EditRetentionDialog';
 
 function DataRetentionCard() {

--- a/sensor_hub/ui/sensor_hub_ui/src/components/EditRetentionDialog.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/components/EditRetentionDialog.tsx
@@ -42,7 +42,7 @@ function bestUnit(hours: number): RetentionUnit {
 interface EditRetentionDialogProps {
   open: boolean;
   onClose: () => void;
-  onSaved: () => void;
+  onSaved: (sensorId: number, retentionHours: number | null) => void;
   sensor: Sensor | null;
   globalRetentionHours: number;
 }
@@ -84,7 +84,7 @@ export default function EditRetentionDialog({ open, onClose, onSaved, sensor, gl
       }
       await SensorsApi.update(sensor.id, { retention_hours: retentionHours });
       onClose();
-      onSaved();
+      onSaved(sensor.id, retentionHours);
     } catch (e) {
       logger.error('Failed to update retention', e);
       setError('Failed to update retention');

--- a/sensor_hub/ui/sensor_hub_ui/src/components/EditRetentionDialog.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/components/EditRetentionDialog.tsx
@@ -14,7 +14,7 @@ import {
 } from '@mui/material';
 import type { Sensor } from '../types/types';
 import { SensorsApi } from '../api/Sensors';
-import { formatRetention } from './SensorRetentionCard';
+import { formatRetention } from '../tools/retention';
 import { logger } from '../tools/logger';
 
 type RetentionUnit = 'hours' | 'days' | 'weeks';

--- a/sensor_hub/ui/sensor_hub_ui/src/components/EditRetentionDialog.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/components/EditRetentionDialog.tsx
@@ -1,0 +1,168 @@
+import { useEffect, useState } from 'react';
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControlLabel,
+  MenuItem,
+  Switch,
+  TextField,
+  Typography,
+} from '@mui/material';
+import type { Sensor } from '../types/types';
+import { SensorsApi } from '../api/Sensors';
+import { formatRetention } from './SensorRetentionCard';
+import { logger } from '../tools/logger';
+
+type RetentionUnit = 'hours' | 'days' | 'weeks';
+
+const unitMultipliers: Record<RetentionUnit, number> = {
+  hours: 1,
+  days: 24,
+  weeks: 168,
+};
+
+function unitToHours(value: number, unit: RetentionUnit): number {
+  return Math.round(value * unitMultipliers[unit]);
+}
+
+function hoursToUnit(hours: number, unit: RetentionUnit): number {
+  return Math.round((hours / unitMultipliers[unit]) * 100) / 100;
+}
+
+function bestUnit(hours: number): RetentionUnit {
+  if (hours >= 168 && hours % 168 === 0) return 'weeks';
+  if (hours >= 24 && hours % 24 === 0) return 'days';
+  return 'hours';
+}
+
+interface EditRetentionDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onSaved: () => void;
+  sensor: Sensor | null;
+  globalRetentionHours: number;
+}
+
+export default function EditRetentionDialog({ open, onClose, onSaved, sensor, globalRetentionHours }: EditRetentionDialogProps) {
+  const [useCustom, setUseCustom] = useState(false);
+  const [unit, setUnit] = useState<RetentionUnit>('days');
+  const [value, setValue] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open && sensor) {
+      const hasCustom = sensor.retentionHours !== null;
+      setUseCustom(hasCustom);
+      setError(null);
+      if (hasCustom && sensor.retentionHours !== null) {
+        const u = bestUnit(sensor.retentionHours);
+        setUnit(u);
+        setValue(String(hoursToUnit(sensor.retentionHours, u)));
+      } else {
+        setUnit('days');
+        setValue('');
+      }
+    }
+  }, [open, sensor]);
+
+  const pendingEffectiveHours = useCustom && value
+    ? unitToHours(parseFloat(value), unit)
+    : globalRetentionHours;
+
+  const handleSave = async () => {
+    if (!sensor) return;
+    setError(null);
+    try {
+      const retentionHours = useCustom ? unitToHours(parseFloat(value), unit) : null;
+      if (useCustom && (!retentionHours || retentionHours < 1)) {
+        setError('Retention must be at least 1 hour');
+        return;
+      }
+      await SensorsApi.update(sensor.id, { retention_hours: retentionHours });
+      onClose();
+      onSaved();
+    } catch (e) {
+      logger.error('Failed to update retention', e);
+      setError('Failed to update retention');
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Edit Data Retention</DialogTitle>
+      <DialogContent>
+        <TextField
+          fullWidth
+          label="Sensor"
+          value={sensor?.name || ''}
+          disabled
+          sx={{ mt: 1 }}
+        />
+
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 2 }}>
+          Effective: <strong>{formatRetention(pendingEffectiveHours)}</strong>
+          {' '}(global default: {formatRetention(globalRetentionHours)})
+        </Typography>
+
+        <FormControlLabel
+          control={
+            <Switch
+              checked={useCustom}
+              onChange={(e) => {
+                setUseCustom(e.target.checked);
+                if (!e.target.checked) setValue('');
+              }}
+            />
+          }
+          label="Override global retention"
+          sx={{ mt: 2 }}
+        />
+
+        {useCustom && (
+          <Box display="flex" gap={2} sx={{ mt: 2 }}>
+            <TextField
+              label="Retention"
+              type="number"
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              slotProps={{ htmlInput: { min: 1, step: 1 } }}
+              sx={{ flex: 1 }}
+            />
+            <TextField
+              select
+              label="Unit"
+              value={unit}
+              onChange={(e) => {
+                const newUnit = e.target.value as RetentionUnit;
+                if (value) {
+                  const hours = unitToHours(parseFloat(value), unit);
+                  setValue(String(hoursToUnit(hours, newUnit)));
+                }
+                setUnit(newUnit);
+              }}
+              sx={{ minWidth: 120 }}
+            >
+              <MenuItem value="hours">Hours</MenuItem>
+              <MenuItem value="days">Days</MenuItem>
+              <MenuItem value="weeks">Weeks</MenuItem>
+            </TextField>
+          </Box>
+        )}
+
+        {error && (
+          <Typography color="error" variant="body2" sx={{ mt: 2 }}>
+            {error}
+          </Typography>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button variant="contained" onClick={handleSave}>Save</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/sensor_hub/ui/sensor_hub_ui/src/components/EditSensorDetails.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/components/EditSensorDetails.tsx
@@ -13,14 +13,14 @@ function EditSensorDetails({ sensor } : EditSensorDetailsProps) {
   const { user } = useAuth();
   if (user === undefined) {
     return (
-      <LayoutCard variant={"secondary"} changes={{alignItems: "center", height: "100%", width: "100%"}}>
+      <LayoutCard variant={"secondary"} changes={{height: "100%", width: "100%"}}>
         Loading...
       </LayoutCard>
     )
   }
 
   return (
-    <LayoutCard variant={"secondary"} changes={{alignItems: "center", height: "100%", width: "100%"}}>
+    <LayoutCard variant={"secondary"} changes={{height: "100%", width: "100%"}}>
       <SensorForm sensor={sensor} mode="edit" user={user} />
     </LayoutCard>
   )

--- a/sensor_hub/ui/sensor_hub_ui/src/components/EditSensorDetails.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/components/EditSensorDetails.tsx
@@ -13,14 +13,14 @@ function EditSensorDetails({ sensor } : EditSensorDetailsProps) {
   const { user } = useAuth();
   if (user === undefined) {
     return (
-      <LayoutCard variant={"secondary"} changes={{height: "100%", width: "100%"}}>
+      <LayoutCard variant={"secondary"} changes={{height: "100%", width: "100%", minHeight: 400}}>
         Loading...
       </LayoutCard>
     )
   }
 
   return (
-    <LayoutCard variant={"secondary"} changes={{height: "100%", width: "100%"}}>
+    <LayoutCard variant={"secondary"} changes={{height: "100%", width: "100%", minHeight: 400}}>
       <SensorForm sensor={sensor} mode="edit" user={user} />
     </LayoutCard>
   )

--- a/sensor_hub/ui/sensor_hub_ui/src/components/SensorHealthHistory.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/components/SensorHealthHistory.tsx
@@ -39,7 +39,7 @@ function SensorHealthHistory({sensor}: SensorHealthHistoryProps) {
 
 
   return (
-    <LayoutCard variant="secondary" changes={{alignItems: "center", width: "100%", minHeight: 400}}>
+    <LayoutCard variant="secondary" changes={{width: "100%", minHeight: 400}}>
       <TypographyH2>Sensor Health History</TypographyH2>
       <div
         style={{

--- a/sensor_hub/ui/sensor_hub_ui/src/components/SensorInfoCard.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/components/SensorInfoCard.tsx
@@ -1,15 +1,19 @@
 import type {Sensor} from "../types/types.ts";
 import LayoutCard from "../tools/LayoutCard.tsx";
-import { CardContent, Chip, Typography, Box, Avatar, Button} from '@mui/material';
+import { Chip, Typography, Box, Avatar, Button} from '@mui/material';
 import SensorsIcon from '@mui/icons-material/Sensors';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, Alert, CircularProgress } from '@mui/material';
 import { useNavigate } from 'react-router';
 import {SensorsApi} from "../api/Sensors.ts";
+import { MeasurementTypesApi } from '../api/Sensors';
+import type { MeasurementTypeInfo } from '../types/types';
 import type {ApiError} from "../api/Client.ts";
 import type {AuthUser} from "../providers/AuthContext.tsx";
 import {hasPerm} from "../tools/Utils.ts";
 import {TypographyH2} from "../tools/Typography.tsx";
+import {useProperties} from "../hooks/useProperties.ts";
+import {formatRetention} from "../tools/retention.ts";
 
 interface SensorInfoCardProps {
   sensor: Sensor
@@ -43,7 +47,19 @@ function SensorInfoCard({sensor, onDelete, onDisable, onEnable, user}: SensorInf
   const [loading, setLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [measurementTypes, setMeasurementTypes] = useState<MeasurementTypeInfo[]>([]);
   const navigate = useNavigate();
+  const properties = useProperties();
+
+  const globalRetentionDays = parseInt(properties['sensor.data.retention.days'] || '90', 10);
+  const globalRetentionHours = globalRetentionDays * 24;
+  const effectiveHours = sensor.retentionHours ?? globalRetentionHours;
+
+  useEffect(() => {
+    MeasurementTypesApi.getForSensor(sensor.id)
+      .then((types) => setMeasurementTypes(types))
+      .catch(() => setMeasurementTypes([]));
+  }, [sensor.id]);
 
   const openDeleteDialog = () => {
     setErrorMessage(null);
@@ -58,12 +74,12 @@ function SensorInfoCard({sensor, onDelete, onDisable, onEnable, user}: SensorInf
   }
 
   const closeDisableDialog = () => {
-    if (loading) return; // prevent closing while request in-flight
+    if (loading) return;
     setDisableDialogOpen(false);
   }
 
   const closeDeleteDialog = () => {
-    if (loading) return; // prevent closing while request in-flight
+    if (loading) return;
     setDeleteDialogOpen(false);
   };
 
@@ -110,7 +126,7 @@ function SensorInfoCard({sensor, onDelete, onDisable, onEnable, user}: SensorInf
   const handleConfirmDelete = async () => { await performSensorAction('delete'); };
 
   return (
-    <LayoutCard variant="secondary" changes={{alignItems: "center", height: "100%", width: "100%"}}>
+    <LayoutCard variant="secondary" changes={{height: "100%", width: "100%"}}>
       <Box display="flex" alignItems="center" gap={2} mb={2}>
         <TypographyH2>
           {sensor.name}
@@ -119,73 +135,86 @@ function SensorInfoCard({sensor, onDelete, onDisable, onEnable, user}: SensorInf
           <SensorsIcon />
         </Avatar>
       </Box>
-      <CardContent>
-        <Box display="flex" flexDirection="column" gap={2}>
+      <Box display="flex" flexDirection="column" gap={2}>
+        <Box display="flex" alignItems="center" gap={1}>
+          <Typography variant="subtitle1">Driver:</Typography>
+          <Chip label={sensor.sensorDriver} color="primary" size="small" />
+        </Box>
+        {sensor.external_id && (
           <Box display="flex" alignItems="center" gap={1}>
-            <Typography variant="subtitle1">Driver:</Typography>
-            <Chip label={sensor.sensorDriver} color="primary" size="small" />
+            <Typography variant="subtitle1">Device ID:</Typography>
+            <Typography variant="body2" color="text.secondary" sx={{ fontFamily: 'monospace' }}>{sensor.external_id}</Typography>
           </Box>
-          {sensor.external_id && (
-            <Box display="flex" alignItems="center" gap={1}>
-              <Typography variant="subtitle1">Device ID:</Typography>
-              <Typography variant="body2" color="text.secondary" sx={{ fontFamily: 'monospace' }}>{sensor.external_id}</Typography>
-            </Box>
-          )}
+        )}
+        <Box display="flex" alignItems="center" gap={1}>
+          <Typography variant="subtitle1">Health:</Typography>
+          <Chip label={sensor.healthStatus} color={getHealthColor(sensor.healthStatus)} size="small" />
+        </Box>
+        {sensor.healthReason && (
           <Box display="flex" alignItems="center" gap={1}>
-            <Typography variant="subtitle1">Health:</Typography>
-            <Chip label={sensor.healthStatus} color={getHealthColor(sensor.healthStatus)} size="small" />
+            <Typography variant="subtitle1" sx={{ textWrap: "nowrap" }}>Health Reason:</Typography>
+            <Typography variant="body2" color="text.secondary">{sensor.healthReason}</Typography>
           </Box>
-          {sensor.healthReason && (
-            <Box display="flex" alignItems="center" gap={1}>
-              <Typography variant="subtitle1" sx={{
-                textWrap: "nowrap"
-              }}>Health Reason:</Typography>
-              <Typography variant="body2" color="text.secondary">{sensor.healthReason}</Typography>
-            </Box>
-          )}
-          <Box display="flex" alignItems="center" gap={1}>
-            <Typography variant="subtitle1">Enabled:</Typography>
-            <Chip label={sensor.enabled ? 'true' : 'false'} color={sensor.enabled ? 'success' : 'error'} size="small" />
-          </Box>
-          {sensor.config && Object.keys(sensor.config).length > 0 && (
-            <Box>
-              <Typography variant="subtitle1" sx={{ mb: 0.5 }}>Configuration:</Typography>
-              {Object.entries(sensor.config).map(([key, value]) => (
-                <Box key={key} display="flex" alignItems="center" gap={1} sx={{ ml: 2 }}>
-                  <Typography variant="body2" color="text.secondary" sx={{ fontWeight: 'bold' }}>{key}:</Typography>
-                  <Typography variant="body2" color="text.secondary">{value}</Typography>
-                </Box>
+        )}
+        <Box display="flex" alignItems="center" gap={1}>
+          <Typography variant="subtitle1">Enabled:</Typography>
+          <Chip label={sensor.enabled ? 'true' : 'false'} color={sensor.enabled ? 'success' : 'error'} size="small" />
+        </Box>
+        <Box display="flex" alignItems="center" gap={1}>
+          <Typography variant="subtitle1">Retention:</Typography>
+          {sensor.retentionHours !== null
+            ? <Chip label={`Custom: ${formatRetention(effectiveHours)}`} color="primary" size="small" variant="outlined" />
+            : <Typography variant="body2" color="text.secondary">Global default ({formatRetention(globalRetentionHours)})</Typography>
+          }
+        </Box>
+        {measurementTypes.length > 0 && (
+          <Box>
+            <Typography variant="subtitle1" sx={{ mb: 0.5 }}>Measurement Types:</Typography>
+            <Box display="flex" flexWrap="wrap" gap={1}>
+              {measurementTypes.map((mt) => (
+                <Chip key={mt.id} label={`${mt.display_name} (${mt.unit})`} size="small" variant="outlined" />
               ))}
             </Box>
-          )}
-          <Box display="flex" alignItems="center" gap={1}>
-            <Button
-              variant="contained"
-              color="error"
-              onClick={openDeleteDialog}
-              disabled={loading || fieldsDisabled}
-            >
-              Delete
-            </Button>
-            <Button
-              variant="outlined"
-              color="warning"
-              onClick={openDisableDialog}
-              disabled={!sensor.enabled || loading || fieldsDisabled}
-            >
-              Disable
-            </Button>
-            <Button
-              variant="contained"
-              color="success"
-              onClick={handleEnableSensor}
-              disabled={sensor.enabled || loading || fieldsDisabled}
-            >
-              Enable
-            </Button>
           </Box>
+        )}
+        {sensor.config && Object.keys(sensor.config).length > 0 && (
+          <Box>
+            <Typography variant="subtitle1" sx={{ mb: 0.5 }}>Configuration:</Typography>
+            {Object.entries(sensor.config).map(([key, value]) => (
+              <Box key={key} display="flex" alignItems="center" gap={1} sx={{ ml: 2 }}>
+                <Typography variant="body2" color="text.secondary" sx={{ fontWeight: 'bold' }}>{key}:</Typography>
+                <Typography variant="body2" color="text.secondary">{value}</Typography>
+              </Box>
+            ))}
+          </Box>
+        )}
+        <Box display="flex" alignItems="center" gap={1}>
+          <Button
+            variant="contained"
+            color="error"
+            onClick={openDeleteDialog}
+            disabled={loading || fieldsDisabled}
+          >
+            Delete
+          </Button>
+          <Button
+            variant="outlined"
+            color="warning"
+            onClick={openDisableDialog}
+            disabled={!sensor.enabled || loading || fieldsDisabled}
+          >
+            Disable
+          </Button>
+          <Button
+            variant="contained"
+            color="success"
+            onClick={handleEnableSensor}
+            disabled={sensor.enabled || loading || fieldsDisabled}
+          >
+            Enable
+          </Button>
         </Box>
-      </CardContent>
+      </Box>
 
       <Dialog open={disableDialogOpen} onClose={closeDisableDialog} >
         <DialogTitle>Disable sensor "{sensor.name}"?</DialogTitle>

--- a/sensor_hub/ui/sensor_hub_ui/src/components/SensorInfoCard.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/components/SensorInfoCard.tsx
@@ -41,6 +41,15 @@ function getHealthBgColor(status: Sensor['healthStatus']) {
   }
 }
 
+function InfoField({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <Box>
+      <Typography variant="subtitle2" color="text.secondary">{label}</Typography>
+      <Box display="flex" alignItems="center" mt={0.5}>{children}</Box>
+    </Box>
+  );
+}
+
 function SensorInfoCard({sensor, onDelete, onDisable, onEnable, user}: SensorInfoCardProps) {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [disableDialogOpen, setDisableDialogOpen] = useState(false);
@@ -126,7 +135,7 @@ function SensorInfoCard({sensor, onDelete, onDisable, onEnable, user}: SensorInf
   const handleConfirmDelete = async () => { await performSensorAction('delete'); };
 
   return (
-    <LayoutCard variant="secondary" changes={{height: "100%", width: "100%"}}>
+    <LayoutCard variant="secondary" changes={{height: "100%", width: "100%", display: "flex", flexDirection: "column"}}>
       <Box display="flex" alignItems="center" gap={2} mb={2}>
         <TypographyH2>
           {sensor.name}
@@ -135,85 +144,70 @@ function SensorInfoCard({sensor, onDelete, onDisable, onEnable, user}: SensorInf
           <SensorsIcon />
         </Avatar>
       </Box>
-      <Box display="flex" flexDirection="column" gap={2}>
-        <Box display="flex" alignItems="center" gap={1}>
-          <Typography variant="subtitle1">Driver:</Typography>
-          <Chip label={sensor.sensorDriver} color="primary" size="small" />
-        </Box>
-        {sensor.external_id && (
-          <Box display="flex" alignItems="center" gap={1}>
-            <Typography variant="subtitle1">Device ID:</Typography>
-            <Typography variant="body2" color="text.secondary" sx={{ fontFamily: 'monospace' }}>{sensor.external_id}</Typography>
-          </Box>
-        )}
-        <Box display="flex" alignItems="center" gap={1}>
-          <Typography variant="subtitle1">Health:</Typography>
-          <Chip label={sensor.healthStatus} color={getHealthColor(sensor.healthStatus)} size="small" />
-        </Box>
-        {sensor.healthReason && (
-          <Box display="flex" alignItems="center" gap={1}>
-            <Typography variant="subtitle1" sx={{ textWrap: "nowrap" }}>Health Reason:</Typography>
-            <Typography variant="body2" color="text.secondary">{sensor.healthReason}</Typography>
-          </Box>
-        )}
-        <Box display="flex" alignItems="center" gap={1}>
-          <Typography variant="subtitle1">Enabled:</Typography>
-          <Chip label={sensor.enabled ? 'true' : 'false'} color={sensor.enabled ? 'success' : 'error'} size="small" />
-        </Box>
-        <Box display="flex" alignItems="center" gap={1}>
-          <Typography variant="subtitle1">Retention:</Typography>
+
+      <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))', gap: 2 }}>
+        <InfoField label="Driver"><Chip label={sensor.sensorDriver} color="primary" size="small" /></InfoField>
+        <InfoField label="Health"><Chip label={sensor.healthStatus} color={getHealthColor(sensor.healthStatus)} size="small" /></InfoField>
+        <InfoField label="Enabled"><Chip label={sensor.enabled ? 'true' : 'false'} color={sensor.enabled ? 'success' : 'error'} size="small" /></InfoField>
+        <InfoField label="Retention">
           {sensor.retentionHours !== null
             ? <Chip label={`Custom: ${formatRetention(effectiveHours)}`} color="primary" size="small" variant="outlined" />
             : <Typography variant="body2" color="text.secondary">Global default ({formatRetention(globalRetentionHours)})</Typography>
           }
-        </Box>
-        {measurementTypes.length > 0 && (
-          <Box>
-            <Typography variant="subtitle1" sx={{ mb: 0.5 }}>Measurement Types:</Typography>
-            <Box display="flex" flexWrap="wrap" gap={1}>
-              {measurementTypes.map((mt) => (
-                <Chip key={mt.id} label={`${mt.display_name} (${mt.unit})`} size="small" variant="outlined" />
-              ))}
-            </Box>
-          </Box>
+        </InfoField>
+        {sensor.external_id && (
+          <InfoField label="Device ID">
+            <Typography variant="body2" color="text.secondary" sx={{ fontFamily: 'monospace' }}>{sensor.external_id}</Typography>
+          </InfoField>
         )}
-        {sensor.config && Object.keys(sensor.config).length > 0 && (
-          <Box>
-            <Typography variant="subtitle1" sx={{ mb: 0.5 }}>Configuration:</Typography>
-            {Object.entries(sensor.config).map(([key, value]) => (
-              <Box key={key} display="flex" alignItems="center" gap={1} sx={{ ml: 2 }}>
-                <Typography variant="body2" color="text.secondary" sx={{ fontWeight: 'bold' }}>{key}:</Typography>
-                <Typography variant="body2" color="text.secondary">{value}</Typography>
-              </Box>
+        {sensor.healthReason && (
+          <InfoField label="Health Reason">
+            <Typography variant="body2" color="text.secondary">{sensor.healthReason}</Typography>
+          </InfoField>
+        )}
+        {sensor.config && Object.entries(sensor.config).map(([key, value]) => (
+          <InfoField key={key} label={key}>
+            <Typography variant="body2" color="text.secondary">{value}</Typography>
+          </InfoField>
+        ))}
+      </Box>
+
+      {measurementTypes.length > 0 && (
+        <Box mt={2}>
+          <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 0.5 }}>Measurement Types</Typography>
+          <Box display="flex" flexWrap="wrap" gap={1}>
+            {measurementTypes.map((mt) => (
+              <Chip key={mt.id} label={`${mt.display_name} (${mt.unit})`} size="small" variant="outlined" />
             ))}
           </Box>
-        )}
-        <Box display="flex" alignItems="center" gap={1}>
-          <Button
-            variant="contained"
-            color="error"
-            onClick={openDeleteDialog}
-            disabled={loading || fieldsDisabled}
-          >
-            Delete
-          </Button>
-          <Button
-            variant="outlined"
-            color="warning"
-            onClick={openDisableDialog}
-            disabled={!sensor.enabled || loading || fieldsDisabled}
-          >
-            Disable
-          </Button>
-          <Button
-            variant="contained"
-            color="success"
-            onClick={handleEnableSensor}
-            disabled={sensor.enabled || loading || fieldsDisabled}
-          >
-            Enable
-          </Button>
         </Box>
+      )}
+
+      <Box display="flex" alignItems="center" gap={1} mt="auto" pt={2}>
+        <Button
+          variant="contained"
+          color="error"
+          onClick={openDeleteDialog}
+          disabled={loading || fieldsDisabled}
+        >
+          Delete
+        </Button>
+        <Button
+          variant="outlined"
+          color="warning"
+          onClick={openDisableDialog}
+          disabled={!sensor.enabled || loading || fieldsDisabled}
+        >
+          Disable
+        </Button>
+        <Button
+          variant="contained"
+          color="success"
+          onClick={handleEnableSensor}
+          disabled={sensor.enabled || loading || fieldsDisabled}
+        >
+          Enable
+        </Button>
       </Box>
 
       <Dialog open={disableDialogOpen} onClose={closeDisableDialog} >

--- a/sensor_hub/ui/sensor_hub_ui/src/components/SensorRetentionCard.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/components/SensorRetentionCard.tsx
@@ -1,0 +1,198 @@
+import { useState, useEffect } from 'react';
+import {
+  Box,
+  CardContent,
+  TextField,
+  Button,
+  Switch,
+  FormControlLabel,
+  Alert,
+  Typography,
+  CircularProgress,
+  MenuItem,
+} from '@mui/material';
+import type { Sensor } from '../types/types';
+import LayoutCard from '../tools/LayoutCard';
+import { TypographyH2 } from '../tools/Typography';
+import { SensorsApi } from '../api/Sensors';
+import { useAuth } from '../providers/AuthContext';
+import { hasPerm } from '../tools/Utils';
+import { useProperties } from '../hooks/useProperties';
+
+interface SensorRetentionCardProps {
+  sensor: Sensor;
+}
+
+type RetentionUnit = 'hours' | 'days' | 'weeks';
+
+const unitMultipliers: Record<RetentionUnit, number> = {
+  hours: 1,
+  days: 24,
+  weeks: 168,
+};
+
+function hoursToUnit(hours: number, unit: RetentionUnit): number {
+  return Math.round((hours / unitMultipliers[unit]) * 100) / 100;
+}
+
+function unitToHours(value: number, unit: RetentionUnit): number {
+  return Math.round(value * unitMultipliers[unit]);
+}
+
+function formatRetention(hours: number): string {
+  if (hours >= 168 && hours % 168 === 0) return `${hours / 168} week${hours / 168 !== 1 ? 's' : ''}`;
+  if (hours >= 24 && hours % 24 === 0) return `${hours / 24} day${hours / 24 !== 1 ? 's' : ''}`;
+  return `${hours} hour${hours !== 1 ? 's' : ''}`;
+}
+
+function SensorRetentionCard({ sensor }: SensorRetentionCardProps) {
+  const { user } = useAuth();
+  const properties = useProperties();
+  const globalRetentionDays = parseInt(properties['sensor.data.retention.days'] || '90', 10);
+  const globalRetentionHours = globalRetentionDays * 24;
+  const effectiveHours = sensor.retentionHours ?? globalRetentionHours;
+
+  const [useCustom, setUseCustom] = useState(sensor.retentionHours !== null);
+  const [unit, setUnit] = useState<RetentionUnit>('days');
+  const [value, setValue] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    const hasCustom = sensor.retentionHours !== null;
+    setUseCustom(hasCustom);
+    if (hasCustom && sensor.retentionHours !== null) {
+      const h = sensor.retentionHours;
+      if (h >= 168 && h % 168 === 0) {
+        setUnit('weeks');
+        setValue(String(h / 168));
+      } else if (h >= 24 && h % 24 === 0) {
+        setUnit('days');
+        setValue(String(h / 24));
+      } else {
+        setUnit('hours');
+        setValue(String(h));
+      }
+    } else {
+      setUnit('days');
+      setValue('');
+    }
+  }, [sensor.retentionHours]);
+
+  const fieldsDisabled = !user || !hasPerm(user, 'manage_sensors');
+
+  const handleSave = async () => {
+    setSuccessMessage(null);
+    setErrorMessage(null);
+    setSaving(true);
+    try {
+      const retentionHours = useCustom ? unitToHours(parseFloat(value), unit) : null;
+      if (useCustom && (!retentionHours || retentionHours < 1)) {
+        setErrorMessage('Retention must be at least 1 hour');
+        setSaving(false);
+        return;
+      }
+      await SensorsApi.update(sensor.id, { retention_hours: retentionHours });
+      setSuccessMessage(retentionHours ? `Retention set to ${formatRetention(retentionHours)}` : 'Reverted to global default');
+    } catch {
+      setErrorMessage('Failed to update retention');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const hasChanges = (() => {
+    if (useCustom !== (sensor.retentionHours !== null)) return true;
+    if (useCustom && value !== '') {
+      const newHours = unitToHours(parseFloat(value), unit);
+      return newHours !== sensor.retentionHours;
+    }
+    return false;
+  })();
+
+  return (
+    <LayoutCard variant="secondary" changes={{ alignItems: 'center', height: '100%', width: '100%' }}>
+      <CardContent sx={{ width: '100%', padding: 3, maxWidth: 650 }}>
+        <TypographyH2>Data Retention</TypographyH2>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          Global default: {formatRetention(globalRetentionHours)}. Effective: {formatRetention(effectiveHours)}.
+        </Typography>
+
+        {successMessage && (
+          <Alert severity="success" onClose={() => setSuccessMessage(null)} sx={{ mb: 2 }}>
+            {successMessage}
+          </Alert>
+        )}
+        {errorMessage && (
+          <Alert severity="error" onClose={() => setErrorMessage(null)} sx={{ mb: 2 }}>
+            {errorMessage}
+          </Alert>
+        )}
+
+        <FormControlLabel
+          control={
+            <Switch
+              checked={useCustom}
+              onChange={(e) => {
+                setUseCustom(e.target.checked);
+                if (!e.target.checked) setValue('');
+              }}
+              disabled={fieldsDisabled}
+            />
+          }
+          label="Override global retention for this sensor"
+          sx={{ mb: 2 }}
+        />
+
+        {useCustom && (
+          <Box sx={{ display: 'flex', gap: 2, alignItems: 'flex-start', mb: 2 }}>
+            <TextField
+              label="Retention"
+              type="number"
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              disabled={fieldsDisabled}
+              slotProps={{ htmlInput: { min: 1, step: 1 } }}
+              size="small"
+              sx={{ width: 140 }}
+            />
+            <TextField
+              select
+              label="Unit"
+              value={unit}
+              onChange={(e) => {
+                const newUnit = e.target.value as RetentionUnit;
+                if (value) {
+                  const hours = unitToHours(parseFloat(value), unit);
+                  setValue(String(hoursToUnit(hours, newUnit)));
+                }
+                setUnit(newUnit);
+              }}
+              disabled={fieldsDisabled}
+              size="small"
+              sx={{ width: 120 }}
+            >
+              <MenuItem value="hours">Hours</MenuItem>
+              <MenuItem value="days">Days</MenuItem>
+              <MenuItem value="weeks">Weeks</MenuItem>
+            </TextField>
+          </Box>
+        )}
+
+        <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+          <Button
+            variant="contained"
+            onClick={handleSave}
+            disabled={fieldsDisabled || saving || !hasChanges}
+            startIcon={saving ? <CircularProgress color="inherit" size={18} /> : undefined}
+          >
+            {saving ? 'Saving...' : 'Save'}
+          </Button>
+        </Box>
+      </CardContent>
+    </LayoutCard>
+  );
+}
+
+export default SensorRetentionCard;

--- a/sensor_hub/ui/sensor_hub_ui/src/components/SensorRetentionCard.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/components/SensorRetentionCard.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from 'react';
 import {
   Box,
-  CardContent,
   TextField,
   Button,
   Switch,
@@ -31,18 +30,24 @@ const unitMultipliers: Record<RetentionUnit, number> = {
   weeks: 168,
 };
 
-function hoursToUnit(hours: number, unit: RetentionUnit): number {
-  return Math.round((hours / unitMultipliers[unit]) * 100) / 100;
-}
-
 function unitToHours(value: number, unit: RetentionUnit): number {
   return Math.round(value * unitMultipliers[unit]);
 }
 
-function formatRetention(hours: number): string {
+function hoursToUnit(hours: number, unit: RetentionUnit): number {
+  return Math.round((hours / unitMultipliers[unit]) * 100) / 100;
+}
+
+export function formatRetention(hours: number): string {
   if (hours >= 168 && hours % 168 === 0) return `${hours / 168} week${hours / 168 !== 1 ? 's' : ''}`;
   if (hours >= 24 && hours % 24 === 0) return `${hours / 24} day${hours / 24 !== 1 ? 's' : ''}`;
   return `${hours} hour${hours !== 1 ? 's' : ''}`;
+}
+
+function bestUnit(hours: number): RetentionUnit {
+  if (hours >= 168 && hours % 168 === 0) return 'weeks';
+  if (hours >= 24 && hours % 24 === 0) return 'days';
+  return 'hours';
 }
 
 function SensorRetentionCard({ sensor }: SensorRetentionCardProps) {
@@ -50,7 +55,6 @@ function SensorRetentionCard({ sensor }: SensorRetentionCardProps) {
   const properties = useProperties();
   const globalRetentionDays = parseInt(properties['sensor.data.retention.days'] || '90', 10);
   const globalRetentionHours = globalRetentionDays * 24;
-  const effectiveHours = sensor.retentionHours ?? globalRetentionHours;
 
   const [useCustom, setUseCustom] = useState(sensor.retentionHours !== null);
   const [unit, setUnit] = useState<RetentionUnit>('days');
@@ -64,16 +68,9 @@ function SensorRetentionCard({ sensor }: SensorRetentionCardProps) {
     setUseCustom(hasCustom);
     if (hasCustom && sensor.retentionHours !== null) {
       const h = sensor.retentionHours;
-      if (h >= 168 && h % 168 === 0) {
-        setUnit('weeks');
-        setValue(String(h / 168));
-      } else if (h >= 24 && h % 24 === 0) {
-        setUnit('days');
-        setValue(String(h / 24));
-      } else {
-        setUnit('hours');
-        setValue(String(h));
-      }
+      const u = bestUnit(h);
+      setUnit(u);
+      setValue(String(hoursToUnit(h, u)));
     } else {
       setUnit('days');
       setValue('');
@@ -81,6 +78,10 @@ function SensorRetentionCard({ sensor }: SensorRetentionCardProps) {
   }, [sensor.retentionHours]);
 
   const fieldsDisabled = !user || !hasPerm(user, 'manage_sensors');
+
+  const pendingEffectiveHours = useCustom && value
+    ? unitToHours(parseFloat(value), unit)
+    : globalRetentionHours;
 
   const handleSave = async () => {
     setSuccessMessage(null);
@@ -112,85 +113,83 @@ function SensorRetentionCard({ sensor }: SensorRetentionCardProps) {
   })();
 
   return (
-    <LayoutCard variant="secondary" changes={{ alignItems: 'center', height: '100%', width: '100%' }}>
-      <CardContent sx={{ width: '100%', padding: 3, maxWidth: 650 }}>
-        <TypographyH2>Data Retention</TypographyH2>
-        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-          Global default: {formatRetention(globalRetentionHours)}. Effective: {formatRetention(effectiveHours)}.
-        </Typography>
+    <LayoutCard variant="secondary" changes={{ height: '100%', width: '100%' }}>
+      <TypographyH2>Data Retention</TypographyH2>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        Effective: <strong>{formatRetention(pendingEffectiveHours)}</strong>
+        {' '}(global default: {formatRetention(globalRetentionHours)})
+      </Typography>
 
-        {successMessage && (
-          <Alert severity="success" onClose={() => setSuccessMessage(null)} sx={{ mb: 2 }}>
-            {successMessage}
-          </Alert>
-        )}
-        {errorMessage && (
-          <Alert severity="error" onClose={() => setErrorMessage(null)} sx={{ mb: 2 }}>
-            {errorMessage}
-          </Alert>
-        )}
+      {successMessage && (
+        <Alert severity="success" onClose={() => setSuccessMessage(null)} sx={{ mb: 2 }}>
+          {successMessage}
+        </Alert>
+      )}
+      {errorMessage && (
+        <Alert severity="error" onClose={() => setErrorMessage(null)} sx={{ mb: 2 }}>
+          {errorMessage}
+        </Alert>
+      )}
 
-        <FormControlLabel
-          control={
-            <Switch
-              checked={useCustom}
-              onChange={(e) => {
-                setUseCustom(e.target.checked);
-                if (!e.target.checked) setValue('');
-              }}
-              disabled={fieldsDisabled}
-            />
-          }
-          label="Override global retention for this sensor"
-          sx={{ mb: 2 }}
-        />
+      <FormControlLabel
+        control={
+          <Switch
+            checked={useCustom}
+            onChange={(e) => {
+              setUseCustom(e.target.checked);
+              if (!e.target.checked) setValue('');
+            }}
+            disabled={fieldsDisabled}
+          />
+        }
+        label="Override global retention for this sensor"
+      />
 
-        {useCustom && (
-          <Box sx={{ display: 'flex', gap: 2, alignItems: 'flex-start', mb: 2 }}>
-            <TextField
-              label="Retention"
-              type="number"
-              value={value}
-              onChange={(e) => setValue(e.target.value)}
-              disabled={fieldsDisabled}
-              slotProps={{ htmlInput: { min: 1, step: 1 } }}
-              size="small"
-              sx={{ width: 140 }}
-            />
-            <TextField
-              select
-              label="Unit"
-              value={unit}
-              onChange={(e) => {
-                const newUnit = e.target.value as RetentionUnit;
-                if (value) {
-                  const hours = unitToHours(parseFloat(value), unit);
-                  setValue(String(hoursToUnit(hours, newUnit)));
-                }
-                setUnit(newUnit);
-              }}
-              disabled={fieldsDisabled}
-              size="small"
-              sx={{ width: 120 }}
-            >
-              <MenuItem value="hours">Hours</MenuItem>
-              <MenuItem value="days">Days</MenuItem>
-              <MenuItem value="weeks">Weeks</MenuItem>
-            </TextField>
-          </Box>
-        )}
-
-        <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
-          <Button
-            variant="contained"
-            onClick={handleSave}
-            disabled={fieldsDisabled || saving || !hasChanges}
-            startIcon={saving ? <CircularProgress color="inherit" size={18} /> : undefined}
+      {useCustom && (
+        <Box sx={{ display: 'flex', gap: 2, alignItems: 'flex-start', mt: 2 }}>
+          <TextField
+            label="Retention"
+            type="number"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            disabled={fieldsDisabled}
+            slotProps={{ htmlInput: { min: 1, step: 1 } }}
+            size="small"
+            sx={{ width: 140 }}
+          />
+          <TextField
+            select
+            label="Unit"
+            value={unit}
+            onChange={(e) => {
+              const newUnit = e.target.value as RetentionUnit;
+              if (value) {
+                const hours = unitToHours(parseFloat(value), unit);
+                setValue(String(hoursToUnit(hours, newUnit)));
+              }
+              setUnit(newUnit);
+            }}
+            disabled={fieldsDisabled}
+            size="small"
+            sx={{ width: 120 }}
           >
-            {saving ? 'Saving...' : 'Save'}
-          </Button>
+            <MenuItem value="hours">Hours</MenuItem>
+            <MenuItem value="days">Days</MenuItem>
+            <MenuItem value="weeks">Weeks</MenuItem>
+          </TextField>
         </Box>
-      </CardContent>
+      )}
+
+      <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 2 }}>
+        <Button
+          variant="contained"
+          onClick={handleSave}
+          disabled={fieldsDisabled || saving || !hasChanges}
+          startIcon={saving ? <CircularProgress color="inherit" size={18} /> : undefined}
+        >
+          {saving ? 'Saving...' : 'Save'}
+        </Button>
+      </Box>
     </LayoutCard>
   );
 }

--- a/sensor_hub/ui/sensor_hub_ui/src/forms/SensorForm.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/forms/SensorForm.tsx
@@ -1,12 +1,15 @@
 import type {Sensor, DriverInfo} from "../types/types.ts";
 import {Formik, Form, type FormikProps} from 'formik';
-import { Button, CardContent, Box, Stack, TextField, Typography, Alert, MenuItem } from '@mui/material';
+import { Button, Box, Stack, TextField, Typography, Alert, MenuItem, Divider, FormControlLabel, Switch } from '@mui/material';
 import {useSensorForm} from "../hooks/useSensorForm.ts";
 import {useDrivers} from "../hooks/useDrivers.ts";
 import * as Yup from 'yup';
 import type {AuthUser} from "../providers/AuthContext.tsx";
 import {hasPerm} from "../tools/Utils.ts";
 import {useMemo} from "react";
+import {TypographyH2} from "../tools/Typography.tsx";
+import {useProperties} from "../hooks/useProperties.ts";
+import {formatRetention, unitToHours, hoursToUnit, type RetentionUnit} from "../tools/retention.ts";
 
 interface SensorFormProps {
   sensor?: Sensor;
@@ -19,6 +22,9 @@ export type SensorFormValues = {
   name: string;
   sensorDriver: string;
   config: Record<string, string>;
+  retentionEnabled: boolean;
+  retentionValue: string;
+  retentionUnit: RetentionUnit;
 };
 
 function buildValidationSchema(selectedDriver: DriverInfo | undefined) {
@@ -42,6 +48,9 @@ function buildValidationSchema(selectedDriver: DriverInfo | undefined) {
 
 function SensorForm ({ sensor, mode = 'edit', onSuccess, user } : SensorFormProps) {
   const { drivers } = useDrivers('pull');
+  const properties = useProperties();
+  const globalRetentionDays = parseInt(properties['sensor.data.retention.days'] || '90', 10);
+  const globalRetentionHours = globalRetentionDays * 24;
   const {
     initialValues,
     onSubmit,
@@ -57,144 +66,204 @@ function SensorForm ({ sensor, mode = 'edit', onSuccess, user } : SensorFormProp
   const fieldsDisabled = !(hasPerm(user, "manage_sensors"));
 
   return (
-      <CardContent sx={{width: "100%", padding: 3, maxWidth: 650}}>
-        <Typography variant="h6" sx={{ mb: 2 }}>
-          {mode === 'create' ? 'Add Sensor' : 'Edit Sensor Details'}
-        </Typography>
-        <Formik<SensorFormValues>
-          initialValues={initialValues}
-          enableReinitialize onSubmit={onSubmit}
-          validationSchema={buildValidationSchema(drivers.find(d => d.type === initialValues.sensorDriver))}
-        >
-          {(formik: FormikProps<SensorFormValues>) => {
-            const { isSubmitting: formikSubmitting, dirty, errors, touched, values, setFieldValue } = formik;
+    <>
+      <TypographyH2>
+        {mode === 'create' ? 'Add Sensor' : 'Edit Sensor Details'}
+      </TypographyH2>
+      <Formik<SensorFormValues>
+        initialValues={initialValues}
+        enableReinitialize onSubmit={onSubmit}
+        validationSchema={buildValidationSchema(drivers.find(d => d.type === initialValues.sensorDriver))}
+      >
+        {(formik: FormikProps<SensorFormValues>) => {
+          const { isSubmitting: formikSubmitting, dirty, errors, touched, values, setFieldValue } = formik;
 
-            const selectedDriver = useMemo(
-              () => drivers.find(d => d.type === values.sensorDriver),
-              [drivers, values.sensorDriver]
-            );
+          const selectedDriver = useMemo(
+            () => drivers.find(d => d.type === values.sensorDriver),
+            [drivers, values.sensorDriver]
+          );
 
-            return (
-              <Form>
-                <Stack spacing={2}>
-                  <TextField
-                    name="name"
-                    label="Name"
-                    variant="outlined"
-                    fullWidth
-                    size="small"
-                    value={values.name}
-                    onChange={formik.handleChange}
-                    disabled={fieldsDisabled}
-                    error={!!(errors.name && touched.name)}
-                    helperText={touched.name && errors.name}
-                  />
+          const pendingEffectiveHours = values.retentionEnabled && values.retentionValue
+            ? unitToHours(parseFloat(values.retentionValue), values.retentionUnit)
+            : globalRetentionHours;
 
-                  <TextField
-                    name="sensorDriver"
-                    label="Sensor Driver"
-                    variant="outlined"
-                    fullWidth
-                    select
-                    size="small"
-                    disabled={fieldsDisabled}
-                    value={values.sensorDriver}
-                    onChange={(e) => {
-                      const newDriver = e.target.value;
-                      void setFieldValue('sensorDriver', newDriver);
-                      // Reset config to defaults for the new driver
-                      const driver = drivers.find(d => d.type === newDriver);
-                      if (driver) {
-                        const newConfig: Record<string, string> = {};
-                        for (const f of driver.config_fields) {
-                          newConfig[f.key] = f.default ?? '';
-                        }
-                        void setFieldValue('config', newConfig);
-                      } else {
-                        void setFieldValue('config', {});
+          return (
+            <Form>
+              <Stack spacing={2}>
+                <TextField
+                  name="name"
+                  label="Name"
+                  variant="outlined"
+                  fullWidth
+                  size="small"
+                  value={values.name}
+                  onChange={formik.handleChange}
+                  disabled={fieldsDisabled}
+                  error={!!(errors.name && touched.name)}
+                  helperText={touched.name && errors.name}
+                />
+
+                <TextField
+                  name="sensorDriver"
+                  label="Sensor Driver"
+                  variant="outlined"
+                  fullWidth
+                  select
+                  size="small"
+                  disabled={fieldsDisabled}
+                  value={values.sensorDriver}
+                  onChange={(e) => {
+                    const newDriver = e.target.value;
+                    void setFieldValue('sensorDriver', newDriver);
+                    const driver = drivers.find(d => d.type === newDriver);
+                    if (driver) {
+                      const newConfig: Record<string, string> = {};
+                      for (const f of driver.config_fields) {
+                        newConfig[f.key] = f.default ?? '';
                       }
-                    }}
-                    error={!!(errors.sensorDriver && touched.sensorDriver)}
-                    helperText={touched.sensorDriver && errors.sensorDriver}
-                  >
-                    {drivers.map((driver) => (
-                      <MenuItem key={driver.type} value={driver.type}>
-                        {driver.display_name}
-                      </MenuItem>
-                    ))}
-                  </TextField>
+                      void setFieldValue('config', newConfig);
+                    } else {
+                      void setFieldValue('config', {});
+                    }
+                  }}
+                  error={!!(errors.sensorDriver && touched.sensorDriver)}
+                  helperText={touched.sensorDriver && errors.sensorDriver}
+                >
+                  {drivers.map((driver) => (
+                    <MenuItem key={driver.type} value={driver.type}>
+                      {driver.display_name}
+                    </MenuItem>
+                  ))}
+                </TextField>
 
-                  {selectedDriver?.config_fields.map((field) => {
-                    const configErrors = errors.config as Record<string, string> | undefined;
-                    const configTouched = touched.config as Record<string, boolean> | undefined;
-                    return (
-                      <TextField
-                        key={field.key}
-                        name={`config.${field.key}`}
-                        label={field.label}
-                        helperText={
-                          (configTouched?.[field.key] && configErrors?.[field.key])
-                            ? configErrors[field.key]
-                            : field.description
-                        }
-                        error={!!(configTouched?.[field.key] && configErrors?.[field.key])}
-                        type={field.sensitive ? 'password' : 'text'}
-                        variant="outlined"
-                        fullWidth
-                        size="small"
-                        required={field.required}
-                        value={values.config?.[field.key] ?? field.default ?? ''}
-                        onChange={formik.handleChange}
-                        disabled={fieldsDisabled}
-                      />
-                    );
-                  })}
-
-                  <Box display="flex">
-                    <Button
-                      type="reset"
-                      disabled={isSubmitting || formikSubmitting || fieldsDisabled}
+                {selectedDriver?.config_fields.map((field) => {
+                  const configErrors = errors.config as Record<string, string> | undefined;
+                  const configTouched = touched.config as Record<string, boolean> | undefined;
+                  return (
+                    <TextField
+                      key={field.key}
+                      name={`config.${field.key}`}
+                      label={field.label}
+                      helperText={
+                        (configTouched?.[field.key] && configErrors?.[field.key])
+                          ? configErrors[field.key]
+                          : field.description
+                      }
+                      error={!!(configTouched?.[field.key] && configErrors?.[field.key])}
+                      type={field.sensitive ? 'password' : 'text'}
                       variant="outlined"
-                      color="primary"
-                      sx={{ mr: 2 }}
-                    >
-                      Reset
-                    </Button>
-                    <Button
-                      type="submit"
-                      disabled={isSubmitting || formikSubmitting || !dirty || fieldsDisabled}
-                      variant="contained"
-                      color="primary"
+                      fullWidth
+                      size="small"
+                      required={field.required}
+                      value={values.config?.[field.key] ?? field.default ?? ''}
+                      onChange={formik.handleChange}
+                      disabled={fieldsDisabled}
+                    />
+                  );
+                })}
 
-                    >
-                      {mode === 'create' ? 'Create' : 'Submit'}
-                    </Button>
-                  </Box>
-                </Stack>
-              </Form>
-            );
-          }}
-        </Formik>
-        {successMessage && (
-          <Box mt={2}>
-            <Alert severity="success" onClose={() => setSuccessMessage(null)}>
-              {successMessage}
-            </Alert>
-          </Box>
-        )}
-        {errorMessage && (
-          <Box mt={2}>
-            <Alert severity="error" onClose={() => { setErrorMessage(null); setAdvancedErrorMessage(null); }}>
-              {errorMessage}
-              {advancedErrorMessage && (
-                <Box mt={1} sx={{ whiteSpace: 'pre-wrap', fontFamily: 'monospace', fontSize: '0.75rem' }} >
-                  {advancedErrorMessage}
+                {mode === 'edit' && (
+                  <>
+                    <Divider />
+                    <Typography variant="subtitle2" color="text.secondary">
+                      Effective retention: <strong>{formatRetention(pendingEffectiveHours)}</strong>
+                      {' '}(global default: {formatRetention(globalRetentionHours)})
+                    </Typography>
+                    <FormControlLabel
+                      control={
+                        <Switch
+                          checked={values.retentionEnabled}
+                          onChange={(e) => {
+                            void setFieldValue('retentionEnabled', e.target.checked);
+                            if (!e.target.checked) void setFieldValue('retentionValue', '');
+                          }}
+                          disabled={fieldsDisabled}
+                        />
+                      }
+                      label="Override global data retention"
+                    />
+                    {values.retentionEnabled && (
+                      <Box sx={{ display: 'flex', gap: 2, alignItems: 'flex-start' }}>
+                        <TextField
+                          label="Retention"
+                          type="number"
+                          value={values.retentionValue}
+                          onChange={(e) => void setFieldValue('retentionValue', e.target.value)}
+                          disabled={fieldsDisabled}
+                          slotProps={{ htmlInput: { min: 1, step: 1 } }}
+                          size="small"
+                          sx={{ flex: 1 }}
+                        />
+                        <TextField
+                          select
+                          label="Unit"
+                          value={values.retentionUnit}
+                          onChange={(e) => {
+                            const newUnit = e.target.value as RetentionUnit;
+                            if (values.retentionValue) {
+                              const hours = unitToHours(parseFloat(values.retentionValue), values.retentionUnit);
+                              void setFieldValue('retentionValue', String(hoursToUnit(hours, newUnit)));
+                            }
+                            void setFieldValue('retentionUnit', newUnit);
+                          }}
+                          disabled={fieldsDisabled}
+                          size="small"
+                          sx={{ minWidth: 120 }}
+                        >
+                          <MenuItem value="hours">Hours</MenuItem>
+                          <MenuItem value="days">Days</MenuItem>
+                          <MenuItem value="weeks">Weeks</MenuItem>
+                        </TextField>
+                      </Box>
+                    )}
+                  </>
+                )}
+
+                <Box display="flex">
+                  <Button
+                    type="reset"
+                    disabled={isSubmitting || formikSubmitting || fieldsDisabled}
+                    variant="outlined"
+                    color="primary"
+                    sx={{ mr: 2 }}
+                  >
+                    Reset
+                  </Button>
+                  <Button
+                    type="submit"
+                    disabled={isSubmitting || formikSubmitting || !dirty || fieldsDisabled}
+                    variant="contained"
+                    color="primary"
+
+                  >
+                    {mode === 'create' ? 'Create' : 'Submit'}
+                  </Button>
                 </Box>
-              )}
-            </Alert>
-          </Box>
-        )}
-      </CardContent>
+              </Stack>
+            </Form>
+          );
+        }}
+      </Formik>
+      {successMessage && (
+        <Box mt={2}>
+          <Alert severity="success" onClose={() => setSuccessMessage(null)}>
+            {successMessage}
+          </Alert>
+        </Box>
+      )}
+      {errorMessage && (
+        <Box mt={2}>
+          <Alert severity="error" onClose={() => { setErrorMessage(null); setAdvancedErrorMessage(null); }}>
+            {errorMessage}
+            {advancedErrorMessage && (
+              <Box mt={1} sx={{ whiteSpace: 'pre-wrap', fontFamily: 'monospace', fontSize: '0.75rem' }} >
+                {advancedErrorMessage}
+              </Box>
+            )}
+          </Alert>
+        </Box>
+      )}
+    </>
   );
 }
 

--- a/sensor_hub/ui/sensor_hub_ui/src/hooks/useSensorForm.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/hooks/useSensorForm.ts
@@ -5,11 +5,20 @@ import type {ApiError} from "../api/Client.ts";
 import type { FormikHelpers } from 'formik';
 import { logger } from '../tools/logger';
 import type { SensorFormValues } from '../forms/SensorForm';
+import { bestUnit, hoursToUnit, unitToHours } from '../tools/retention';
 
 export interface UseSensorFormOpts {
   mode?: 'create' | 'edit';
   initialSensor?: Sensor | null;
   onSuccess?: (sensor: Sensor | null) => void;
+}
+
+function retentionInitialValues(sensor: Sensor | null): Pick<SensorFormValues, 'retentionEnabled' | 'retentionValue' | 'retentionUnit'> {
+  if (sensor?.retentionHours != null) {
+    const u = bestUnit(sensor.retentionHours);
+    return { retentionEnabled: true, retentionValue: String(hoursToUnit(sensor.retentionHours, u)), retentionUnit: u };
+  }
+  return { retentionEnabled: false, retentionValue: '', retentionUnit: 'days' };
 }
 
 export function useSensorForm({ mode = 'edit', initialSensor = null, onSuccess }: UseSensorFormOpts) {
@@ -22,6 +31,7 @@ export function useSensorForm({ mode = 'edit', initialSensor = null, onSuccess }
     name: initialSensor?.name ?? '',
     sensorDriver: initialSensor?.sensorDriver ?? '',
     config: initialSensor?.config ?? {},
+    ...retentionInitialValues(initialSensor),
   };
 
   const handleErrors = (err: unknown) => {
@@ -62,10 +72,14 @@ export function useSensorForm({ mode = 'edit', initialSensor = null, onSuccess }
           if (!initialSensor || initialSensor.id == null) {
             throw new Error('Missing sensor id for update');
           }
+          const retentionHours = values.retentionEnabled
+            ? unitToHours(parseFloat(values.retentionValue), values.retentionUnit)
+            : null;
           await SensorsApi.update(Number(initialSensor.id), {
             name: values.name,
             sensor_driver: values.sensorDriver,
             config: values.config,
+            retention_hours: retentionHours,
           });
         }
 
@@ -83,13 +97,14 @@ export function useSensorForm({ mode = 'edit', initialSensor = null, onSuccess }
 
         if (actions && typeof actions.resetForm === 'function') {
           if (mode === 'create') {
-            actions.resetForm({ values: { name: '', sensorDriver: '', config: {} } });
+            actions.resetForm({ values: { name: '', sensorDriver: '', config: {}, retentionEnabled: false, retentionValue: '', retentionUnit: 'days' } });
           } else {
             actions.resetForm({
               values: {
                 name: newSensor?.name ?? values.name,
                 sensorDriver: newSensor?.sensorDriver ?? values.sensorDriver,
                 config: newSensor?.config ?? values.config,
+                ...retentionInitialValues(newSensor),
               },
             });
           }

--- a/sensor_hub/ui/sensor_hub_ui/src/hooks/useSensors.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/hooks/useSensors.ts
@@ -17,7 +17,8 @@ function arraysEqual(a: Sensor[], b: Sensor[]) {
       JSON.stringify(ai.config) !== JSON.stringify(bi.config) ||
       ai.enabled !== bi.enabled ||
       ai.healthStatus !== bi.healthStatus ||
-      ai.healthReason !== bi.healthReason
+      ai.healthReason !== bi.healthReason ||
+      ai.retentionHours !== bi.retentionHours
     ) return false;
   }
   return true;

--- a/sensor_hub/ui/sensor_hub_ui/src/hooks/useSensors.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/hooks/useSensors.ts
@@ -36,6 +36,8 @@ function mapSensor(sj: SensorJson): Sensor {
     healthReason: normalizedHealthReason,
     enabled: sj.enabled,
     status: sj.status || 'active',
+    retentionHours: sj.retention_hours ?? null,
+    effectiveRetentionHours: sj.effective_retention_hours,
   };
 }
 

--- a/sensor_hub/ui/sensor_hub_ui/src/navigation/AppRoutes.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/navigation/AppRoutes.tsx
@@ -12,6 +12,7 @@ import DeveloperPage from "../pages/account/DeveloperPage.tsx";
 import RequireAuth from "./RequireAuth.tsx";
 import DashboardPage from "../dashboard/DashboardPage.tsx";
 import MqttPage from "../pages/mqtt/MqttPage.tsx";
+import DataRetentionPage from "../pages/data-retention/DataRetentionPage.tsx";
 
 
 function AppRoutes() {
@@ -40,6 +41,7 @@ function AppRoutes() {
           )
         })}
         <Route path="/properties-overview" element={<RequireAuth><PropertiesOverview /></RequireAuth>} />
+        <Route path="/data-retention" element={<RequireAuth><DataRetentionPage /></RequireAuth>} />
       </Routes>
     </BrowserRouter>
   )

--- a/sensor_hub/ui/sensor_hub_ui/src/navigation/NavigationSidebar.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/navigation/NavigationSidebar.tsx
@@ -12,6 +12,7 @@ import MenuBookIcon from '@mui/icons-material/MenuBook';
 import LogoutIcon from '@mui/icons-material/Logout';
 import LoginIcon from '@mui/icons-material/Login';
 import CellTowerIcon from '@mui/icons-material/CellTower';
+import StorageIcon from '@mui/icons-material/Storage';
 import {SidebarContext} from "../providers/SidebarContextType.tsx";
 import {useNavigate} from "react-router";
 import { useAuth } from '../providers/AuthContext.tsx';
@@ -93,6 +94,14 @@ function NavigationSidebar() {
             <ListItemButton onClick={() => handleNavigate('/sensors-overview')}>
               <ListItemIcon><SensorsIcon /></ListItemIcon>
               <ListItemText primary="Sensors" />
+            </ListItemButton>
+          </ListItem>
+        ))}
+        { (hasPerm(user, 'view_sensors') && (
+          <ListItem disablePadding>
+            <ListItemButton onClick={() => handleNavigate('/data-retention')}>
+              <ListItemIcon><StorageIcon /></ListItemIcon>
+              <ListItemText primary="Data Retention" />
             </ListItemButton>
           </ListItem>
         ))}

--- a/sensor_hub/ui/sensor_hub_ui/src/pages/data-retention/DataRetentionPage.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/pages/data-retention/DataRetentionPage.tsx
@@ -1,0 +1,25 @@
+import { Box, Grid } from '@mui/material';
+import PageContainer from '../../tools/PageContainer';
+import { useAuth } from '../../providers/AuthContext';
+import { hasPerm } from '../../tools/Utils';
+import { useIsMobile } from '../../hooks/useMobile';
+import DataRetentionCard from '../../components/DataRetentionCard';
+
+function DataRetentionPage() {
+  const { user } = useAuth();
+  const isMobile = useIsMobile();
+
+  return (
+    <PageContainer titleText="Data Retention" loading={user === undefined}>
+      <Box sx={{ flexGrow: 1 }}>
+        <Grid container spacing={2} alignItems="stretch" sx={{ minHeight: '100%' }}>
+          {hasPerm(user, 'view_sensors') && (
+            <Grid size={isMobile ? 12 : 12}><DataRetentionCard /></Grid>
+          )}
+        </Grid>
+      </Box>
+    </PageContainer>
+  );
+}
+
+export default DataRetentionPage;

--- a/sensor_hub/ui/sensor_hub_ui/src/pages/sensor/SensorPage.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/pages/sensor/SensorPage.tsx
@@ -7,7 +7,6 @@ import EditSensorDetails from '../../components/EditSensorDetails';
 import SensorHealthHistory from '../../components/SensorHealthHistory';
 import SensorHealthHistoryChartCard from '../../components/SensorHealthHistoryChartCard';
 import SensorTemperatureDataCard from '../../components/SensorTemperatureDataCard';
-import SensorRetentionCard from '../../components/SensorRetentionCard';
 import { useAuth } from '../../providers/AuthContext';
 import { hasPerm } from '../../tools/Utils';
 
@@ -61,9 +60,6 @@ function SensorPage({ sensorId }: SensorPageProps) {
           )}
           {hasPerm(user, 'view_sensors') && (
             <Grid size={isMobile ? 12 : 6}><SensorHealthHistory sensor={sensor} /></Grid>
-          )}
-          {hasPerm(user, 'manage_sensors') && (
-            <Grid size={isMobile ? 12 : 6}><SensorRetentionCard sensor={sensor} /></Grid>
           )}
         </Grid>
       </Box>

--- a/sensor_hub/ui/sensor_hub_ui/src/pages/sensor/SensorPage.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/pages/sensor/SensorPage.tsx
@@ -7,6 +7,7 @@ import EditSensorDetails from '../../components/EditSensorDetails';
 import SensorHealthHistory from '../../components/SensorHealthHistory';
 import SensorHealthHistoryChartCard from '../../components/SensorHealthHistoryChartCard';
 import SensorTemperatureDataCard from '../../components/SensorTemperatureDataCard';
+import SensorRetentionCard from '../../components/SensorRetentionCard';
 import { useAuth } from '../../providers/AuthContext';
 import { hasPerm } from '../../tools/Utils';
 
@@ -60,6 +61,9 @@ function SensorPage({ sensorId }: SensorPageProps) {
           )}
           {hasPerm(user, 'view_sensors') && (
             <Grid size={isMobile ? 12 : 6}><SensorHealthHistory sensor={sensor} /></Grid>
+          )}
+          {hasPerm(user, 'manage_sensors') && (
+            <Grid size={isMobile ? 12 : 6}><SensorRetentionCard sensor={sensor} /></Grid>
           )}
         </Grid>
       </Box>

--- a/sensor_hub/ui/sensor_hub_ui/src/tools/retention.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/tools/retention.ts
@@ -1,0 +1,27 @@
+export type RetentionUnit = 'hours' | 'days' | 'weeks';
+
+const unitMultipliers: Record<RetentionUnit, number> = {
+  hours: 1,
+  days: 24,
+  weeks: 168,
+};
+
+export function unitToHours(value: number, unit: RetentionUnit): number {
+  return Math.round(value * unitMultipliers[unit]);
+}
+
+export function hoursToUnit(hours: number, unit: RetentionUnit): number {
+  return Math.round((hours / unitMultipliers[unit]) * 100) / 100;
+}
+
+export function formatRetention(hours: number): string {
+  if (hours >= 168 && hours % 168 === 0) return `${hours / 168} week${hours / 168 !== 1 ? 's' : ''}`;
+  if (hours >= 24 && hours % 24 === 0) return `${hours / 24} day${hours / 24 !== 1 ? 's' : ''}`;
+  return `${hours} hour${hours !== 1 ? 's' : ''}`;
+}
+
+export function bestUnit(hours: number): RetentionUnit {
+  if (hours >= 168 && hours % 168 === 0) return 'weeks';
+  if (hours >= 24 && hours % 24 === 0) return 'days';
+  return 'hours';
+}

--- a/sensor_hub/ui/sensor_hub_ui/src/types/types.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/types/types.ts
@@ -20,15 +20,17 @@ export type TotalReadingsCountForEachSensorApiMessage = Record<string, number>;
 export type SensorHealthStatus = 'good' | 'bad' | 'unknown';
 
 export type Sensor = {
-    id:           number;
-    name:         string;
-    external_id?: string;
-    sensorDriver: string;
-    config:       Record<string, string>;
-    healthStatus: SensorHealthStatus;
-    healthReason: string | null;
-    enabled:      boolean;
-    status:       SensorStatus;
+    id:                       number;
+    name:                     string;
+    external_id?:             string;
+    sensorDriver:             string;
+    config:                   Record<string, string>;
+    healthStatus:             SensorHealthStatus;
+    healthReason:             string | null;
+    enabled:                  boolean;
+    status:                   SensorStatus;
+    retentionHours:           number | null;
+    effectiveRetentionHours?: number;
 }
 
 export type SensorHealthHistory = {
@@ -46,14 +48,16 @@ export type SensorHealthHistoryJson = {
 }
 
 export type SensorJson = {
-    id:             number;
-    name:           string;
-    sensor_driver:  string;
-    config:         Record<string, string>;
-    health_status:  SensorHealthStatus;
-    health_reason:  string | null;
-    enabled:        boolean;
-    status:         SensorStatus;
+    id:                         number;
+    name:                       string;
+    sensor_driver:              string;
+    config:                     Record<string, string>;
+    health_status:              SensorHealthStatus;
+    health_reason:              string | null;
+    enabled:                    boolean;
+    status:                     SensorStatus;
+    retention_hours?:           number | null;
+    effective_retention_hours?: number;
 }
 
 export type ConfigFieldSpec = {


### PR DESCRIPTION
## Summary

Implements per-sensor data retention policies, allowing individual sensors to override the global retention period with a custom retention in hours.

Closes #24

## Backend
- **Migration** `000015_sensor_retention`: adds nullable `retention_hours` column to sensors table
- **Atomic updates**: `UpdateSensorById` handles retention alongside other fields in a single transaction via `RetentionHoursPresent` flag
- **Cleanup service**: per-sensor retention applied first, then global retention excluding custom sensors
- **API**: merge-patch semantics on `PUT /sensors/:name` — `retention_hours` absent=no-op, `null`=clear, positive int=set
- **Detail endpoint**: `GET /sensors/:name` returns computed `effective_retention_hours`

## Frontend
- **Data Retention page** (`/data-retention`): DataGrid of all sensors with context-menu modal editing (consistent with alerts page pattern)
- **SensorForm**: retention fields (toggle + value + unit) integrated into Edit Sensor Details card with live effective preview
- **SensorInfoCard**: responsive CSS grid layout showing driver, health, retention, measurement types, config — utilises available width dynamically
- **Navigation**: new sidebar entry with StorageIcon

## Tests
- 3 new integration tests: set retention, clear retention, reject invalid values
- Cleanup service unit tests updated + 3 new per-sensor cleanup tests
- All 47 integration tests pass, all unit tests pass, frontend builds clean

## Documentation
- `managing-sensors.md`: per-sensor retention section
- `configuration.md`: updated default values (90d retention, 30d health, 1h cleanup)
- OpenAPI specs updated (main, docker, docker_tests)
- LLM skill files updated (copilot.md, claude.md)
