### PR TITLE
fix: audit and fix OpenAPI spec-to-implementation drift

### DIFF
--- a/sensor_hub/api/openapi.yaml
+++ b/sensor_hub/api/openapi.yaml
@@ -36,6 +36,24 @@ paths:
                   status:
                     type: string
                     example: ok
+  /openapi.yaml:
+    get:
+      tags:
+        - health
+      summary: Get OpenAPI specification
+      description: >-
+        Returns the OpenAPI specification in YAML format with the server
+        URL dynamically patched to match the request's host and scheme.
+        No authentication required.
+      operationId: getOpenApiSpec
+      security: []
+      responses:
+        '200':
+          description: OpenAPI specification in YAML format
+          content:
+            text/yaml:
+              schema:
+                type: string
   /readings/between:
     get:
       tags:
@@ -248,20 +266,51 @@ paths:
               unit: "°C"
               time: "2026-01-10T12:01:00Z"
 
-  /sensors/ws/{type}:
+  /sensors/ws:
     get:
       tags:
         - sensors
-      summary: WebSocket endpoint — subscribe to sensor metadata by type
+      summary: WebSocket endpoint — subscribe to all sensor metadata
       description: >-
         Upgrades the HTTP connection to a WebSocket and sends a snapshot of
-        sensors matching the given type. This is used by the backend to push
+        all sensors. Subsequent messages may be full sensor arrays or
+        incremental sensor objects for real-time updates.
+      operationId: subscribeAllSensors
+      responses:
+        '101':
+          description: Switching Protocols — connection upgraded to WebSocket
+        '200':
+          description: Non-upgrade response (error)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      x-websocket:
+        description: |
+          WebSocket sends JSON messages. First message is a snapshot: an array
+          of all Sensor objects. Subsequent messages may be snapshot arrays or
+          single Sensor objects for incremental updates.
+        messages:
+          snapshot:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Sensor'
+
+  /sensors/ws/{driver}:
+    get:
+      tags:
+        - sensors
+      summary: WebSocket endpoint — subscribe to sensor metadata by driver
+      description: >-
+        Upgrades the HTTP connection to a WebSocket and sends a snapshot of
+        sensors matching the given driver. This is used by the backend to push
         sensor lists and potentially sensor updates. The initial message is an
         array of `Sensor` objects. Subsequent messages depend on backend events
         and may be full sensor arrays or incremental sensor objects.
-      operationId: subscribeSensorsByType
+      operationId: subscribeSensorsByDriver
       parameters:
-        - name: type
+        - name: driver
           in: path
           required: true
           schema:
@@ -944,6 +993,17 @@ paths:
         drivers. Use this to discover which drivers are available and what
         configuration each driver requires when creating or updating a sensor.
       operationId: listDrivers
+      security: []
+      parameters:
+        - name: type
+          in: query
+          required: false
+          schema:
+            type: string
+            enum:
+              - pull
+              - push
+          description: Filter drivers by type. Omit to return all drivers.
       responses:
         '200':
           description: Array of driver metadata

--- a/sensor_hub/api/openapi.yaml
+++ b/sensor_hub/api/openapi.yaml
@@ -588,7 +588,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/SensorHealthRecord'
+                  $ref: '#/components/schemas/SensorHealthHistory'
         '400':
           description: Invalid request
           content:
@@ -3091,9 +3091,14 @@ components:
           format: date-time
           readOnly: true
       required:
+        - id
         - name
+        - type
         - host
         - port
+        - enabled
+        - created_at
+        - updated_at
 
     MQTTSubscription:
       type: object
@@ -3127,9 +3132,13 @@ components:
           format: date-time
           readOnly: true
       required:
+        - id
         - broker_id
         - topic_pattern
         - driver_type
+        - enabled
+        - created_at
+        - updated_at
 
     MQTTBrokerStats:
       type: object
@@ -3224,6 +3233,8 @@ components:
         - display_name
         - unit
         - category
+        - default_aggregation_function
+        - supported_aggregation_functions
 
     ApiKey:
       type: object
@@ -3333,7 +3344,7 @@ components:
           description: Type of measurement (e.g. "temperature", "humidity").
         numeric_value:
           type: number
-          format: float
+          format: double
           nullable: true
           description: Numeric measurement value (null for non-numeric readings).
         text_state:
@@ -3345,7 +3356,6 @@ components:
           description: Unit of measurement (e.g. "°C", "%").
         time:
           type: string
-          format: date-time
           description: RFC3339 timestamp for when the reading was recorded. Use this for x-axis time in graphs.
       required:
         - sensor_name
@@ -3460,6 +3470,11 @@ components:
         - id
         - name
         - sensor_driver
+        - config
+        - health_status
+        - health_reason
+        - enabled
+        - status
       example:
         id: 1
         name: "living-room"
@@ -3553,7 +3568,7 @@ components:
       required:
         - message
 
-    SensorHealthRecord:
+    SensorHealthHistory:
       type: object
       description: Historical health check record for a sensor.
       properties:
@@ -3754,6 +3769,13 @@ components:
       required:
         - id
         - username
+        - email
+        - disabled
+        - must_change_password
+        - roles
+        - permissions
+        - created_at
+        - updated_at
 
     CreateUserRequest:
       type: object
@@ -3833,12 +3855,10 @@ components:
           description: Type of alert (threshold-based or status-based)
         HighThreshold:
           type: number
-          format: float
-          nullable: true
+          format: double
         LowThreshold:
           type: number
-          format: float
-          nullable: true
+          format: double
         TriggerStatus:
           type: string
           description: Status that triggers alert (for status_based type)
@@ -3858,10 +3878,17 @@ components:
           type: string
           description: Human-readable measurement type name (e.g. "temperature", "battery_low")
       required:
+        - ID
         - SensorID
-        - AlertType
+        - SensorName
         - MeasurementTypeID
+        - MeasurementType
+        - AlertType
+        - HighThreshold
+        - LowThreshold
+        - TriggerStatus
         - Enabled
+        - RateLimitSeconds
 
     AlertHistoryEntry:
       type: object
@@ -3871,9 +3898,6 @@ components:
           type: integer
         sensor_id:
           type: integer
-        measurement_type_id:
-          type: integer
-          description: Foreign key to measurement_types table.
         alert_type:
           type: string
         reading_value:
@@ -3885,6 +3909,7 @@ components:
         - id
         - sensor_id
         - alert_type
+        - reading_value
         - sent_at
 
     # =========================================================================
@@ -4031,6 +4056,10 @@ components:
         - user_id
         - name
         - config
+        - shared
+        - is_default
+        - created_at
+        - updated_at
 
     CreateDashboardRequest:
       type: object
@@ -4064,6 +4093,9 @@ components:
     DashboardConfig:
       type: object
       description: Widget layout and configuration stored as the dashboard config
+      required:
+        - widgets
+        - breakpoints
       properties:
         widgets:
           type: array
