### PR TITLE
feat(#35): migrate health/drivers/measurement-types/properties/roles handlers to generated types

### DIFF
--- a/sensor_hub/api/api.go
+++ b/sensor_hub/api/api.go
@@ -49,9 +49,7 @@ func InitialiseAndListen(ctx context.Context, logger *slog.Logger, prometheusHan
 	// All API routes live under /api
 	apiGroup := router.Group("/api")
 
-	apiGroup.GET("/health", func(c *gin.Context) {
-		c.JSON(200, gin.H{"status": "ok"})
-	})
+	apiGroup.GET("/health", server.GetHealth)
 
 	apiGroup.GET("/openapi.yaml", func(c *gin.Context) {
 		scheme := "http"

--- a/sensor_hub/api/driver_api.go
+++ b/sensor_hub/api/driver_api.go
@@ -2,52 +2,80 @@ package api
 
 import (
 	"example/sensorHub/drivers"
+	gen "example/sensorHub/gen"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
 )
 
-type driverInfoResponse struct {
-	Type                      string                    `json:"type"`
-	DisplayName               string                    `json:"display_name"`
-	Description               string                    `json:"description"`
-	SupportedMeasurementTypes []string                  `json:"supported_measurement_types"`
-	ConfigFields              []drivers.ConfigFieldSpec `json:"config_fields"`
-}
-
-func (s *Server) listDriversHandler(c *gin.Context) {
+// ListDrivers implements gen.ServerInterface.
+func (s *Server) ListDrivers(c *gin.Context, params gen.ListDriversParams) {
 	allDrivers := drivers.All()
-	typeFilter := c.Query("type") // "pull", "push", or "" (all)
 
-	result := make([]driverInfoResponse, 0, len(allDrivers))
+	result := make([]gen.DriverInfo, 0, len(allDrivers))
 	for _, d := range allDrivers {
-		if typeFilter == "pull" {
-			if _, ok := d.(drivers.PullDriver); !ok {
-				continue
-			}
-		} else if typeFilter == "push" {
-			if _, ok := d.(drivers.PushDriver); !ok {
-				continue
+		if params.Type != nil {
+			switch *params.Type {
+			case gen.Pull:
+				if _, ok := d.(drivers.PullDriver); !ok {
+					continue
+				}
+			case gen.Push:
+				if _, ok := d.(drivers.PushDriver); !ok {
+					continue
+				}
 			}
 		}
-		mtNames := make([]string, 0)
-		for _, mt := range d.SupportedMeasurementTypes() {
-			mtNames = append(mtNames, mt.Name)
-		}
-		result = append(result, driverInfoResponse{
-			Type:                      d.Type(),
-			DisplayName:               d.DisplayName(),
-			Description:               d.Description(),
-			SupportedMeasurementTypes: mtNames,
-			ConfigFields:              d.ConfigFields(),
-		})
+		result = append(result, driverToGenInfo(d))
 	}
 	c.IndentedJSON(http.StatusOK, result)
+}
+
+func driverToGenInfo(d drivers.SensorDriver) gen.DriverInfo {
+	mtNames := make([]string, 0)
+	for _, mt := range d.SupportedMeasurementTypes() {
+		mtNames = append(mtNames, mt.Name)
+	}
+	desc := d.Description()
+	fields := d.ConfigFields()
+	configFields := make([]gen.ConfigFieldSpec, len(fields))
+	for i, f := range fields {
+		configFields[i] = convertConfigFieldSpec(f)
+	}
+	return gen.DriverInfo{
+		Type:                      d.Type(),
+		DisplayName:               d.DisplayName(),
+		Description:               &desc,
+		SupportedMeasurementTypes: &mtNames,
+		ConfigFields:              configFields,
+	}
+}
+
+func convertConfigFieldSpec(f drivers.ConfigFieldSpec) gen.ConfigFieldSpec {
+	spec := gen.ConfigFieldSpec{
+		Key:       f.Key,
+		Label:     f.Label,
+		Required:  f.Required,
+		Sensitive: f.Sensitive,
+	}
+	spec.Description = &f.Description
+	if f.Default != "" {
+		spec.Default = &f.Default
+	}
+	return spec
 }
 
 func (s *Server) RegisterDriverRoutes(router gin.IRouter) {
 	driversGroup := router.Group("/drivers")
 	{
-		driversGroup.GET("", s.listDriversHandler)
+		driversGroup.GET("", func(c *gin.Context) {
+			var params gen.ListDriversParams
+			if t := c.Query("type"); t != "" {
+				pt := gen.ListDriversParamsType(t)
+				params.Type = &pt
+			}
+			s.ListDrivers(c, params)
+		})
 	}
 }
+

--- a/sensor_hub/api/driver_api_test.go
+++ b/sensor_hub/api/driver_api_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	_ "example/sensorHub/drivers" // register built-in drivers
+	gen "example/sensorHub/gen"
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
@@ -20,7 +21,7 @@ func setupDriverRouter() *gin.Engine {
 	return router
 }
 
-func TestListDriversHandler(t *testing.T) {
+func TestListDrivers(t *testing.T) {
 	router := setupDriverRouter()
 
 	w := httptest.NewRecorder()
@@ -29,13 +30,13 @@ func TestListDriversHandler(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	var result []driverInfoResponse
+	var result []gen.DriverInfo
 	err := json.Unmarshal(w.Body.Bytes(), &result)
 	require.NoError(t, err)
 	require.NotEmpty(t, result)
 
 	// Verify the built-in HTTP temperature driver is present
-	var found *driverInfoResponse
+	var found *gen.DriverInfo
 	for i, d := range result {
 		if d.Type == "sensor-hub-http-temperature" {
 			found = &result[i]
@@ -44,14 +45,16 @@ func TestListDriversHandler(t *testing.T) {
 	}
 	require.NotNil(t, found, "sensor-hub-http-temperature driver should be listed")
 	assert.Equal(t, "Sensor Hub HTTP Temperature", found.DisplayName)
-	assert.NotEmpty(t, found.Description)
-	assert.Contains(t, found.SupportedMeasurementTypes, "temperature")
+	require.NotNil(t, found.Description)
+	assert.NotEmpty(t, *found.Description)
+	require.NotNil(t, found.SupportedMeasurementTypes)
+	assert.Contains(t, *found.SupportedMeasurementTypes, "temperature")
 	require.NotEmpty(t, found.ConfigFields)
 	assert.Equal(t, "url", found.ConfigFields[0].Key)
 	assert.True(t, found.ConfigFields[0].Required)
 }
 
-func TestListDriversHandler_ResponseShape(t *testing.T) {
+func TestListDrivers_ResponseShape(t *testing.T) {
 	router := setupDriverRouter()
 
 	w := httptest.NewRecorder()
@@ -71,3 +74,4 @@ func TestListDriversHandler_ResponseShape(t *testing.T) {
 	assert.Contains(t, first, "supported_measurement_types")
 	assert.Contains(t, first, "config_fields")
 }
+

--- a/sensor_hub/api/health_api.go
+++ b/sensor_hub/api/health_api.go
@@ -1,0 +1,12 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// GetHealth implements gen.ServerInterface.
+func (s *Server) GetHealth(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+}

--- a/sensor_hub/api/health_api_test.go
+++ b/sensor_hub/api/health_api_test.go
@@ -1,0 +1,29 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func setupHealthRouter() *gin.Engine {
+	router := gin.New()
+	s := new(Server)
+	router.GET("/api/health", s.GetHealth)
+	return router
+}
+
+func TestGetHealth_ReturnsOK(t *testing.T) {
+	router := setupHealthRouter()
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/health", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"status"`)
+	assert.Contains(t, w.Body.String(), `"ok"`)
+}

--- a/sensor_hub/api/properties_api.go
+++ b/sensor_hub/api/properties_api.go
@@ -2,17 +2,18 @@ package api
 
 import (
 	"example/sensorHub/api/middleware"
+	gen "example/sensorHub/gen"
 	"example/sensorHub/ws"
+	"fmt"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
 )
 
-
-
-func (s *Server) updatePropertiesHandler(c *gin.Context) {
+// UpdateProperties implements gen.ServerInterface.
+func (s *Server) UpdateProperties(c *gin.Context) {
 	ctx := c.Request.Context()
-	var requestBody map[string]string
+	var requestBody gen.UpdatePropertiesJSONRequestBody
 
 	if err := c.BindJSON(&requestBody); err != nil {
 		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid request body"})
@@ -28,7 +29,8 @@ func (s *Server) updatePropertiesHandler(c *gin.Context) {
 	c.IndentedJSON(http.StatusAccepted, gin.H{"message": "Property updated successfully"})
 }
 
-func (s *Server) getPropertiesHandler(c *gin.Context) {
+// GetProperties implements gen.ServerInterface.
+func (s *Server) GetProperties(c *gin.Context) {
 	ctx := c.Request.Context()
 	properties, err := s.propertiesService.ServiceGetProperties(ctx)
 	if err != nil {
@@ -36,10 +38,15 @@ func (s *Server) getPropertiesHandler(c *gin.Context) {
 		return
 	}
 
-	c.IndentedJSON(http.StatusOK, properties)
+	result := make(gen.PropertiesMap)
+	for k, v := range properties {
+		result[k] = fmt.Sprintf("%v", v)
+	}
+	c.IndentedJSON(http.StatusOK, result)
 }
 
-func (s *Server) propertiesWebSocketHandler(c *gin.Context) {
+// PropertiesWebSocket implements gen.ServerInterface.
+func (s *Server) PropertiesWebSocket(c *gin.Context) {
 	ctx := c.Request.Context()
 	properties, err := s.propertiesService.ServiceGetProperties(ctx)
 	if err != nil {
@@ -49,14 +56,19 @@ func (s *Server) propertiesWebSocketHandler(c *gin.Context) {
 
 	createPushWebSocket(c, "properties")
 
-	ws.BroadcastToTopic("properties", properties)
+	result := make(gen.PropertiesMap)
+	for k, v := range properties {
+		result[k] = fmt.Sprintf("%v", v)
+	}
+	ws.BroadcastToTopic("properties", result)
 }
 
 func (s *Server) RegisterPropertiesRoutes(router gin.IRouter) {
 	propertiesGroup := router.Group("/properties")
 	{
-		propertiesGroup.PATCH("", middleware.AuthRequired(), middleware.RequirePermission("manage_properties"), s.updatePropertiesHandler)
-		propertiesGroup.GET("", middleware.AuthRequired(), middleware.RequirePermission("view_properties"), s.getPropertiesHandler)
-		propertiesGroup.GET("/ws", middleware.AuthRequired(), middleware.RequirePermission("view_properties"), s.propertiesWebSocketHandler)
+		propertiesGroup.PATCH("", middleware.AuthRequired(), middleware.RequirePermission("manage_properties"), s.UpdateProperties)
+		propertiesGroup.GET("", middleware.AuthRequired(), middleware.RequirePermission("view_properties"), s.GetProperties)
+		propertiesGroup.GET("/ws", middleware.AuthRequired(), middleware.RequirePermission("view_properties"), s.PropertiesWebSocket)
 	}
 }
+

--- a/sensor_hub/api/properties_api_test.go
+++ b/sensor_hub/api/properties_api_test.go
@@ -21,9 +21,9 @@ func setupPropertiesRouter() (*gin.Engine, *gin.RouterGroup, *Server, *MockPrope
 	return router, apiGroup, s, mockService
 }
 
-func TestUpdatePropertiesHandler(t *testing.T) {
+func TestUpdateProperties(t *testing.T) {
 	router, api, s, mockService := setupPropertiesRouter()
-	api.PATCH("/properties", s.updatePropertiesHandler)
+	api.PATCH("/properties", s.UpdateProperties)
 
 	props := map[string]string{"key": "value"}
 	jsonBody, _ := json.Marshal(props)
@@ -37,9 +37,9 @@ func TestUpdatePropertiesHandler(t *testing.T) {
 	assert.Equal(t, http.StatusAccepted, w.Code)
 }
 
-func TestGetPropertiesHandler(t *testing.T) {
+func TestGetProperties(t *testing.T) {
 	router, api, s, mockService := setupPropertiesRouter()
-	api.GET("/properties", s.getPropertiesHandler)
+	api.GET("/properties", s.GetProperties)
 
 	mockService.On("ServiceGetProperties", mock.Anything).Return(map[string]interface{}{"key": "value"}, nil)
 
@@ -51,9 +51,9 @@ func TestGetPropertiesHandler(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "value")
 }
 
-func TestUpdatePropertiesHandler_InvalidJSON(t *testing.T) {
+func TestUpdateProperties_InvalidJSON(t *testing.T) {
 	router, api, s, _ := setupPropertiesRouter()
-	api.PATCH("/properties", s.updatePropertiesHandler)
+	api.PATCH("/properties", s.UpdateProperties)
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("PATCH", "/api/properties", bytes.NewBufferString("invalid"))
@@ -62,9 +62,9 @@ func TestUpdatePropertiesHandler_InvalidJSON(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
-func TestUpdatePropertiesHandler_ServiceError(t *testing.T) {
+func TestUpdateProperties_ServiceError(t *testing.T) {
 	router, api, s, mockService := setupPropertiesRouter()
-	api.PATCH("/properties", s.updatePropertiesHandler)
+	api.PATCH("/properties", s.UpdateProperties)
 
 	props := map[string]string{"key": "value"}
 	jsonBody, _ := json.Marshal(props)
@@ -78,9 +78,9 @@ func TestUpdatePropertiesHandler_ServiceError(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
 
-func TestGetPropertiesHandler_ServiceError(t *testing.T) {
+func TestGetProperties_ServiceError(t *testing.T) {
 	router, api, s, mockService := setupPropertiesRouter()
-	api.GET("/properties", s.getPropertiesHandler)
+	api.GET("/properties", s.GetProperties)
 
 	mockService.On("ServiceGetProperties", mock.Anything).Return(map[string]interface{}{}, errors.New("db error"))
 

--- a/sensor_hub/api/role_routes.go
+++ b/sensor_hub/api/role_routes.go
@@ -1,6 +1,9 @@
 package api
 
 import (
+	"fmt"
+	"net/http"
+
 	"example/sensorHub/api/middleware"
 
 	"github.com/gin-gonic/gin"
@@ -9,10 +12,36 @@ import (
 func (s *Server) RegisterRoleRoutes(router gin.IRouter) {
 	roles := router.Group("/roles")
 	{
-		roles.GET("", middleware.AuthRequired(), middleware.RequirePermission("view_roles"), s.listRolesHandler)
-		roles.GET("/permissions", middleware.AuthRequired(), middleware.RequirePermission("view_roles"), s.listPermissionsHandler)
-		roles.GET("/:id/permissions", middleware.AuthRequired(), middleware.RequirePermission("view_roles"), s.getRolePermissionsHandler)
-		roles.POST("/:id/permissions", middleware.AuthRequired(), middleware.RequirePermission("manage_roles"), s.assignPermissionHandler)
-		roles.DELETE("/:id/permissions/:pid", middleware.AuthRequired(), middleware.RequirePermission("manage_roles"), s.removePermissionHandler)
+		roles.GET("", middleware.AuthRequired(), middleware.RequirePermission("view_roles"), s.ListRoles)
+		roles.GET("/permissions", middleware.AuthRequired(), middleware.RequirePermission("view_roles"), s.ListPermissions)
+		roles.GET("/:id/permissions", middleware.AuthRequired(), middleware.RequirePermission("view_roles"), func(c *gin.Context) {
+			var id int
+			if _, err := fmt.Sscan(c.Param("id"), &id); err != nil {
+				c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid role id"})
+				return
+			}
+			s.GetRolePermissions(c, id)
+		})
+		roles.POST("/:id/permissions", middleware.AuthRequired(), middleware.RequirePermission("manage_roles"), func(c *gin.Context) {
+			var id int
+			if _, err := fmt.Sscan(c.Param("id"), &id); err != nil {
+				c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid role id"})
+				return
+			}
+			s.AssignPermission(c, id)
+		})
+		roles.DELETE("/:id/permissions/:pid", middleware.AuthRequired(), middleware.RequirePermission("manage_roles"), func(c *gin.Context) {
+			var id, pid int
+			if _, err := fmt.Sscan(c.Param("id"), &id); err != nil {
+				c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid role id"})
+				return
+			}
+			if _, err := fmt.Sscan(c.Param("pid"), &pid); err != nil {
+				c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid permission id"})
+				return
+			}
+			s.RemovePermission(c, id, pid)
+		})
 	}
 }
+

--- a/sensor_hub/api/roles_api.go
+++ b/sensor_hub/api/roles_api.go
@@ -1,92 +1,82 @@
 package api
 
 import (
-	"fmt"
 	"net/http"
+
+	db "example/sensorHub/db"
+	gen "example/sensorHub/gen"
 
 	"github.com/gin-gonic/gin"
 )
 
-
-
-func (s *Server) listRolesHandler(c *gin.Context) {
+// ListRoles implements gen.ServerInterface.
+func (s *Server) ListRoles(c *gin.Context) {
 	ctx := c.Request.Context()
 	roles, err := s.roleService.ListRoles(ctx)
 	if err != nil {
 		c.IndentedJSON(http.StatusInternalServerError, gin.H{"message": "failed to list roles", "error": err.Error()})
 		return
 	}
-	c.IndentedJSON(http.StatusOK, roles)
+	result := make([]gen.RoleInfo, len(roles))
+	for i, r := range roles {
+		result[i] = gen.RoleInfo{Id: r.Id, Name: r.Name}
+	}
+	c.IndentedJSON(http.StatusOK, result)
 }
 
-func (s *Server) listPermissionsHandler(c *gin.Context) {
+// ListPermissions implements gen.ServerInterface.
+func (s *Server) ListPermissions(c *gin.Context) {
 	ctx := c.Request.Context()
 	perms, err := s.roleService.ListPermissions(ctx)
 	if err != nil {
 		c.IndentedJSON(http.StatusInternalServerError, gin.H{"message": "failed to list permissions", "error": err.Error()})
 		return
 	}
-	c.IndentedJSON(http.StatusOK, perms)
+	c.IndentedJSON(http.StatusOK, convertPermissions(perms))
 }
 
-func (s *Server) getRolePermissionsHandler(c *gin.Context) {
+// GetRolePermissions implements gen.ServerInterface.
+func (s *Server) GetRolePermissions(c *gin.Context, id int) {
 	ctx := c.Request.Context()
-	id := c.Param("id")
-	var roleId int
-	_, err := fmt.Sscan(id, &roleId)
-	if err != nil {
-		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid role id"})
-		return
-	}
-	perms, err := s.roleService.ListPermissionsForRole(ctx, roleId)
+	perms, err := s.roleService.ListPermissionsForRole(ctx, id)
 	if err != nil {
 		c.IndentedJSON(http.StatusInternalServerError, gin.H{"message": "failed to list role permissions", "error": err.Error()})
 		return
 	}
-	c.IndentedJSON(http.StatusOK, perms)
+	c.IndentedJSON(http.StatusOK, convertPermissions(perms))
 }
 
-func (s *Server) assignPermissionHandler(c *gin.Context) {
+// AssignPermission implements gen.ServerInterface.
+func (s *Server) AssignPermission(c *gin.Context, id int) {
 	ctx := c.Request.Context()
-	id := c.Param("id")
-	var roleId int
-	_, err := fmt.Sscan(id, &roleId)
-	if err != nil {
-		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid role id"})
-		return
-	}
-	var req struct {
-		PermissionId int `json:"permission_id"`
-	}
+	var req gen.AssignPermissionJSONRequestBody
 	if err := c.BindJSON(&req); err != nil {
 		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid request"})
 		return
 	}
-	if err := s.roleService.AssignPermission(ctx, roleId, req.PermissionId); err != nil {
+	if err := s.roleService.AssignPermission(ctx, id, req.PermissionId); err != nil {
 		c.IndentedJSON(http.StatusInternalServerError, gin.H{"message": "failed to assign permission", "error": err.Error()})
 		return
 	}
 	c.Status(http.StatusOK)
 }
 
-func (s *Server) removePermissionHandler(c *gin.Context) {
+// RemovePermission implements gen.ServerInterface.
+func (s *Server) RemovePermission(c *gin.Context, id int, pid int) {
 	ctx := c.Request.Context()
-	id := c.Param("id")
-	pid := c.Param("pid")
-	var roleId, permissionId int
-	_, err := fmt.Sscan(id, &roleId)
-	if err != nil {
-		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid role id"})
-		return
-	}
-	_, err = fmt.Sscan(pid, &permissionId)
-	if err != nil {
-		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid permission id"})
-		return
-	}
-	if err := s.roleService.RemovePermission(ctx, roleId, permissionId); err != nil {
+	if err := s.roleService.RemovePermission(ctx, id, pid); err != nil {
 		c.IndentedJSON(http.StatusInternalServerError, gin.H{"message": "failed to remove permission", "error": err.Error()})
 		return
 	}
 	c.Status(http.StatusOK)
 }
+
+func convertPermissions(perms []db.PermissionInfo) []gen.PermissionInfo {
+	result := make([]gen.PermissionInfo, len(perms))
+	for i, p := range perms {
+		desc := p.Description
+		result[i] = gen.PermissionInfo{Id: p.Id, Name: p.Name, Description: &desc}
+	}
+	return result
+}
+

--- a/sensor_hub/api/roles_api_test.go
+++ b/sensor_hub/api/roles_api_test.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	db "example/sensorHub/db"
+	gen "example/sensorHub/gen"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -22,9 +24,9 @@ func setupRoleRouter() (*gin.Engine, *gin.RouterGroup, *Server, *MockRoleService
 	return router, apiGroup, s, mockService
 }
 
-func TestListRolesHandler(t *testing.T) {
+func TestListRoles(t *testing.T) {
 	router, api, s, mockService := setupRoleRouter()
-	api.GET("/roles", s.listRolesHandler)
+	api.GET("/roles", s.ListRoles)
 
 	mockService.On("ListRoles", mock.Anything).Return([]db.RoleInfo{{Id: 1, Name: "admin"}}, nil)
 
@@ -36,9 +38,9 @@ func TestListRolesHandler(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "admin")
 }
 
-func TestListPermissionsHandler(t *testing.T) {
+func TestListPermissions(t *testing.T) {
 	router, api, s, mockService := setupRoleRouter()
-	api.GET("/permissions", s.listPermissionsHandler)
+	api.GET("/permissions", s.ListPermissions)
 
 	mockService.On("ListPermissions", mock.Anything).Return([]db.PermissionInfo{{Id: 1, Name: "read"}}, nil)
 
@@ -50,13 +52,15 @@ func TestListPermissionsHandler(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "read")
 }
 
-func TestAssignPermissionHandler(t *testing.T) {
-	router, api, s, mockService := setupRoleRouter()
-	api.POST("/roles/:id/permissions", s.assignPermissionHandler)
+func TestAssignPermission(t *testing.T) {
+	router, _, s, mockService := setupRoleRouter()
+	router.POST("/api/roles/:id/permissions", func(c *gin.Context) {
+		var id int
+		fmt.Sscan(c.Param("id"), &id)
+		s.AssignPermission(c, id)
+	})
 
-	reqBody := struct {
-		PermissionId int `json:"permission_id"`
-	}{PermissionId: 10}
+	reqBody := gen.AssignPermissionJSONRequestBody{PermissionId: 10}
 	jsonBody, _ := json.Marshal(reqBody)
 
 	mockService.On("AssignPermission", mock.Anything, 1, 10).Return(nil)
@@ -68,9 +72,14 @@ func TestAssignPermissionHandler(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
-func TestRemovePermissionHandler(t *testing.T) {
-	router, api, s, mockService := setupRoleRouter()
-	api.DELETE("/roles/:id/permissions/:pid", s.removePermissionHandler)
+func TestRemovePermission(t *testing.T) {
+	router, _, s, mockService := setupRoleRouter()
+	router.DELETE("/api/roles/:id/permissions/:pid", func(c *gin.Context) {
+		var id, pid int
+		fmt.Sscan(c.Param("id"), &id)
+		fmt.Sscan(c.Param("pid"), &pid)
+		s.RemovePermission(c, id, pid)
+	})
 
 	mockService.On("RemovePermission", mock.Anything, 1, 10).Return(nil)
 
@@ -81,9 +90,13 @@ func TestRemovePermissionHandler(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
-func TestGetRolePermissionsHandler(t *testing.T) {
-	router, api, s, mockService := setupRoleRouter()
-	api.GET("/roles/:id/permissions", s.getRolePermissionsHandler)
+func TestGetRolePermissions(t *testing.T) {
+	router, _, s, mockService := setupRoleRouter()
+	router.GET("/api/roles/:id/permissions", func(c *gin.Context) {
+		var id int
+		fmt.Sscan(c.Param("id"), &id)
+		s.GetRolePermissions(c, id)
+	})
 
 	mockService.On("ListPermissionsForRole", mock.Anything, 1).Return([]db.PermissionInfo{{Id: 10, Name: "read"}}, nil)
 
@@ -95,9 +108,9 @@ func TestGetRolePermissionsHandler(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "read")
 }
 
-func TestListRolesHandler_ServiceError(t *testing.T) {
+func TestListRoles_ServiceError(t *testing.T) {
 	router, api, s, mockService := setupRoleRouter()
-	api.GET("/roles", s.listRolesHandler)
+	api.GET("/roles", s.ListRoles)
 
 	mockService.On("ListRoles", mock.Anything).Return([]db.RoleInfo{}, errors.New("db error"))
 
@@ -108,9 +121,9 @@ func TestListRolesHandler_ServiceError(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
 
-func TestListPermissionsHandler_ServiceError(t *testing.T) {
+func TestListPermissions_ServiceError(t *testing.T) {
 	router, api, s, mockService := setupRoleRouter()
-	api.GET("/permissions", s.listPermissionsHandler)
+	api.GET("/permissions", s.ListPermissions)
 
 	mockService.On("ListPermissions", mock.Anything).Return([]db.PermissionInfo{}, errors.New("db error"))
 
@@ -121,9 +134,16 @@ func TestListPermissionsHandler_ServiceError(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
 
-func TestGetRolePermissionsHandler_InvalidID(t *testing.T) {
-	router, api, s, _ := setupRoleRouter()
-	api.GET("/roles/:id/permissions", s.getRolePermissionsHandler)
+func TestGetRolePermissions_InvalidID(t *testing.T) {
+	router, _, s, _ := setupRoleRouter()
+	router.GET("/api/roles/:id/permissions", func(c *gin.Context) {
+		var id int
+		if _, err := fmt.Sscan(c.Param("id"), &id); err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid role id"})
+			return
+		}
+		s.GetRolePermissions(c, id)
+	})
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/roles/invalid/permissions", nil)
@@ -132,9 +152,13 @@ func TestGetRolePermissionsHandler_InvalidID(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
-func TestGetRolePermissionsHandler_ServiceError(t *testing.T) {
-	router, api, s, mockService := setupRoleRouter()
-	api.GET("/roles/:id/permissions", s.getRolePermissionsHandler)
+func TestGetRolePermissions_ServiceError(t *testing.T) {
+	router, _, s, mockService := setupRoleRouter()
+	router.GET("/api/roles/:id/permissions", func(c *gin.Context) {
+		var id int
+		fmt.Sscan(c.Param("id"), &id)
+		s.GetRolePermissions(c, id)
+	})
 
 	mockService.On("ListPermissionsForRole", mock.Anything, 1).Return([]db.PermissionInfo{}, errors.New("db error"))
 
@@ -145,13 +169,18 @@ func TestGetRolePermissionsHandler_ServiceError(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
 
-func TestAssignPermissionHandler_InvalidID(t *testing.T) {
-	router, api, s, _ := setupRoleRouter()
-	api.POST("/roles/:id/permissions", s.assignPermissionHandler)
+func TestAssignPermission_InvalidID(t *testing.T) {
+	router, _, s, _ := setupRoleRouter()
+	router.POST("/api/roles/:id/permissions", func(c *gin.Context) {
+		var id int
+		if _, err := fmt.Sscan(c.Param("id"), &id); err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid role id"})
+			return
+		}
+		s.AssignPermission(c, id)
+	})
 
-	reqBody := struct {
-		PermissionId int `json:"permission_id"`
-	}{PermissionId: 10}
+	reqBody := gen.AssignPermissionJSONRequestBody{PermissionId: 10}
 	jsonBody, _ := json.Marshal(reqBody)
 
 	w := httptest.NewRecorder()
@@ -161,9 +190,13 @@ func TestAssignPermissionHandler_InvalidID(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
-func TestAssignPermissionHandler_InvalidJSON(t *testing.T) {
-	router, api, s, _ := setupRoleRouter()
-	api.POST("/roles/:id/permissions", s.assignPermissionHandler)
+func TestAssignPermission_InvalidJSON(t *testing.T) {
+	router, _, s, _ := setupRoleRouter()
+	router.POST("/api/roles/:id/permissions", func(c *gin.Context) {
+		var id int
+		fmt.Sscan(c.Param("id"), &id)
+		s.AssignPermission(c, id)
+	})
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/roles/1/permissions", bytes.NewBufferString("invalid"))
@@ -172,13 +205,15 @@ func TestAssignPermissionHandler_InvalidJSON(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
-func TestAssignPermissionHandler_ServiceError(t *testing.T) {
-	router, api, s, mockService := setupRoleRouter()
-	api.POST("/roles/:id/permissions", s.assignPermissionHandler)
+func TestAssignPermission_ServiceError(t *testing.T) {
+	router, _, s, mockService := setupRoleRouter()
+	router.POST("/api/roles/:id/permissions", func(c *gin.Context) {
+		var id int
+		fmt.Sscan(c.Param("id"), &id)
+		s.AssignPermission(c, id)
+	})
 
-	reqBody := struct {
-		PermissionId int `json:"permission_id"`
-	}{PermissionId: 10}
+	reqBody := gen.AssignPermissionJSONRequestBody{PermissionId: 10}
 	jsonBody, _ := json.Marshal(reqBody)
 
 	mockService.On("AssignPermission", mock.Anything, 1, 10).Return(errors.New("db error"))
@@ -190,9 +225,20 @@ func TestAssignPermissionHandler_ServiceError(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
 
-func TestRemovePermissionHandler_InvalidRoleID(t *testing.T) {
-	router, api, s, _ := setupRoleRouter()
-	api.DELETE("/roles/:id/permissions/:pid", s.removePermissionHandler)
+func TestRemovePermission_InvalidRoleID(t *testing.T) {
+	router, _, s, _ := setupRoleRouter()
+	router.DELETE("/api/roles/:id/permissions/:pid", func(c *gin.Context) {
+		var id, pid int
+		if _, err := fmt.Sscan(c.Param("id"), &id); err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid role id"})
+			return
+		}
+		if _, err := fmt.Sscan(c.Param("pid"), &pid); err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid permission id"})
+			return
+		}
+		s.RemovePermission(c, id, pid)
+	})
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("DELETE", "/api/roles/invalid/permissions/10", nil)
@@ -201,9 +247,20 @@ func TestRemovePermissionHandler_InvalidRoleID(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
-func TestRemovePermissionHandler_InvalidPermissionID(t *testing.T) {
-	router, api, s, _ := setupRoleRouter()
-	api.DELETE("/roles/:id/permissions/:pid", s.removePermissionHandler)
+func TestRemovePermission_InvalidPermissionID(t *testing.T) {
+	router, _, s, _ := setupRoleRouter()
+	router.DELETE("/api/roles/:id/permissions/:pid", func(c *gin.Context) {
+		var id, pid int
+		if _, err := fmt.Sscan(c.Param("id"), &id); err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid role id"})
+			return
+		}
+		if _, err := fmt.Sscan(c.Param("pid"), &pid); err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid permission id"})
+			return
+		}
+		s.RemovePermission(c, id, pid)
+	})
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("DELETE", "/api/roles/1/permissions/invalid", nil)
@@ -212,9 +269,14 @@ func TestRemovePermissionHandler_InvalidPermissionID(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
-func TestRemovePermissionHandler_ServiceError(t *testing.T) {
-	router, api, s, mockService := setupRoleRouter()
-	api.DELETE("/roles/:id/permissions/:pid", s.removePermissionHandler)
+func TestRemovePermission_ServiceError(t *testing.T) {
+	router, _, s, mockService := setupRoleRouter()
+	router.DELETE("/api/roles/:id/permissions/:pid", func(c *gin.Context) {
+		var id, pid int
+		fmt.Sscan(c.Param("id"), &id)
+		fmt.Sscan(c.Param("pid"), &pid)
+		s.RemovePermission(c, id, pid)
+	})
 
 	mockService.On("RemovePermission", mock.Anything, 1, 10).Return(errors.New("db error"))
 
@@ -224,3 +286,4 @@ func TestRemovePermissionHandler_ServiceError(t *testing.T) {
 
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
+

--- a/sensor_hub/api/sensor_api.go
+++ b/sensor_hub/api/sensor_api.go
@@ -429,13 +429,8 @@ func (s *Server) dismissSensorHandler(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, gin.H{"message": "Sensor dismissed"})
 }
 
-func (s *Server) sensorMeasurementTypesHandler(c *gin.Context) {
+func (s *Server) GetSensorMeasurementTypes(c *gin.Context, id int) {
 	ctx := c.Request.Context()
-	id, err := strconv.Atoi(c.Param("id"))
-	if err != nil {
-		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid sensor ID"})
-		return
-	}
 	mts, err := s.sensorService.ServiceGetMeasurementTypesForSensor(ctx, id)
 	if err != nil {
 		c.IndentedJSON(http.StatusInternalServerError, gin.H{"message": err.Error()})
@@ -447,13 +442,13 @@ func (s *Server) sensorMeasurementTypesHandler(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, mts)
 }
 
-func (s *Server) allMeasurementTypesHandler(c *gin.Context) {
+func (s *Server) GetAllMeasurementTypes(c *gin.Context, params gen.GetAllMeasurementTypesParams) {
 	ctx := c.Request.Context()
 
 	var mts []gen.MeasurementType
 	var err error
 
-	if c.Query("has_readings") == "true" {
+	if params.HasReadings != nil && *params.HasReadings {
 		mts, err = s.sensorService.ServiceGetAllMeasurementTypesWithReadings(ctx)
 	} else {
 		mts, err = s.sensorService.ServiceGetAllMeasurementTypes(ctx)

--- a/sensor_hub/api/sensor_api_test.go
+++ b/sensor_hub/api/sensor_api_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	appProps "example/sensorHub/application_properties"
 	gen "example/sensorHub/gen"
 	"net/http"
@@ -586,4 +587,60 @@ func TestDismissSensorHandler_Error(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestGetAllMeasurementTypes(t *testing.T) {
+router, _, s, mockService := setupSensorRouter()
+router.GET("/api/measurement-types", func(c *gin.Context) {
+var params gen.GetAllMeasurementTypesParams
+s.GetAllMeasurementTypes(c, params)
+})
+
+mts := []gen.MeasurementType{{Name: "temperature"}}
+mockService.On("ServiceGetAllMeasurementTypes", mock.Anything).Return(mts, nil)
+
+w := httptest.NewRecorder()
+req := httptest.NewRequest("GET", "/api/measurement-types", nil)
+router.ServeHTTP(w, req)
+
+assert.Equal(t, http.StatusOK, w.Code)
+assert.Contains(t, w.Body.String(), "temperature")
+}
+
+func TestGetAllMeasurementTypes_HasReadings(t *testing.T) {
+router, _, s, mockService := setupSensorRouter()
+router.GET("/api/measurement-types", func(c *gin.Context) {
+hasReadings := c.Query("has_readings") == "true"
+params := gen.GetAllMeasurementTypesParams{HasReadings: &hasReadings}
+s.GetAllMeasurementTypes(c, params)
+})
+
+mts := []gen.MeasurementType{{Name: "humidity"}}
+mockService.On("ServiceGetAllMeasurementTypesWithReadings", mock.Anything).Return(mts, nil)
+
+w := httptest.NewRecorder()
+req := httptest.NewRequest("GET", "/api/measurement-types?has_readings=true", nil)
+router.ServeHTTP(w, req)
+
+assert.Equal(t, http.StatusOK, w.Code)
+assert.Contains(t, w.Body.String(), "humidity")
+}
+
+func TestGetSensorMeasurementTypes(t *testing.T) {
+router, _, s, mockService := setupSensorRouter()
+router.GET("/api/sensors/:id/measurement-types", func(c *gin.Context) {
+var id int
+fmt.Sscan(c.Param("id"), &id)
+s.GetSensorMeasurementTypes(c, id)
+})
+
+mts := []gen.MeasurementType{{Name: "temperature"}}
+mockService.On("ServiceGetMeasurementTypesForSensor", mock.Anything, 1).Return(mts, nil)
+
+w := httptest.NewRecorder()
+req := httptest.NewRequest("GET", "/api/sensors/1/measurement-types", nil)
+router.ServeHTTP(w, req)
+
+assert.Equal(t, http.StatusOK, w.Code)
+assert.Contains(t, w.Body.String(), "temperature")
 }

--- a/sensor_hub/api/sensor_routes.go
+++ b/sensor_hub/api/sensor_routes.go
@@ -1,7 +1,11 @@
 package api
 
 import (
+	"fmt"
+	"net/http"
+
 	"example/sensorHub/api/middleware"
+	gen "example/sensorHub/gen"
 
 	"github.com/gin-gonic/gin"
 )
@@ -27,8 +31,23 @@ func (s *Server) RegisterSensorRoutes(router gin.IRouter) {
 		sensorsGroup.GET("/status/:status", middleware.AuthRequired(), middleware.RequirePermission("view_sensors"), s.getSensorsByStatusHandler)
 		sensorsGroup.POST("/approve/:id", middleware.AuthRequired(), middleware.RequirePermission("manage_sensors"), s.approveSensorHandler)
 		sensorsGroup.POST("/dismiss/:id", middleware.AuthRequired(), middleware.RequirePermission("manage_sensors"), s.dismissSensorHandler)
-		sensorsGroup.GET("/by-id/:id/measurement-types", middleware.AuthRequired(), middleware.RequirePermission("view_sensors"), s.sensorMeasurementTypesHandler)
+		sensorsGroup.GET("/by-id/:id/measurement-types", middleware.AuthRequired(), middleware.RequirePermission("view_sensors"), func(c *gin.Context) {
+			var id int
+			if _, err := fmt.Sscan(c.Param("id"), &id); err != nil {
+				c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid sensor ID"})
+				return
+			}
+			s.GetSensorMeasurementTypes(c, id)
+		})
 	}
 
-	router.GET("/measurement-types", middleware.AuthRequired(), middleware.RequirePermission("view_sensors"), s.allMeasurementTypesHandler)
+	router.GET("/measurement-types", middleware.AuthRequired(), middleware.RequirePermission("view_sensors"), func(c *gin.Context) {
+		var params gen.GetAllMeasurementTypesParams
+		if hr := c.Query("has_readings"); hr != "" {
+			hasReadings := hr == "true"
+			params.HasReadings = &hasReadings
+		}
+		s.GetAllMeasurementTypes(c, params)
+	})
 }
+


### PR DESCRIPTION
Closes #35

## Summary

Migrates the health, properties, roles, drivers, and measurement-types API handlers to use generated types and method names from `gen.ServerInterface`, as part of the OpenAPI codegen rollout.

## Changes

### New files
- `api/health_api.go` — `GetHealth` handler extracted from inline closure in `api.go`
- `api/health_api_test.go` — test for `GetHealth`

### Renamed handlers (all now implement `gen.ServerInterface` signatures)

| Old name | New name |
|---|---|
| inline closure | `GetHealth(c)` |
| `updatePropertiesHandler` | `UpdateProperties(c)` |
| `getPropertiesHandler` | `GetProperties(c)` |
| `propertiesWebSocketHandler` | `PropertiesWebSocket(c)` |
| `listRolesHandler` | `ListRoles(c)` |
| `listPermissionsHandler` | `ListPermissions(c)` |
| `getRolePermissionsHandler` | `GetRolePermissions(c, id)` |
| `assignPermissionHandler` | `AssignPermission(c, id)` |
| `removePermissionHandler` | `RemovePermission(c, id, pid)` |
| `listDriversHandler` | `ListDrivers(c, params)` |
| `allMeasurementTypesHandler` | `GetAllMeasurementTypes(c, params)` |
| `sensorMeasurementTypesHandler` | `GetSensorMeasurementTypes(c, id)` |

### Type migrations
- **Properties**: request body uses `gen.UpdatePropertiesJSONRequestBody`; response converts `map[string]interface{}` → `gen.PropertiesMap`
- **Roles**: `db.RoleInfo` → `gen.RoleInfo`; `db.PermissionInfo` → `gen.PermissionInfo` (Description becomes `*string`); request body uses `gen.AssignPermissionJSONRequestBody`
- **Drivers**: removed local `driverInfoResponse` struct; added `driverToGenInfo` + `convertConfigFieldSpec` helpers returning `gen.DriverInfo` / `gen.ConfigFieldSpec`
- **Measurement types**: use `gen.GetAllMeasurementTypesParams` (HasReadings `*bool`) instead of raw `c.Query()`

### Route registration
Handlers with extra parameters (`GetRolePermissions`, `AssignPermission`, `RemovePermission`, `ListDrivers`, `GetAllMeasurementTypes`, `GetSensorMeasurementTypes`) now use gin closures in their `Register*Routes` functions to extract path/query params before calling the handler — ready for `gen.RegisterHandlers` in #40.

## Testing
- TDD (red → green) for each group
- All existing tests updated to use new names and gen types
- New tests: `TestGetAllMeasurementTypes`, `TestGetAllMeasurementTypes_HasReadings`, `TestGetSensorMeasurementTypes`
- All 41 integration tests pass