@@ -4071,6 +4103,10 @@ components:
             $ref: '#/components/schemas/DashboardWidget'
         breakpoints:
           type: object
+          required:
+            - lg
+            - md
+            - sm
           properties:
             lg: { type: integer }
             md: { type: integer }
@@ -4079,6 +4115,11 @@ components:
     DashboardWidget:
       type: object
       description: A single widget on the dashboard
+      required:
+        - id
+        - type
+        - config
+        - layout
       properties:
         id:
           type: string
@@ -4089,6 +4130,11 @@ components:
           additionalProperties: true
         layout:
           type: object
+          required:
+            - x
+            - y
+            - w
+            - h
           properties:
             x: { type: integer }
             y: { type: integer }

--- a/sensor_hub/gen/client.gen.go
+++ b/sensor_hub/gen/client.gen.go
@@ -13,6 +13,8 @@ import (
 	"net/url"
 	"strings"
 
+	"gopkg.in/yaml.v2"
+
 	"github.com/oapi-codegen/runtime"
 )
 
@@ -178,7 +180,7 @@ type ClientInterface interface {
 	ShareDashboard(ctx context.Context, id int, body ShareDashboardJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListDrivers request
-	ListDrivers(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+	ListDrivers(ctx context.Context, params *ListDriversParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetHealth request
 	GetHealth(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -270,6 +272,9 @@ type ClientInterface interface {
 
 	SubmitOAuthCode(ctx context.Context, body SubmitOAuthCodeJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// GetOpenApiSpec request
+	GetOpenApiSpec(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// GetProperties request
 	GetProperties(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -345,8 +350,11 @@ type ClientInterface interface {
 	// GetSensorsByStatus request
 	GetSensorsByStatus(ctx context.Context, status GetSensorsByStatusParamsStatus, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// SubscribeSensorsByType request
-	SubscribeSensorsByType(ctx context.Context, pType string, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// SubscribeAllSensors request
+	SubscribeAllSensors(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// SubscribeSensorsByDriver request
+	SubscribeSensorsByDriver(ctx context.Context, driver string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// UpdateSensorByIdWithBody request with any body
 	UpdateSensorByIdWithBody(ctx context.Context, id int, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -773,8 +781,8 @@ func (c *Client) ShareDashboard(ctx context.Context, id int, body ShareDashboard
 	return c.Client.Do(req)
 }
 
-func (c *Client) ListDrivers(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewListDriversRequest(c.Server)
+func (c *Client) ListDrivers(ctx context.Context, params *ListDriversParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListDriversRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -1169,6 +1177,18 @@ func (c *Client) SubmitOAuthCode(ctx context.Context, body SubmitOAuthCodeJSONRe
 	return c.Client.Do(req)
 }
 
+func (c *Client) GetOpenApiSpec(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetOpenApiSpecRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) GetProperties(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetPropertiesRequest(c.Server)
 	if err != nil {
@@ -1481,8 +1501,20 @@ func (c *Client) GetSensorsByStatus(ctx context.Context, status GetSensorsByStat
 	return c.Client.Do(req)
 }
 
-func (c *Client) SubscribeSensorsByType(ctx context.Context, pType string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewSubscribeSensorsByTypeRequest(c.Server, pType)
+func (c *Client) SubscribeAllSensors(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSubscribeAllSensorsRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) SubscribeSensorsByDriver(ctx context.Context, driver string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSubscribeSensorsByDriverRequest(c.Server, driver)
 	if err != nil {
 		return nil, err
 	}
@@ -2546,7 +2578,7 @@ func NewShareDashboardRequestWithBody(server string, id int, contentType string,
 }
 
 // NewListDriversRequest generates requests for ListDrivers
-func NewListDriversRequest(server string) (*http.Request, error) {
+func NewListDriversRequest(server string, params *ListDriversParams) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -2562,6 +2594,28 @@ func NewListDriversRequest(server string) (*http.Request, error) {
 	queryURL, err := serverURL.Parse(operationPath)
 	if err != nil {
 		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Type != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "type", *params.Type, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
 	}
 
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
@@ -3506,6 +3560,33 @@ func NewSubmitOAuthCodeRequestWithBody(server string, contentType string, body i
 	return req, nil
 }
 
+// NewGetOpenApiSpecRequest generates requests for GetOpenApiSpec
+func NewGetOpenApiSpecRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/openapi.yaml")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewGetPropertiesRequest generates requests for GetProperties
 func NewGetPropertiesRequest(server string) (*http.Request, error) {
 	var err error
@@ -4373,13 +4454,40 @@ func NewGetSensorsByStatusRequest(server string, status GetSensorsByStatusParams
 	return req, nil
 }
 
-// NewSubscribeSensorsByTypeRequest generates requests for SubscribeSensorsByType
-func NewSubscribeSensorsByTypeRequest(server string, pType string) (*http.Request, error) {
+// NewSubscribeAllSensorsRequest generates requests for SubscribeAllSensors
+func NewSubscribeAllSensorsRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/sensors/ws")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewSubscribeSensorsByDriverRequest generates requests for SubscribeSensorsByDriver
+func NewSubscribeSensorsByDriverRequest(server string, driver string) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
 
-	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "type", pType, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "driver", driver, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
 	if err != nil {
 		return nil, err
 	}
@@ -4923,7 +5031,7 @@ type ClientWithResponsesInterface interface {
 	ShareDashboardWithResponse(ctx context.Context, id int, body ShareDashboardJSONRequestBody, reqEditors ...RequestEditorFn) (*ShareDashboardResp, error)
 
 	// ListDriversWithResponse request
-	ListDriversWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListDriversResp, error)
+	ListDriversWithResponse(ctx context.Context, params *ListDriversParams, reqEditors ...RequestEditorFn) (*ListDriversResp, error)
 
 	// GetHealthWithResponse request
 	GetHealthWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetHealthResp, error)
@@ -5015,6 +5123,9 @@ type ClientWithResponsesInterface interface {
 
 	SubmitOAuthCodeWithResponse(ctx context.Context, body SubmitOAuthCodeJSONRequestBody, reqEditors ...RequestEditorFn) (*SubmitOAuthCodeResp, error)
 
+	// GetOpenApiSpecWithResponse request
+	GetOpenApiSpecWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetOpenApiSpecResp, error)
+
 	// GetPropertiesWithResponse request
 	GetPropertiesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetPropertiesResp, error)
 
@@ -5090,8 +5201,11 @@ type ClientWithResponsesInterface interface {
 	// GetSensorsByStatusWithResponse request
 	GetSensorsByStatusWithResponse(ctx context.Context, status GetSensorsByStatusParamsStatus, reqEditors ...RequestEditorFn) (*GetSensorsByStatusResp, error)
 
-	// SubscribeSensorsByTypeWithResponse request
-	SubscribeSensorsByTypeWithResponse(ctx context.Context, pType string, reqEditors ...RequestEditorFn) (*SubscribeSensorsByTypeResp, error)
+	// SubscribeAllSensorsWithResponse request
+	SubscribeAllSensorsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*SubscribeAllSensorsResp, error)
+
+	// SubscribeSensorsByDriverWithResponse request
+	SubscribeSensorsByDriverWithResponse(ctx context.Context, driver string, reqEditors ...RequestEditorFn) (*SubscribeSensorsByDriverResp, error)
 
 	// UpdateSensorByIdWithBodyWithResponse request with any body
 	UpdateSensorByIdWithBodyWithResponse(ctx context.Context, id int, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateSensorByIdResp, error)
@@ -6312,6 +6426,28 @@ func (r SubmitOAuthCodeResp) StatusCode() int {
 	return 0
 }
 
+type GetOpenApiSpecResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	YAML200      *string
+}
+
+// Status returns HTTPResponse.Status
+func (r GetOpenApiSpecResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetOpenApiSpecResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type GetPropertiesResp struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -6776,7 +6912,7 @@ func (r EnableSensorResp) StatusCode() int {
 type GetSensorHealthHistoryByNameResp struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *[]SensorHealthRecord
+	JSON200      *[]SensorHealthHistory
 	JSON400      *ErrorResponse
 	JSON404      *ErrorResponse
 }
@@ -6841,14 +6977,14 @@ func (r GetSensorsByStatusResp) StatusCode() int {
 	return 0
 }
 
-type SubscribeSensorsByTypeResp struct {
+type SubscribeAllSensorsResp struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *ErrorResponse
 }
 
 // Status returns HTTPResponse.Status
-func (r SubscribeSensorsByTypeResp) Status() string {
+func (r SubscribeAllSensorsResp) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -6856,7 +6992,29 @@ func (r SubscribeSensorsByTypeResp) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r SubscribeSensorsByTypeResp) StatusCode() int {
+func (r SubscribeAllSensorsResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type SubscribeSensorsByDriverResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ErrorResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r SubscribeSensorsByDriverResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r SubscribeSensorsByDriverResp) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -7381,8 +7539,8 @@ func (c *ClientWithResponses) ShareDashboardWithResponse(ctx context.Context, id
 }
 
 // ListDriversWithResponse request returning *ListDriversResp
-func (c *ClientWithResponses) ListDriversWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListDriversResp, error) {
-	rsp, err := c.ListDrivers(ctx, reqEditors...)
+func (c *ClientWithResponses) ListDriversWithResponse(ctx context.Context, params *ListDriversParams, reqEditors ...RequestEditorFn) (*ListDriversResp, error) {
+	rsp, err := c.ListDrivers(ctx, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7671,6 +7829,15 @@ func (c *ClientWithResponses) SubmitOAuthCodeWithResponse(ctx context.Context, b
 	return ParseSubmitOAuthCodeResp(rsp)
 }
 
+// GetOpenApiSpecWithResponse request returning *GetOpenApiSpecResp
+func (c *ClientWithResponses) GetOpenApiSpecWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetOpenApiSpecResp, error) {
+	rsp, err := c.GetOpenApiSpec(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetOpenApiSpecResp(rsp)
+}
+
 // GetPropertiesWithResponse request returning *GetPropertiesResp
 func (c *ClientWithResponses) GetPropertiesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetPropertiesResp, error) {
 	rsp, err := c.GetProperties(ctx, reqEditors...)
@@ -7902,13 +8069,22 @@ func (c *ClientWithResponses) GetSensorsByStatusWithResponse(ctx context.Context
 	return ParseGetSensorsByStatusResp(rsp)
 }
 
-// SubscribeSensorsByTypeWithResponse request returning *SubscribeSensorsByTypeResp
-func (c *ClientWithResponses) SubscribeSensorsByTypeWithResponse(ctx context.Context, pType string, reqEditors ...RequestEditorFn) (*SubscribeSensorsByTypeResp, error) {
-	rsp, err := c.SubscribeSensorsByType(ctx, pType, reqEditors...)
+// SubscribeAllSensorsWithResponse request returning *SubscribeAllSensorsResp
+func (c *ClientWithResponses) SubscribeAllSensorsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*SubscribeAllSensorsResp, error) {
+	rsp, err := c.SubscribeAllSensors(ctx, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseSubscribeSensorsByTypeResp(rsp)
+	return ParseSubscribeAllSensorsResp(rsp)
+}
+
+// SubscribeSensorsByDriverWithResponse request returning *SubscribeSensorsByDriverResp
+func (c *ClientWithResponses) SubscribeSensorsByDriverWithResponse(ctx context.Context, driver string, reqEditors ...RequestEditorFn) (*SubscribeSensorsByDriverResp, error) {
+	rsp, err := c.SubscribeSensorsByDriver(ctx, driver, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSubscribeSensorsByDriverResp(rsp)
 }
 
 // UpdateSensorByIdWithBodyWithResponse request with arbitrary body returning *UpdateSensorByIdResp
@@ -9663,6 +9839,32 @@ func ParseSubmitOAuthCodeResp(rsp *http.Response) (*SubmitOAuthCodeResp, error) 
 	return response, nil
 }
 
+// ParseGetOpenApiSpecResp parses an HTTP response from a GetOpenApiSpecWithResponse call
+func ParseGetOpenApiSpecResp(rsp *http.Response) (*GetOpenApiSpecResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetOpenApiSpecResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "yaml") && rsp.StatusCode == 200:
+		var dest string
+		if err := yaml.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.YAML200 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseGetPropertiesResp parses an HTTP response from a GetPropertiesWithResponse call
 func ParseGetPropertiesResp(rsp *http.Response) (*GetPropertiesResp, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -10345,7 +10547,7 @@ func ParseGetSensorHealthHistoryByNameResp(rsp *http.Response) (*GetSensorHealth
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest []SensorHealthRecord
+		var dest []SensorHealthHistory
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -10422,15 +10624,41 @@ func ParseGetSensorsByStatusResp(rsp *http.Response) (*GetSensorsByStatusResp, e
 	return response, nil
 }
 
-// ParseSubscribeSensorsByTypeResp parses an HTTP response from a SubscribeSensorsByTypeWithResponse call
-func ParseSubscribeSensorsByTypeResp(rsp *http.Response) (*SubscribeSensorsByTypeResp, error) {
+// ParseSubscribeAllSensorsResp parses an HTTP response from a SubscribeAllSensorsWithResponse call
+func ParseSubscribeAllSensorsResp(rsp *http.Response) (*SubscribeAllSensorsResp, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &SubscribeSensorsByTypeResp{
+	response := &SubscribeAllSensorsResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseSubscribeSensorsByDriverResp parses an HTTP response from a SubscribeSensorsByDriverWithResponse call
+func ParseSubscribeSensorsByDriverResp(rsp *http.Response) (*SubscribeSensorsByDriverResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &SubscribeSensorsByDriverResp{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}

--- a/sensor_hub/gen/server.gen.go
+++ b/sensor_hub/gen/server.gen.go
@@ -87,7 +87,7 @@ type ServerInterface interface {
 	ShareDashboard(c *gin.Context, id int)
 	// List available sensor drivers
 	// (GET /drivers)
-	ListDrivers(c *gin.Context)
+	ListDrivers(c *gin.Context, params ListDriversParams)
 	// Health check
 	// (GET /health)
 	GetHealth(c *gin.Context)
@@ -166,6 +166,9 @@ type ServerInterface interface {
 	// Submit OAuth authorization code
 	// (POST /oauth/submit-code)
 	SubmitOAuthCode(c *gin.Context)
+	// Get OpenAPI specification
+	// (GET /openapi.yaml)
+	GetOpenApiSpec(c *gin.Context)
 	// Get current application properties
 	// (GET /properties)
 	GetProperties(c *gin.Context)
@@ -235,9 +238,12 @@ type ServerInterface interface {
 	// Get sensors by lifecycle status
 	// (GET /sensors/status/{status})
 	GetSensorsByStatus(c *gin.Context, status GetSensorsByStatusParamsStatus)
-	// WebSocket endpoint — subscribe to sensor metadata by type
-	// (GET /sensors/ws/{type})
-	SubscribeSensorsByType(c *gin.Context, pType string)
+	// WebSocket endpoint — subscribe to all sensor metadata
+	// (GET /sensors/ws)
+	SubscribeAllSensors(c *gin.Context)
+	// WebSocket endpoint — subscribe to sensor metadata by driver
+	// (GET /sensors/ws/{driver})
+	SubscribeSensorsByDriver(c *gin.Context, driver string)
 	// Update an existing sensor by id
 	// (PUT /sensors/{id})
 	UpdateSensorById(c *gin.Context, id int)
@@ -897,11 +903,18 @@ func (siw *ServerInterfaceWrapper) ShareDashboard(c *gin.Context) {
 // ListDrivers operation middleware
 func (siw *ServerInterfaceWrapper) ListDrivers(c *gin.Context) {
 
-	c.Set(CookieAuthScopes, []string{})
+	var err error
 
-	c.Set(CsrfTokenScopes, []string{})
+	// Parameter object where we will unmarshal all parameters from the context
+	var params ListDriversParams
 
-	c.Set(ApiKeyAuthScopes, []string{})
+	// ------------- Optional query parameter "type" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "type", c.Request.URL.Query(), &params.Type, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter type: %w", err), http.StatusBadRequest)
+		return
+	}
 
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
@@ -910,7 +923,7 @@ func (siw *ServerInterfaceWrapper) ListDrivers(c *gin.Context) {
 		}
 	}
 
-	siw.Handler.ListDrivers(c)
+	siw.Handler.ListDrivers(c, params)
 }
 
 // GetHealth operation middleware
@@ -1542,6 +1555,19 @@ func (siw *ServerInterfaceWrapper) SubmitOAuthCode(c *gin.Context) {
 	}
 
 	siw.Handler.SubmitOAuthCode(c)
+}
+
+// GetOpenApiSpec operation middleware
+func (siw *ServerInterfaceWrapper) GetOpenApiSpec(c *gin.Context) {
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		middleware(c)
+		if c.IsAborted() {
+			return
+		}
+	}
+
+	siw.Handler.GetOpenApiSpec(c)
 }
 
 // GetProperties operation middleware
@@ -2200,17 +2226,36 @@ func (siw *ServerInterfaceWrapper) GetSensorsByStatus(c *gin.Context) {
 	siw.Handler.GetSensorsByStatus(c, status)
 }
 
-// SubscribeSensorsByType operation middleware
-func (siw *ServerInterfaceWrapper) SubscribeSensorsByType(c *gin.Context) {
+// SubscribeAllSensors operation middleware
+func (siw *ServerInterfaceWrapper) SubscribeAllSensors(c *gin.Context) {
+
+	c.Set(CookieAuthScopes, []string{})
+
+	c.Set(CsrfTokenScopes, []string{})
+
+	c.Set(ApiKeyAuthScopes, []string{})
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		middleware(c)
+		if c.IsAborted() {
+			return
+		}
+	}
+
+	siw.Handler.SubscribeAllSensors(c)
+}
+
+// SubscribeSensorsByDriver operation middleware
+func (siw *ServerInterfaceWrapper) SubscribeSensorsByDriver(c *gin.Context) {
 
 	var err error
 
-	// ------------- Path parameter "type" -------------
-	var pType string
+	// ------------- Path parameter "driver" -------------
+	var driver string
 
-	err = runtime.BindStyledParameterWithOptions("simple", "type", c.Param("type"), &pType, runtime.BindStyledParameterOptions{Explode: false, Required: true, Type: "string", Format: ""})
+	err = runtime.BindStyledParameterWithOptions("simple", "driver", c.Param("driver"), &driver, runtime.BindStyledParameterOptions{Explode: false, Required: true, Type: "string", Format: ""})
 	if err != nil {
-		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter type: %w", err), http.StatusBadRequest)
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter driver: %w", err), http.StatusBadRequest)
 		return
 	}
 
@@ -2227,7 +2272,7 @@ func (siw *ServerInterfaceWrapper) SubscribeSensorsByType(c *gin.Context) {
 		}
 	}
 
-	siw.Handler.SubscribeSensorsByType(c, pType)
+	siw.Handler.SubscribeSensorsByDriver(c, driver)
 }
 
 // UpdateSensorById operation middleware
@@ -2575,6 +2620,7 @@ func RegisterHandlersWithOptions(router gin.IRouter, si ServerInterface, options
 	router.POST(options.BaseURL+"/oauth/reload", wrapper.ReloadOAuth)
 	router.GET(options.BaseURL+"/oauth/status", wrapper.GetOAuthStatus)
 	router.POST(options.BaseURL+"/oauth/submit-code", wrapper.SubmitOAuthCode)
+	router.GET(options.BaseURL+"/openapi.yaml", wrapper.GetOpenApiSpec)
 	router.GET(options.BaseURL+"/properties", wrapper.GetProperties)
 	router.PATCH(options.BaseURL+"/properties", wrapper.UpdateProperties)
 	router.GET(options.BaseURL+"/properties/ws", wrapper.PropertiesWebSocket)
@@ -2598,7 +2644,8 @@ func RegisterHandlersWithOptions(router gin.IRouter, si ServerInterface, options
 	router.GET(options.BaseURL+"/sensors/health/:name", wrapper.GetSensorHealthHistoryByName)
 	router.GET(options.BaseURL+"/sensors/stats/total-readings", wrapper.GetTotalReadingsPerSensor)
 	router.GET(options.BaseURL+"/sensors/status/:status", wrapper.GetSensorsByStatus)
-	router.GET(options.BaseURL+"/sensors/ws/:type", wrapper.SubscribeSensorsByType)
+	router.GET(options.BaseURL+"/sensors/ws", wrapper.SubscribeAllSensors)
+	router.GET(options.BaseURL+"/sensors/ws/:driver", wrapper.SubscribeSensorsByDriver)
 	router.PUT(options.BaseURL+"/sensors/:id", wrapper.UpdateSensorById)
 	router.DELETE(options.BaseURL+"/sensors/:name", wrapper.DeleteSensorByName)
 	router.GET(options.BaseURL+"/sensors/:name", wrapper.GetSensorByName)

--- a/sensor_hub/gen/types.gen.go
+++ b/sensor_hub/gen/types.gen.go
@@ -211,6 +211,24 @@ func (e SensorHealthStatus) Valid() bool {
 	}
 }
 
+// Defines values for ListDriversParamsType.
+const (
+	Pull ListDriversParamsType = "pull"
+	Push ListDriversParamsType = "push"
+)
+
+// Valid indicates whether the value is a known member of the ListDriversParamsType enum.
+func (e ListDriversParamsType) Valid() bool {
+	switch e {
+	case Pull:
+		return true
+	case Push:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for ListNotificationsParamsIncludeDismissed.
 const (
 	False ListNotificationsParamsIncludeDismissed = "false"
@@ -324,14 +342,11 @@ type AggregatedReadingsResponseAggregationInterval string
 
 // AlertHistoryEntry Historical alert event
 type AlertHistoryEntry struct {
-	AlertType string `json:"alert_type"`
-	Id        int    `json:"id"`
-
-	// MeasurementTypeId Foreign key to measurement_types table.
-	MeasurementTypeId *int      `json:"measurement_type_id,omitempty"`
-	ReadingValue      *string   `json:"reading_value,omitempty"`
-	SensorId          int       `json:"sensor_id"`
-	SentAt            time.Time `json:"sent_at"`
+	AlertType    string    `json:"alert_type"`
+	Id           int       `json:"id"`
+	ReadingValue string    `json:"reading_value"`
+	SensorId     int       `json:"sensor_id"`
+	SentAt       time.Time `json:"sent_at"`
 }
 
 // AlertRule Alert rule configuration
@@ -339,24 +354,24 @@ type AlertRule struct {
 	// AlertType Type of alert (threshold-based or status-based)
 	AlertType       AlertRuleAlertType `json:"AlertType"`
 	Enabled         bool               `json:"Enabled"`
-	HighThreshold   *float32           `json:"HighThreshold,omitempty"`
-	ID              *int               `json:"ID,omitempty"`
+	HighThreshold   float64            `json:"HighThreshold"`
+	ID              int                `json:"ID"`
 	LastAlertSentAt *time.Time         `json:"LastAlertSentAt,omitempty"`
-	LowThreshold    *float32           `json:"LowThreshold,omitempty"`
+	LowThreshold    float64            `json:"LowThreshold"`
 
 	// MeasurementType Human-readable measurement type name (e.g. "temperature", "battery_low")
-	MeasurementType *string `json:"MeasurementType,omitempty"`
+	MeasurementType string `json:"MeasurementType"`
 
 	// MeasurementTypeID ID of the measurement type this rule applies to
 	MeasurementTypeID int `json:"MeasurementTypeID"`
 
 	// RateLimitSeconds Minimum seconds between alerts
-	RateLimitSeconds *int    `json:"RateLimitSeconds,omitempty"`
-	SensorID         int     `json:"SensorID"`
-	SensorName       *string `json:"SensorName,omitempty"`
+	RateLimitSeconds int    `json:"RateLimitSeconds"`
+	SensorID         int    `json:"SensorID"`
+	SensorName       string `json:"SensorName"`
 
 	// TriggerStatus Status that triggers alert (for status_based type)
-	TriggerStatus *string `json:"TriggerStatus,omitempty"`
+	TriggerStatus string `json:"TriggerStatus"`
 }
 
 // AlertRuleAlertType Type of alert (threshold-based or status-based)
@@ -441,37 +456,37 @@ type CreateUserRequest struct {
 // Dashboard A user's saved dashboard configuration
 type Dashboard struct {
 	// Config JSON-encoded widget layout and configuration
-	Config    string     `json:"config"`
-	CreatedAt *time.Time `json:"created_at,omitempty"`
-	Id        int        `json:"id"`
-	IsDefault *bool      `json:"is_default,omitempty"`
-	Name      string     `json:"name"`
-	Shared    *bool      `json:"shared,omitempty"`
-	UpdatedAt *time.Time `json:"updated_at,omitempty"`
-	UserId    int        `json:"user_id"`
+	Config    string    `json:"config"`
+	CreatedAt time.Time `json:"created_at"`
+	Id        int       `json:"id"`
+	IsDefault bool      `json:"is_default"`
+	Name      string    `json:"name"`
+	Shared    bool      `json:"shared"`
+	UpdatedAt time.Time `json:"updated_at"`
+	UserId    int       `json:"user_id"`
 }
 
 // DashboardConfig Widget layout and configuration stored as the dashboard config
 type DashboardConfig struct {
-	Breakpoints *struct {
-		Lg *int `json:"lg,omitempty"`
-		Md *int `json:"md,omitempty"`
-		Sm *int `json:"sm,omitempty"`
-	} `json:"breakpoints,omitempty"`
-	Widgets *[]DashboardWidget `json:"widgets,omitempty"`
+	Breakpoints struct {
+		Lg int `json:"lg"`
+		Md int `json:"md"`
+		Sm int `json:"sm"`
+	} `json:"breakpoints"`
+	Widgets []DashboardWidget `json:"widgets"`
 }
 
 // DashboardWidget A single widget on the dashboard
 type DashboardWidget struct {
-	Config *map[string]interface{} `json:"config,omitempty"`
-	Id     *string                 `json:"id,omitempty"`
-	Layout *struct {
-		H *int `json:"h,omitempty"`
-		W *int `json:"w,omitempty"`
-		X *int `json:"x,omitempty"`
-		Y *int `json:"y,omitempty"`
-	} `json:"layout,omitempty"`
-	Type *string `json:"type,omitempty"`
+	Config map[string]interface{} `json:"config"`
+	Id     string                 `json:"id"`
+	Layout struct {
+		H int `json:"h"`
+		W int `json:"w"`
+		X int `json:"x"`
+		Y int `json:"y"`
+	} `json:"layout"`
+	Type string `json:"type"`
 }
 
 // DriverInfo Metadata and config schema for a sensor driver.
@@ -532,7 +547,7 @@ type MQTTBroker struct {
 	CreatedAt     *time.Time `json:"created_at,omitempty"`
 
 	// Enabled Whether the broker connection is active.
-	Enabled *bool `json:"enabled,omitempty"`
+	Enabled bool `json:"enabled"`
 
 	// Host Broker hostname or IP address.
 	Host string `json:"host"`
@@ -548,7 +563,7 @@ type MQTTBroker struct {
 	Port int `json:"port"`
 
 	// Type Broker type (e.g. "mosquitto", "emqx").
-	Type      *string    `json:"type,omitempty"`
+	Type      string     `json:"type"`
 	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 
 	// Username Optional authentication username.
@@ -592,8 +607,8 @@ type MQTTSubscription struct {
 	DriverType string `json:"driver_type"`
 
 	// Enabled Whether this subscription is active.
-	Enabled *bool `json:"enabled,omitempty"`
-	Id      *int  `json:"id,omitempty"`
+	Enabled bool `json:"enabled"`
+	Id      *int `json:"id,omitempty"`
 
 	// TopicPattern MQTT topic pattern to subscribe to. Supports MQTT wildcards (+ for single level, # for multi level).
 	TopicPattern string     `json:"topic_pattern"`
@@ -615,7 +630,7 @@ type MeasurementType struct {
 	Category MeasurementTypeCategory `json:"category"`
 
 	// DefaultAggregationFunction Default aggregation function for this measurement type
-	DefaultAggregationFunction *string `json:"default_aggregation_function,omitempty"`
+	DefaultAggregationFunction string `json:"default_aggregation_function"`
 
 	// DisplayName Human-readable label.
 	DisplayName string `json:"display_name"`
@@ -625,7 +640,7 @@ type MeasurementType struct {
 	Name string `json:"name"`
 
 	// SupportedAggregationFunctions List of aggregation functions supported by this measurement type. The `aggregation_function` query parameter on GET /readings/between must be one of these values (or omitted to use the default).
-	SupportedAggregationFunctions *[]string `json:"supported_aggregation_functions,omitempty"`
+	SupportedAggregationFunctions []string `json:"supported_aggregation_functions"`
 
 	// Unit Unit of measurement.
 	Unit string `json:"unit"`
@@ -715,7 +730,7 @@ type Reading struct {
 	MeasurementType string `json:"measurement_type"`
 
 	// NumericValue Numeric measurement value (null for non-numeric readings).
-	NumericValue *float32 `json:"numeric_value,omitempty"`
+	NumericValue *float64 `json:"numeric_value,omitempty"`
 
 	// SensorName Human-readable sensor name. This is the series key an MCP should use to group measurements.
 	SensorName string `json:"sensor_name"`
@@ -724,7 +739,7 @@ type Reading struct {
 	TextState *string `json:"text_state,omitempty"`
 
 	// Time RFC3339 timestamp for when the reading was recorded. Use this for x-axis time in graphs.
-	Time time.Time `json:"time"`
+	Time string `json:"time"`
 
 	// Unit Unit of measurement (e.g. "°C", "%").
 	Unit *string `json:"unit,omitempty"`
@@ -739,22 +754,22 @@ type RoleInfo struct {
 // Sensor Metadata for a sensor as returned by sensors endpoints and WebSocket snapshots.
 type Sensor struct {
 	// Config Driver-specific configuration key-value pairs. Each driver declares which keys it expects via the GET /drivers endpoint. Sensitive values are masked as "****" in GET responses.
-	Config *map[string]string `json:"config,omitempty"`
+	Config map[string]string `json:"config"`
 
 	// EffectiveRetentionHours Computed retention in hours that will actually be applied during cleanup: the sensor's own `retention_hours` if set, otherwise `sensor.data.retention.days × 24`. Only returned on the single- sensor GET endpoint.
 	EffectiveRetentionHours *int `json:"effective_retention_hours,omitempty"`
 
 	// Enabled Whether the sensor is enabled for collection.
-	Enabled *bool `json:"enabled,omitempty"`
+	Enabled bool `json:"enabled"`
 
 	// ExternalId Immutable device identifier for push-based sensors (e.g. MQTT). Set at auto-discovery and never changes, even if the sensor is renamed. Null for poll-based sensors.
 	ExternalId *string `json:"external_id,omitempty"`
 
 	// HealthReason Optional short reason or message describing health state.
-	HealthReason *string `json:"health_reason,omitempty"`
+	HealthReason string `json:"health_reason"`
 
 	// HealthStatus Health status ("good", "bad", or "unknown").
-	HealthStatus *string `json:"health_status,omitempty"`
+	HealthStatus string `json:"health_status"`
 
 	// Id Internal numeric id for the sensor (database primary key).
 	Id int `json:"id"`
@@ -769,14 +784,14 @@ type Sensor struct {
 	SensorDriver string `json:"sensor_driver"`
 
 	// Status Lifecycle status. Push-based sensors start as "pending" until approved. "dismissed" sensors are hidden but can be restored.
-	Status *SensorStatus `json:"status,omitempty"`
+	Status SensorStatus `json:"status"`
 }
 
 // SensorStatus Lifecycle status. Push-based sensors start as "pending" until approved. "dismissed" sensors are hidden but can be restored.
 type SensorStatus string
 
-// SensorHealthRecord Historical health check record for a sensor.
-type SensorHealthRecord struct {
+// SensorHealthHistory Historical health check record for a sensor.
+type SensorHealthHistory struct {
 	// HealthStatus Enum matching types.SensorHealthStatus in Go.
 	HealthStatus SensorHealthStatus `json:"health_status"`
 
@@ -835,15 +850,15 @@ type UpdatePropertiesRequest map[string]string
 
 // User User information
 type User struct {
-	CreatedAt          *time.Time `json:"created_at,omitempty"`
-	Disabled           *bool      `json:"disabled,omitempty"`
-	Email              *string    `json:"email,omitempty"`
-	Id                 int        `json:"id"`
-	MustChangePassword *bool      `json:"must_change_password,omitempty"`
-	Permissions        *[]string  `json:"permissions,omitempty"`
-	Roles              *[]string  `json:"roles,omitempty"`
-	UpdatedAt          *time.Time `json:"updated_at,omitempty"`
-	Username           string     `json:"username"`
+	CreatedAt          time.Time `json:"created_at"`
+	Disabled           bool      `json:"disabled"`
+	Email              string    `json:"email"`
+	Id                 int       `json:"id"`
+	MustChangePassword bool      `json:"must_change_password"`
+	Permissions        []string  `json:"permissions"`
+	Roles              []string  `json:"roles"`
+	UpdatedAt          time.Time `json:"updated_at"`
+	Username           string    `json:"username"`
 }
 
 // UserNotification User-specific notification with read/dismiss state
@@ -880,6 +895,15 @@ type UpdateApiKeyExpiryJSONBody struct {
 	// ExpiresAt New expiration timestamp, or null to remove expiration.
 	ExpiresAt *time.Time `json:"expires_at,omitempty"`
 }
+
+// ListDriversParams defines parameters for ListDrivers.
+type ListDriversParams struct {
+	// Type Filter drivers by type. Omit to return all drivers.
+	Type *ListDriversParamsType `form:"type,omitempty" json:"type,omitempty"`
+}
+
+// ListDriversParamsType defines parameters for ListDrivers.
+type ListDriversParamsType string
 
 // GetAllMeasurementTypesParams defines parameters for GetAllMeasurementTypes.
 type GetAllMeasurementTypesParams struct {

--- a/sensor_hub/go.mod
+++ b/sensor_hub/go.mod
@@ -115,6 +115,7 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20260209200024-4cfbd4190f57 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260209200024-4cfbd4190f57 // indirect
 	google.golang.org/grpc v1.79.2 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	lukechampine.com/uint128 v1.2.0 // indirect
 	modernc.org/cc/v3 v3.36.3 // indirect
 	modernc.org/ccgo/v3 v3.16.9 // indirect

--- a/sensor_hub/go.sum
+++ b/sensor_hub/go.sum
@@ -377,6 +377,8 @@ google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/sensor_hub/ui/sensor_hub_ui/src/gen/schema.d.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/gen/schema.d.ts
@@ -46,6 +46,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/openapi.yaml": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get OpenAPI specification
+         * @description Returns the OpenAPI specification in YAML format with the server URL dynamically patched to match the request's host and scheme. No authentication required.
+         */
+        get: operations["getOpenApiSpec"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/readings/between": {
         parameters: {
             query?: never;
@@ -86,7 +106,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/sensors/ws/{type}": {
+    "/sensors/ws": {
         parameters: {
             query?: never;
             header?: never;
@@ -94,10 +114,30 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * WebSocket endpoint — subscribe to sensor metadata by type
-         * @description Upgrades the HTTP connection to a WebSocket and sends a snapshot of sensors matching the given type. This is used by the backend to push sensor lists and potentially sensor updates. The initial message is an array of `Sensor` objects. Subsequent messages depend on backend events and may be full sensor arrays or incremental sensor objects.
+         * WebSocket endpoint — subscribe to all sensor metadata
+         * @description Upgrades the HTTP connection to a WebSocket and sends a snapshot of all sensors. Subsequent messages may be full sensor arrays or incremental sensor objects for real-time updates.
          */
-        get: operations["subscribeSensorsByType"];
+        get: operations["subscribeAllSensors"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/sensors/ws/{driver}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * WebSocket endpoint — subscribe to sensor metadata by driver
+         * @description Upgrades the HTTP connection to a WebSocket and sends a snapshot of sensors matching the given driver. This is used by the backend to push sensor lists and potentially sensor updates. The initial message is an array of `Sensor` objects. Subsequent messages depend on backend events and may be full sensor arrays or incremental sensor objects.
+         */
+        get: operations["subscribeSensorsByDriver"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1395,7 +1435,7 @@ export interface components {
     schemas: {
         /** @description An MQTT broker connection configuration. */
         MQTTBroker: {
-            readonly id?: number;
+            readonly id: number;
             /**
              * @description Human-friendly broker name.
              * @example zigbee2mqtt
@@ -1405,7 +1445,7 @@ export interface components {
              * @description Broker type (e.g. "mosquitto", "emqx").
              * @example mosquitto
              */
-            type?: string;
+            type: string;
             /**
              * @description Broker hostname or IP address.
              * @example 192.168.1.100
@@ -1429,15 +1469,15 @@ export interface components {
             /** @description Path to client private key for mutual TLS. */
             client_key_path?: string;
             /** @description Whether the broker connection is active. */
-            enabled?: boolean;
+            enabled: boolean;
             /** Format: date-time */
-            readonly created_at?: string;
+            readonly created_at: string;
             /** Format: date-time */
-            readonly updated_at?: string;
+            readonly updated_at: string;
         };
         /** @description An MQTT topic subscription that routes messages to a driver. */
         MQTTSubscription: {
-            readonly id?: number;
+            readonly id: number;
             /** @description ID of the broker this subscription belongs to. */
             broker_id: number;
             /**
@@ -1451,11 +1491,11 @@ export interface components {
              */
             driver_type: string;
             /** @description Whether this subscription is active. */
-            enabled?: boolean;
+            enabled: boolean;
             /** Format: date-time */
-            readonly created_at?: string;
+            readonly created_at: string;
             /** Format: date-time */
-            readonly updated_at?: string;
+            readonly updated_at: string;
         };
         /**
          * @description Runtime statistics for a single MQTT broker connection. Stats are tracked in-memory and reset when the server restarts.
@@ -1534,7 +1574,7 @@ export interface components {
              * @description Default aggregation function for this measurement type
              * @example avg
              */
-            default_aggregation_function?: string;
+            default_aggregation_function: string;
             /**
              * @description List of aggregation functions supported by this measurement type. The `aggregation_function` query parameter on GET /readings/between must be one of these values (or omitted to use the default).
              * @example [
@@ -1543,7 +1583,7 @@ export interface components {
              *       "last"
              *     ]
              */
-            supported_aggregation_functions?: string[];
+            supported_aggregation_functions: string[];
         };
         /** @description An API key belonging to a user. The full key value is never returned after creation. */
         ApiKey: {
@@ -1645,7 +1685,7 @@ export interface components {
             /** @description Type of measurement (e.g. "temperature", "humidity"). */
             measurement_type: string;
             /**
-             * Format: float
+             * Format: double
              * @description Numeric measurement value (null for non-numeric readings).
              */
             numeric_value?: number | null;
@@ -1653,10 +1693,7 @@ export interface components {
             text_state?: string | null;
             /** @description Unit of measurement (e.g. "°C", "%"). */
             unit?: string;
-            /**
-             * Format: date-time
-             * @description RFC3339 timestamp for when the reading was recorded. Use this for x-axis time in graphs.
-             */
+            /** @description RFC3339 timestamp for when the reading was recorded. Use this for x-axis time in graphs. */
             time: string;
         };
         /**
@@ -1722,20 +1759,20 @@ export interface components {
             /** @description Sensor driver identifier (e.g. "sensor-hub-http-temperature"). */
             sensor_driver: string;
             /** @description Driver-specific configuration key-value pairs. Each driver declares which keys it expects via the GET /drivers endpoint. Sensitive values are masked as "****" in GET responses. */
-            config?: {
+            config: {
                 [key: string]: string;
             };
             /** @description Health status ("good", "bad", or "unknown"). */
-            health_status?: string;
+            health_status: string;
             /** @description Optional short reason or message describing health state. */
-            health_reason?: string;
+            health_reason: string;
             /** @description Whether the sensor is enabled for collection. */
-            enabled?: boolean;
+            enabled: boolean;
             /**
              * @description Lifecycle status. Push-based sensors start as "pending" until approved. "dismissed" sensors are hidden but can be restored.
              * @enum {string}
              */
-            status?: "active" | "pending" | "dismissed";
+            status: "active" | "pending" | "dismissed";
             /** @description Per-sensor data retention override, in hours. When set, this overrides the global `sensor.data.retention.days` configuration for this sensor's readings. Set to null to revert to the global default. Absent on list endpoints when not configured. */
             retention_hours?: number | null;
             /** @description Computed retention in hours that will actually be applied during cleanup: the sensor's own `retention_hours` if set, otherwise `sensor.data.retention.days × 24`. Only returned on the single- sensor GET endpoint. */
@@ -1793,7 +1830,7 @@ export interface components {
             message: string;
         };
         /** @description Historical health check record for a sensor. */
-        SensorHealthRecord: {
+        SensorHealthHistory: {
             /** @description Internal identifier for the health history record (database id). */
             id: number;
             /** @description Internal sensor identifier. */
@@ -1899,15 +1936,15 @@ export interface components {
         User: {
             id: number;
             username: string;
-            email?: string;
-            disabled?: boolean;
-            must_change_password?: boolean;
-            roles?: string[];
-            permissions?: string[];
+            email: string;
+            disabled: boolean;
+            must_change_password: boolean;
+            roles: string[];
+            permissions: string[];
             /** Format: date-time */
-            created_at?: string;
+            created_at: string;
             /** Format: date-time */
-            updated_at?: string;
+            updated_at: string;
         };
         /** @description Create user request body */
         CreateUserRequest: {
@@ -1935,38 +1972,36 @@ export interface components {
         };
         /** @description Alert rule configuration */
         AlertRule: {
-            ID?: number;
+            ID: number;
             SensorID: number;
-            SensorName?: string;
+            SensorName: string;
             /**
              * @description Type of alert (threshold-based or status-based)
              * @enum {string}
              */
             AlertType: "numeric_range" | "status_based";
-            /** Format: float */
-            HighThreshold?: number | null;
-            /** Format: float */
-            LowThreshold?: number | null;
+            /** Format: double */
+            HighThreshold: number;
+            /** Format: double */
+            LowThreshold: number;
             /** @description Status that triggers alert (for status_based type) */
-            TriggerStatus?: string;
+            TriggerStatus: string;
             Enabled: boolean;
             /** @description Minimum seconds between alerts */
-            RateLimitSeconds?: number;
+            RateLimitSeconds: number;
             /** Format: date-time */
             LastAlertSentAt?: string | null;
             /** @description ID of the measurement type this rule applies to */
             MeasurementTypeID: number;
             /** @description Human-readable measurement type name (e.g. "temperature", "battery_low") */
-            MeasurementType?: string;
+            MeasurementType: string;
         };
         /** @description Historical alert event */
         AlertHistoryEntry: {
             id: number;
             sensor_id: number;
-            /** @description Foreign key to measurement_types table. */
-            measurement_type_id?: number;
             alert_type: string;
-            reading_value?: string;
+            reading_value: string;
             /** Format: date-time */
             sent_at: string;
         };
@@ -2038,12 +2073,12 @@ export interface components {
             name: string;
             /** @description JSON-encoded widget layout and configuration */
             config: string;
-            shared?: boolean;
-            is_default?: boolean;
+            shared: boolean;
+            is_default: boolean;
             /** Format: date-time */
-            created_at?: string;
+            created_at: string;
             /** Format: date-time */
-            updated_at?: string;
+            updated_at: string;
         };
         /** @description Request body for creating a dashboard */
         CreateDashboardRequest: {
@@ -2061,25 +2096,25 @@ export interface components {
         };
         /** @description Widget layout and configuration stored as the dashboard config */
         DashboardConfig: {
-            widgets?: components["schemas"]["DashboardWidget"][];
-            breakpoints?: {
-                lg?: number;
-                md?: number;
-                sm?: number;
+            widgets: components["schemas"]["DashboardWidget"][];
+            breakpoints: {
+                lg: number;
+                md: number;
+                sm: number;
             };
         };
         /** @description A single widget on the dashboard */
         DashboardWidget: {
-            id?: string;
-            type?: string;
-            config?: {
+            id: string;
+            type: string;
+            config: {
                 [key: string]: unknown;
             };
-            layout?: {
-                x?: number;
-                y?: number;
-                w?: number;
-                h?: number;
+            layout: {
+                x: number;
+                y: number;
+                w: number;
+                h: number;
             };
         };
         /** @description Generic success response */
@@ -2095,6 +2130,26 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
+    getOpenApiSpec: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OpenAPI specification in YAML format */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/yaml": string;
+                };
+            };
+        };
+    };
     getReadingsBetweenDates: {
         parameters: {
             query: {
@@ -2191,7 +2246,34 @@ export interface operations {
             };
         };
     };
-    subscribeSensorsByType: {
+    subscribeAllSensors: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Switching Protocols — connection upgraded to WebSocket */
+            101: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Non-upgrade response (error) */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    subscribeSensorsByDriver: {
         parameters: {
             query?: never;
             header?: never;
@@ -2200,7 +2282,7 @@ export interface operations {
                  * @description Sensor driver to subscribe to (e.g. "sensor-hub-http-temperature"). Filters sensors by their driver.
                  * @example sensor-hub-http-temperature
                  */
-                type: string;
+                driver: string;
             };
             cookie?: never;
         };
@@ -2573,7 +2655,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["SensorHealthRecord"][];
+                    "application/json": components["schemas"]["SensorHealthHistory"][];
                 };
             };
             /** @description Invalid request */
@@ -3032,7 +3114,10 @@ export interface operations {
     };
     listDrivers: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Filter drivers by type. Omit to return all drivers. */
+                type?: "pull" | "push";
+            };
             header?: never;
             path?: never;
             cookie?: never;


### PR DESCRIPTION
## Summary

Systematic audit of every generated OpenAPI type against hand-written Go counterparts, fixing all discrepancies in the spec, then regenerating all code.

### Schema Fixes (14)
- **Reading.numeric_value**: `format: float` → `format: double` (Go uses `*float64`)
- **Reading.time**: Removed `format: date-time` (Go uses bare `string`, not `time.Time`)
- **Sensor**: Added `config, health_status, health_reason, enabled, status` to required
- **SensorHealthRecord → SensorHealthHistory**: Renamed schema + all `$ref` references
- **MeasurementType**: Added `default_aggregation_function, supported_aggregation_functions` to required
- **User**: Added all 9 fields to required (all non-pointer, no omitempty)
- **MQTTBroker**: Added `id, type, enabled, created_at, updated_at` to required
- **MQTTSubscription**: Added `id, enabled, created_at, updated_at` to required
- **AlertHistoryEntry**: Removed phantom `measurement_type_id`, added `reading_value` to required
- **AlertRule**: Expanded required to 11 fields, removed incorrect nullable from thresholds, format float→double
- **Dashboard**: Added `shared, is_default, created_at, updated_at` to required
- **DashboardConfig**: Added `required: [widgets, breakpoints]`
- **DashboardWidget**: Added `required: [id, type, config, layout]` + nested layout required
- **DashboardBreakpoints**: Added `required: [lg, md, sm]`

### Path Fixes (4)
- Added `/openapi.yaml` GET endpoint with `security: []`
- Added `security: []` and `type` query param to `GET /drivers`
- Added `/sensors/ws` WebSocket endpoint
- Renamed `/sensors/ws/{type}` → `/sensors/ws/{driver}` to match Go route param

### Verification
- `go test ./...` — all packages pass
- `go build ./gen/...` — compiles cleanly
- `npm run build` — frontend builds successfully

Closes #30