### PR TITLE
feat(#36): migrate sensor handlers to generated types

### DIFF
--- a/sensor_hub/api/sensor_api.go
+++ b/sensor_hub/api/sensor_api.go
@@ -7,18 +7,11 @@ import (
 	"example/sensorHub/ws"
 	"log/slog"
 	"net/http"
-	"strconv"
 
 	"github.com/gin-gonic/gin"
 )
 
 
-
-// sensorDetailResponse extends gen.Sensor with computed fields for the single-sensor endpoint.
-type sensorDetailResponse struct {
-	gen.Sensor
-	EffectiveRetentionHours int `json:"effective_retention_hours"`
-}
 
 // computeEffectiveRetentionHours returns the sensor's custom retention if set, otherwise
 // the global default (sensor.data.retention.days × 24 hours).
@@ -29,7 +22,8 @@ func computeEffectiveRetentionHours(sensor gen.Sensor) int {
 	return appProps.AppConfig.SensorDataRetentionDays * 24
 }
 
-func (s *Server) addSensorHandler(c *gin.Context) {
+// AddSensor implements gen.ServerInterface.
+func (s *Server) AddSensor(c *gin.Context) {
 	ctx := c.Request.Context()
 	var sensor gen.Sensor
 	if err := c.BindJSON(&sensor); err != nil {
@@ -44,18 +38,10 @@ func (s *Server) addSensorHandler(c *gin.Context) {
 	c.IndentedJSON(http.StatusCreated, gin.H{"message": "Sensor added successfully"})
 }
 
-func (s *Server) updateSensorHandler(c *gin.Context) {
+// UpdateSensorById implements gen.ServerInterface.
+// The id is extracted by the route closure; merge-patch semantics are preserved.
+func (s *Server) UpdateSensorById(c *gin.Context, id int) {
 	ctx := c.Request.Context()
-	idStr := c.Param("id")
-	if idStr == "" {
-		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Sensor ID is required"})
-		return
-	}
-	idInt, err := strconv.Atoi(idStr)
-	if err != nil {
-		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid sensor ID", "error": err.Error()})
-		return
-	}
 
 	// Parse as raw map to support merge-patch semantics
 	var body map[string]interface{}
@@ -65,7 +51,7 @@ func (s *Server) updateSensorHandler(c *gin.Context) {
 	}
 
 	// Load existing sensor so partial updates (e.g. retention_hours only) don't clobber other fields.
-	existing, err := s.sensorService.ServiceGetSensorById(ctx, idInt)
+	existing, err := s.sensorService.ServiceGetSensorById(ctx, id)
 	if err != nil {
 		c.IndentedJSON(http.StatusNotFound, gin.H{"message": "Sensor not found", "error": err.Error()})
 		return
@@ -136,15 +122,10 @@ func (s *Server) updateSensorHandler(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, gin.H{"message": "Sensor updated successfully"})
 }
 
-func (s *Server) deleteSensorHandler(c *gin.Context) {
+// DeleteSensorByName implements gen.ServerInterface.
+func (s *Server) DeleteSensorByName(c *gin.Context, name string) {
 	ctx := c.Request.Context()
-	sensorName := c.Param("name")
-
-	if sensorName == "" {
-		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Sensor name is required"})
-		return
-	}
-	err := s.sensorService.ServiceDeleteSensorByName(ctx, sensorName)
+	err := s.sensorService.ServiceDeleteSensorByName(ctx, name)
 	if err != nil {
 		c.IndentedJSON(http.StatusInternalServerError, gin.H{"message": "Error deleting sensor", "error": err.Error()})
 		return
@@ -152,14 +133,11 @@ func (s *Server) deleteSensorHandler(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, gin.H{"message": "Sensor deleted successfully"})
 }
 
-func (s *Server) getSensorByNameHandler(c *gin.Context) {
+// GetSensorByName implements gen.ServerInterface.
+// It returns the sensor with effective_retention_hours computed and set directly on gen.Sensor.
+func (s *Server) GetSensorByName(c *gin.Context, name string) {
 	ctx := c.Request.Context()
-	sensorName := c.Param("name")
-	if sensorName == "" {
-		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Sensor name is required"})
-		return
-	}
-	sensor, err := s.sensorService.ServiceGetSensorByName(ctx, sensorName)
+	sensor, err := s.sensorService.ServiceGetSensorByName(ctx, name)
 	if err != nil {
 		c.IndentedJSON(http.StatusInternalServerError, gin.H{"message": "Error retrieving sensor", "error": err.Error()})
 		return
@@ -169,13 +147,13 @@ func (s *Server) getSensorByNameHandler(c *gin.Context) {
 		return
 	}
 	masked := maskSensitiveConfig(*sensor)
-	c.IndentedJSON(http.StatusOK, sensorDetailResponse{
-		Sensor:                  masked,
-		EffectiveRetentionHours: computeEffectiveRetentionHours(masked),
-	})
+	effectiveHours := computeEffectiveRetentionHours(masked)
+	masked.EffectiveRetentionHours = &effectiveHours
+	c.IndentedJSON(http.StatusOK, masked)
 }
 
-func (s *Server) getAllSensorsHandler(c *gin.Context) {
+// GetAllSensors implements gen.ServerInterface.
+func (s *Server) GetAllSensors(c *gin.Context) {
 	ctx := c.Request.Context()
 	sensors, err := s.sensorService.ServiceGetAllSensors(ctx)
 	if err != nil {
@@ -185,13 +163,9 @@ func (s *Server) getAllSensorsHandler(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, maskSensitiveConfigSlice(sensors))
 }
 
-func (s *Server) getSensorsByDriverHandler(c *gin.Context) {
+// GetSensorsByDriver implements gen.ServerInterface.
+func (s *Server) GetSensorsByDriver(c *gin.Context, driver string) {
 	ctx := c.Request.Context()
-	driver := c.Param("driver")
-	if driver == "" {
-		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Sensor driver is required"})
-		return
-	}
 	sensors, err := s.sensorService.ServiceGetSensorsByDriver(ctx, driver)
 	if err != nil {
 		c.IndentedJSON(http.StatusInternalServerError, gin.H{"message": "Error retrieving sensors by driver", "error": err.Error()})
@@ -200,14 +174,10 @@ func (s *Server) getSensorsByDriverHandler(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, maskSensitiveConfigSlice(sensors))
 }
 
-func (s *Server) sensorExistsHandler(c *gin.Context) {
+// SensorExists implements gen.ServerInterface.
+func (s *Server) SensorExists(c *gin.Context, name string) {
 	ctx := c.Request.Context()
-	sensorName := c.Param("name")
-	if sensorName == "" {
-		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Sensor name is required"})
-		return
-	}
-	exists, err := s.sensorService.ServiceSensorExists(ctx, sensorName)
+	exists, err := s.sensorService.ServiceSensorExists(ctx, name)
 	if err != nil {
 		c.IndentedJSON(http.StatusInternalServerError, gin.H{"message": "Error checking sensor existence", "error": err.Error()})
 		return
@@ -219,7 +189,8 @@ func (s *Server) sensorExistsHandler(c *gin.Context) {
 	}
 }
 
-func (s *Server) collectAndStoreAllSensorReadingsHandler(c *gin.Context) {
+// CollectAllSensorReadings implements gen.ServerInterface.
+func (s *Server) CollectAllSensorReadings(c *gin.Context) {
 	ctx := c.Request.Context()
 	err := s.sensorService.ServiceCollectAndStoreAllSensorReadings(ctx)
 	if err != nil {
@@ -229,14 +200,9 @@ func (s *Server) collectAndStoreAllSensorReadingsHandler(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, gin.H{"message": "Sensor readings collected and stored successfully"})
 }
 
-func (s *Server) collectFromSensorByNameHandler(c *gin.Context) {
+// CollectFromSensor implements gen.ServerInterface.
+func (s *Server) CollectFromSensor(c *gin.Context, sensorName string) {
 	ctx := c.Request.Context()
-	sensorName := c.Param("sensorName")
-	if sensorName == "" {
-		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Sensor name is required"})
-		return
-	}
-
 	err := s.sensorService.ServiceCollectFromSensorByName(ctx, sensorName)
 	if err != nil {
 		c.IndentedJSON(http.StatusInternalServerError, gin.H{"message": "Error collecting from sensor", "error": err.Error()})
@@ -245,13 +211,9 @@ func (s *Server) collectFromSensorByNameHandler(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, gin.H{"message": "Sensor reading collected successfully"})
 }
 
-func (s *Server) disableSensorHandler(c *gin.Context) {
+// DisableSensor implements gen.ServerInterface.
+func (s *Server) DisableSensor(c *gin.Context, sensorName string) {
 	ctx := c.Request.Context()
-	sensorName := c.Param("sensorName")
-	if sensorName == "" {
-		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Sensor name is required"})
-		return
-	}
 	err := s.sensorService.ServiceSetEnabledSensorByName(ctx, sensorName, false)
 	if err != nil {
 		c.IndentedJSON(http.StatusInternalServerError, gin.H{"message": "Error disabling sensor", "error": err.Error()})
@@ -260,13 +222,9 @@ func (s *Server) disableSensorHandler(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, gin.H{"message": "Sensor disabled successfully"})
 }
 
-func (s *Server) enableSensorHandler(c *gin.Context) {
+// EnableSensor implements gen.ServerInterface.
+func (s *Server) EnableSensor(c *gin.Context, sensorName string) {
 	ctx := c.Request.Context()
-	sensorName := c.Param("sensorName")
-	if sensorName == "" {
-		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Sensor name is required"})
-		return
-	}
 	err := s.sensorService.ServiceSetEnabledSensorByName(ctx, sensorName, true)
 	if err != nil {
 		c.IndentedJSON(http.StatusInternalServerError, gin.H{"message": "Error enabling sensor", "error": err.Error()})
@@ -275,7 +233,8 @@ func (s *Server) enableSensorHandler(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, gin.H{"message": "Sensor enabled successfully"})
 }
 
-func (s *Server) allSensorsWebSocketHandler(c *gin.Context) {
+// SubscribeAllSensors implements gen.ServerInterface.
+func (s *Server) SubscribeAllSensors(c *gin.Context) {
 	ctx := c.Request.Context()
 	topic := "sensors:all"
 	createPushWebSocket(c, topic)
@@ -295,13 +254,9 @@ func (s *Server) allSensorsWebSocketHandler(c *gin.Context) {
 	ws.BroadcastToTopic(topic, active)
 }
 
-func (s *Server) sensorWebSocketHandler(c *gin.Context) {
+// SubscribeSensorsByDriver implements gen.ServerInterface.
+func (s *Server) SubscribeSensorsByDriver(c *gin.Context, driver string) {
 	ctx := c.Request.Context()
-	driver := c.Param("driver")
-	if driver == "" {
-		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Sensor driver is required"})
-		return
-	}
 
 	topic := "sensors:" + driver
 	createPushWebSocket(c, topic)
@@ -315,22 +270,21 @@ func (s *Server) sensorWebSocketHandler(c *gin.Context) {
 	ws.BroadcastToTopic(topic, sensors)
 }
 
-func (s *Server) getSensorHealthHistoryByNameHandler(c *gin.Context) {
+// GetSensorHealthHistoryByName implements gen.ServerInterface.
+// Limit defaults to the app config value when params.Limit is nil.
+func (s *Server) GetSensorHealthHistoryByName(c *gin.Context, name string, params gen.GetSensorHealthHistoryByNameParams) {
 	ctx := c.Request.Context()
-	sensorName := c.Param("name")
-	if sensorName == "" {
-		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Sensor name is required"})
-		return
+
+	limit := appProps.AppConfig.HealthHistoryDefaultResponseNumber
+	if params.Limit != nil {
+		if *params.Limit <= 0 {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid limit parameter"})
+			return
+		}
+		limit = *params.Limit
 	}
 
-	limitStr := c.DefaultQuery("limit", strconv.Itoa(appProps.AppConfig.HealthHistoryDefaultResponseNumber))
-	limit, err := strconv.Atoi(limitStr)
-	if err != nil || limit <= 0 {
-		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid limit parameter"})
-		return
-	}
-
-	healthHistory, err := s.sensorService.ServiceGetSensorHealthHistoryByName(ctx, sensorName, limit)
+	healthHistory, err := s.sensorService.ServiceGetSensorHealthHistoryByName(ctx, name, limit)
 	if err != nil {
 		c.IndentedJSON(http.StatusInternalServerError, gin.H{"message": "Error retrieving sensor health history", "error": err.Error()})
 		return
@@ -338,7 +292,8 @@ func (s *Server) getSensorHealthHistoryByNameHandler(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, healthHistory)
 }
 
-func (s *Server) totalReadingsPerSensorHandler(c *gin.Context) {
+// GetTotalReadingsPerSensor implements gen.ServerInterface.
+func (s *Server) GetTotalReadingsPerSensor(c *gin.Context) {
 	ctx := c.Request.Context()
 	stats, err := s.sensorService.ServiceGetTotalReadingsForEachSensor(ctx)
 	if err != nil {
@@ -383,14 +338,10 @@ func maskSensitiveConfigSlice(sensors []gen.Sensor) []gen.Sensor {
 	return result
 }
 
-func (s *Server) getSensorsByStatusHandler(c *gin.Context) {
+// GetSensorsByStatus implements gen.ServerInterface.
+func (s *Server) GetSensorsByStatus(c *gin.Context, status gen.GetSensorsByStatusParamsStatus) {
 	ctx := c.Request.Context()
-	status := c.Param("status")
-	if status == "" {
-		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Status is required"})
-		return
-	}
-	sensors, err := s.sensorService.ServiceGetSensorsByStatus(ctx, status)
+	sensors, err := s.sensorService.ServiceGetSensorsByStatus(ctx, string(status))
 	if err != nil {
 		c.IndentedJSON(http.StatusInternalServerError, gin.H{"message": "Error retrieving sensors by status", "error": err.Error()})
 		return
@@ -401,13 +352,9 @@ func (s *Server) getSensorsByStatusHandler(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, maskSensitiveConfigSlice(sensors))
 }
 
-func (s *Server) approveSensorHandler(c *gin.Context) {
+// ApproveSensor implements gen.ServerInterface.
+func (s *Server) ApproveSensor(c *gin.Context, id int) {
 	ctx := c.Request.Context()
-	id, err := strconv.Atoi(c.Param("id"))
-	if err != nil {
-		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid sensor ID"})
-		return
-	}
 	if err := s.sensorService.ServiceApproveSensor(ctx, id); err != nil {
 		c.IndentedJSON(http.StatusInternalServerError, gin.H{"message": err.Error()})
 		return
@@ -415,13 +362,9 @@ func (s *Server) approveSensorHandler(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, gin.H{"message": "Sensor approved"})
 }
 
-func (s *Server) dismissSensorHandler(c *gin.Context) {
+// DismissSensor implements gen.ServerInterface.
+func (s *Server) DismissSensor(c *gin.Context, id int) {
 	ctx := c.Request.Context()
-	id, err := strconv.Atoi(c.Param("id"))
-	if err != nil {
-		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid sensor ID"})
-		return
-	}
 	if err := s.sensorService.ServiceDismissSensor(ctx, id); err != nil {
 		c.IndentedJSON(http.StatusInternalServerError, gin.H{"message": err.Error()})
 		return

--- a/sensor_hub/api/sensor_api_test.go
+++ b/sensor_hub/api/sensor_api_test.go
@@ -9,6 +9,7 @@ import (
 	gen "example/sensorHub/gen"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -31,7 +32,7 @@ func setupSensorRouter() (*gin.Engine, *gin.RouterGroup, *Server, *MockSensorSer
 
 func TestAddSensorHandler(t *testing.T) {
 	router, api, s, mockService := setupSensorRouter()
-	api.POST("/sensors", s.addSensorHandler)
+	api.POST("/sensors", s.AddSensor)
 
 	sensor := gen.Sensor{Name: "test-sensor", SensorDriver: "sensor-hub-http-temperature", Config: map[string]string{"url": "http://localhost:8080"}}
 	jsonBody, _ := json.Marshal(sensor)
@@ -47,7 +48,7 @@ func TestAddSensorHandler(t *testing.T) {
 
 func TestGetAllSensorsHandler(t *testing.T) {
 	router, api, s, mockService := setupSensorRouter()
-	api.GET("/sensors", s.getAllSensorsHandler)
+	api.GET("/sensors", s.GetAllSensors)
 
 	mockService.On("ServiceGetAllSensors", mock.Anything).Return([]gen.Sensor{{Name: "s1"}}, nil)
 
@@ -61,7 +62,9 @@ func TestGetAllSensorsHandler(t *testing.T) {
 
 func TestGetSensorByNameHandler(t *testing.T) {
 	router, api, s, mockService := setupSensorRouter()
-	api.GET("/sensors/:name", s.getSensorByNameHandler)
+	api.GET("/sensors/:name", func(c *gin.Context) {
+		s.GetSensorByName(c, c.Param("name"))
+	})
 
 	mockService.On("ServiceGetSensorByName", mock.Anything, "s1").Return(&gen.Sensor{Name: "s1"}, nil)
 
@@ -71,11 +74,19 @@ func TestGetSensorByNameHandler(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Contains(t, w.Body.String(), "s1")
+	assert.Contains(t, w.Body.String(), "effective_retention_hours")
 }
 
 func TestUpdateSensorHandler(t *testing.T) {
 	router, api, s, mockService := setupSensorRouter()
-	api.PUT("/sensors/:id", s.updateSensorHandler)
+	api.PUT("/sensors/:id", func(c *gin.Context) {
+		var id int
+		if _, err := fmt.Sscan(c.Param("id"), &id); err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid sensor ID"})
+			return
+		}
+		s.UpdateSensorById(c, id)
+	})
 
 	existing := gen.Sensor{Id: 1, Name: "s1", SensorDriver: "sensor-hub-http-temperature", Config: map[string]string{"url": "http://localhost:8080"}, Enabled: true}
 	update := map[string]interface{}{"name": "s1-updated", "sensor_driver": "sensor-hub-http-temperature", "config": map[string]interface{}{"url": "http://localhost:8080"}}
@@ -96,7 +107,9 @@ func TestUpdateSensorHandler(t *testing.T) {
 
 func TestDeleteSensorHandler(t *testing.T) {
 	router, api, s, mockService := setupSensorRouter()
-	api.DELETE("/sensors/:name", s.deleteSensorHandler)
+	api.DELETE("/sensors/:name", func(c *gin.Context) {
+		s.DeleteSensorByName(c, c.Param("name"))
+	})
 
 	mockService.On("ServiceDeleteSensorByName", mock.Anything, "s1").Return(nil)
 
@@ -109,7 +122,7 @@ func TestDeleteSensorHandler(t *testing.T) {
 
 func TestCollectAndStoreAllSensorReadingsHandler(t *testing.T) {
 	router, api, s, mockService := setupSensorRouter()
-	api.POST("/sensors/collect", s.collectAndStoreAllSensorReadingsHandler)
+	api.POST("/sensors/collect", s.CollectAllSensorReadings)
 
 	mockService.On("ServiceCollectAndStoreAllSensorReadings", mock.Anything).Return(nil)
 
@@ -122,7 +135,9 @@ func TestCollectAndStoreAllSensorReadingsHandler(t *testing.T) {
 
 func TestCollectFromSensorByNameHandler(t *testing.T) {
 	router, api, s, mockService := setupSensorRouter()
-	api.POST("/sensors/:sensorName/collect", s.collectFromSensorByNameHandler)
+	api.POST("/sensors/:sensorName/collect", func(c *gin.Context) {
+		s.CollectFromSensor(c, c.Param("sensorName"))
+	})
 
 	mockService.On("ServiceCollectFromSensorByName", mock.Anything, "s1").Return(nil)
 
@@ -135,7 +150,9 @@ func TestCollectFromSensorByNameHandler(t *testing.T) {
 
 func TestEnableSensorHandler(t *testing.T) {
 	router, api, s, mockService := setupSensorRouter()
-	api.POST("/sensors/:sensorName/enable", s.enableSensorHandler)
+	api.POST("/sensors/:sensorName/enable", func(c *gin.Context) {
+		s.EnableSensor(c, c.Param("sensorName"))
+	})
 
 	mockService.On("ServiceSetEnabledSensorByName", mock.Anything, "s1", true).Return(nil)
 
@@ -148,7 +165,9 @@ func TestEnableSensorHandler(t *testing.T) {
 
 func TestDisableSensorHandler(t *testing.T) {
 	router, api, s, mockService := setupSensorRouter()
-	api.POST("/sensors/:sensorName/disable", s.disableSensorHandler)
+	api.POST("/sensors/:sensorName/disable", func(c *gin.Context) {
+		s.DisableSensor(c, c.Param("sensorName"))
+	})
 
 	mockService.On("ServiceSetEnabledSensorByName", mock.Anything, "s1", false).Return(nil)
 
@@ -161,7 +180,7 @@ func TestDisableSensorHandler(t *testing.T) {
 
 func TestTotalReadingsPerSensorHandler(t *testing.T) {
 	router, api, s, mockService := setupSensorRouter()
-	api.GET("/sensors/readings/total", s.totalReadingsPerSensorHandler)
+	api.GET("/sensors/readings/total", s.GetTotalReadingsPerSensor)
 
 	mockService.On("ServiceGetTotalReadingsForEachSensor", mock.Anything).Return(map[string]int{"s1": 10}, nil)
 
@@ -175,7 +194,9 @@ func TestTotalReadingsPerSensorHandler(t *testing.T) {
 
 func TestGetSensorsByDriverHandler(t *testing.T) {
 	router, api, s, mockService := setupSensorRouter()
-	api.GET("/sensors/driver/:driver", s.getSensorsByDriverHandler)
+	api.GET("/sensors/driver/:driver", func(c *gin.Context) {
+		s.GetSensorsByDriver(c, c.Param("driver"))
+	})
 
 	mockService.On("ServiceGetSensorsByDriver", mock.Anything, "sensor-hub-http-temperature").Return([]gen.Sensor{{Name: "s1"}}, nil)
 
@@ -189,7 +210,9 @@ func TestGetSensorsByDriverHandler(t *testing.T) {
 
 func TestSensorExistsHandler(t *testing.T) {
 	router, api, s, mockService := setupSensorRouter()
-	api.HEAD("/sensors/:name", s.sensorExistsHandler)
+	api.HEAD("/sensors/:name", func(c *gin.Context) {
+		s.SensorExists(c, c.Param("name"))
+	})
 
 	mockService.On("ServiceSensorExists", mock.Anything, "s1").Return(true, nil)
 
@@ -202,7 +225,18 @@ func TestSensorExistsHandler(t *testing.T) {
 
 func TestGetSensorHealthHistoryByNameHandler(t *testing.T) {
 	router, api, s, mockService := setupSensorRouter()
-	api.GET("/sensors/:name/health", s.getSensorHealthHistoryByNameHandler)
+	api.GET("/sensors/:name/health", func(c *gin.Context) {
+		var params gen.GetSensorHealthHistoryByNameParams
+		if limitStr := c.Query("limit"); limitStr != "" {
+			limit, err := strconv.Atoi(limitStr)
+			if err != nil || limit <= 0 {
+				c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid limit parameter"})
+				return
+			}
+			params.Limit = &limit
+		}
+		s.GetSensorHealthHistoryByName(c, c.Param("name"), params)
+	})
 
 	mockService.On("ServiceGetSensorHealthHistoryByName", mock.Anything, "s1", 10).Return([]gen.SensorHealthHistory{}, nil)
 
@@ -215,7 +249,7 @@ func TestGetSensorHealthHistoryByNameHandler(t *testing.T) {
 
 func TestAddSensorHandler_InvalidJSON(t *testing.T) {
 	router, api, s, _ := setupSensorRouter()
-	api.POST("/sensors", s.addSensorHandler)
+	api.POST("/sensors", s.AddSensor)
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/sensors", bytes.NewBufferString("invalid"))
@@ -226,7 +260,7 @@ func TestAddSensorHandler_InvalidJSON(t *testing.T) {
 
 func TestAddSensorHandler_ServiceError(t *testing.T) {
 	router, api, s, mockService := setupSensorRouter()
-	api.POST("/sensors", s.addSensorHandler)
+	api.POST("/sensors", s.AddSensor)
 
 	sensor := gen.Sensor{Name: "test-sensor", SensorDriver: "sensor-hub-http-temperature", Config: map[string]string{"url": "http://localhost:8080"}}
 	jsonBody, _ := json.Marshal(sensor)
@@ -242,7 +276,9 @@ func TestAddSensorHandler_ServiceError(t *testing.T) {
 
 func TestGetSensorByNameHandler_NotFound(t *testing.T) {
 	router, api, s, mockService := setupSensorRouter()
-	api.GET("/sensors/:name", s.getSensorByNameHandler)
+	api.GET("/sensors/:name", func(c *gin.Context) {
+		s.GetSensorByName(c, c.Param("name"))
+	})
 
 	mockService.On("ServiceGetSensorByName", mock.Anything, "notfound").Return((*gen.Sensor)(nil), nil)
 
@@ -255,7 +291,9 @@ func TestGetSensorByNameHandler_NotFound(t *testing.T) {
 
 func TestGetSensorByNameHandler_ServiceError(t *testing.T) {
 	router, api, s, mockService := setupSensorRouter()
-	api.GET("/sensors/:name", s.getSensorByNameHandler)
+	api.GET("/sensors/:name", func(c *gin.Context) {
+		s.GetSensorByName(c, c.Param("name"))
+	})
 
 	mockService.On("ServiceGetSensorByName", mock.Anything, "s1").Return((*gen.Sensor)(nil), errors.New("db error"))
 
@@ -268,7 +306,14 @@ func TestGetSensorByNameHandler_ServiceError(t *testing.T) {
 
 func TestUpdateSensorHandler_InvalidID(t *testing.T) {
 	router, api, s, _ := setupSensorRouter()
-	api.PUT("/sensors/:id", s.updateSensorHandler)
+	api.PUT("/sensors/:id", func(c *gin.Context) {
+		var id int
+		if _, err := fmt.Sscan(c.Param("id"), &id); err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid sensor ID"})
+			return
+		}
+		s.UpdateSensorById(c, id)
+	})
 
 	sensor := gen.Sensor{Name: "s1-updated", SensorDriver: "sensor-hub-http-temperature", Config: map[string]string{"url": "http://localhost:8080"}}
 	jsonBody, _ := json.Marshal(sensor)
@@ -282,7 +327,14 @@ func TestUpdateSensorHandler_InvalidID(t *testing.T) {
 
 func TestUpdateSensorHandler_InvalidJSON(t *testing.T) {
 	router, api, s, _ := setupSensorRouter()
-	api.PUT("/sensors/:id", s.updateSensorHandler)
+	api.PUT("/sensors/:id", func(c *gin.Context) {
+		var id int
+		if _, err := fmt.Sscan(c.Param("id"), &id); err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid sensor ID"})
+			return
+		}
+		s.UpdateSensorById(c, id)
+	})
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("PUT", "/api/sensors/1", bytes.NewBufferString("invalid"))
@@ -293,7 +345,14 @@ func TestUpdateSensorHandler_InvalidJSON(t *testing.T) {
 
 func TestUpdateSensorHandler_ServiceError(t *testing.T) {
 	router, api, s, mockService := setupSensorRouter()
-	api.PUT("/sensors/:id", s.updateSensorHandler)
+	api.PUT("/sensors/:id", func(c *gin.Context) {
+		var id int
+		if _, err := fmt.Sscan(c.Param("id"), &id); err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid sensor ID"})
+			return
+		}
+		s.UpdateSensorById(c, id)
+	})
 
 	existing := gen.Sensor{Id: 1, Name: "s1", SensorDriver: "sensor-hub-http-temperature", Config: map[string]string{"url": "http://localhost:8080"}}
 	update := map[string]interface{}{"name": "s1-updated", "sensor_driver": "sensor-hub-http-temperature", "config": map[string]interface{}{"url": "http://localhost:8080"}}
@@ -314,7 +373,9 @@ func TestUpdateSensorHandler_ServiceError(t *testing.T) {
 
 func TestDeleteSensorHandler_ServiceError(t *testing.T) {
 	router, api, s, mockService := setupSensorRouter()
-	api.DELETE("/sensors/:name", s.deleteSensorHandler)
+	api.DELETE("/sensors/:name", func(c *gin.Context) {
+		s.DeleteSensorByName(c, c.Param("name"))
+	})
 
 	mockService.On("ServiceDeleteSensorByName", mock.Anything, "s1").Return(errors.New("db error"))
 
@@ -327,7 +388,7 @@ func TestDeleteSensorHandler_ServiceError(t *testing.T) {
 
 func TestGetAllSensorsHandler_ServiceError(t *testing.T) {
 	router, api, s, mockService := setupSensorRouter()
-	api.GET("/sensors", s.getAllSensorsHandler)
+	api.GET("/sensors", s.GetAllSensors)
 
 	mockService.On("ServiceGetAllSensors", mock.Anything).Return([]gen.Sensor{}, errors.New("db error"))
 
@@ -340,7 +401,9 @@ func TestGetAllSensorsHandler_ServiceError(t *testing.T) {
 
 func TestGetSensorsByDriverHandler_ServiceError(t *testing.T) {
 	router, api, s, mockService := setupSensorRouter()
-	api.GET("/sensors/driver/:driver", s.getSensorsByDriverHandler)
+	api.GET("/sensors/driver/:driver", func(c *gin.Context) {
+		s.GetSensorsByDriver(c, c.Param("driver"))
+	})
 
 	mockService.On("ServiceGetSensorsByDriver", mock.Anything, "sensor-hub-http-temperature").Return([]gen.Sensor{}, errors.New("db error"))
 
@@ -353,7 +416,9 @@ func TestGetSensorsByDriverHandler_ServiceError(t *testing.T) {
 
 func TestSensorExistsHandler_NotFound(t *testing.T) {
 	router, api, s, mockService := setupSensorRouter()
-	api.HEAD("/sensors/:name", s.sensorExistsHandler)
+	api.HEAD("/sensors/:name", func(c *gin.Context) {
+		s.SensorExists(c, c.Param("name"))
+	})
 
 	mockService.On("ServiceSensorExists", mock.Anything, "notfound").Return(false, nil)
 
@@ -366,7 +431,9 @@ func TestSensorExistsHandler_NotFound(t *testing.T) {
 
 func TestSensorExistsHandler_ServiceError(t *testing.T) {
 	router, api, s, mockService := setupSensorRouter()
-	api.HEAD("/sensors/:name", s.sensorExistsHandler)
+	api.HEAD("/sensors/:name", func(c *gin.Context) {
+		s.SensorExists(c, c.Param("name"))
+	})
 
 	mockService.On("ServiceSensorExists", mock.Anything, "s1").Return(false, errors.New("db error"))
 
@@ -379,7 +446,7 @@ func TestSensorExistsHandler_ServiceError(t *testing.T) {
 
 func TestCollectAndStoreAllSensorReadingsHandler_ServiceError(t *testing.T) {
 	router, api, s, mockService := setupSensorRouter()
-	api.POST("/sensors/collect", s.collectAndStoreAllSensorReadingsHandler)
+	api.POST("/sensors/collect", s.CollectAllSensorReadings)
 
 	mockService.On("ServiceCollectAndStoreAllSensorReadings", mock.Anything).Return(errors.New("collection error"))
 
@@ -392,7 +459,9 @@ func TestCollectAndStoreAllSensorReadingsHandler_ServiceError(t *testing.T) {
 
 func TestCollectFromSensorByNameHandler_ServiceError(t *testing.T) {
 	router, api, s, mockService := setupSensorRouter()
-	api.POST("/sensors/:sensorName/collect", s.collectFromSensorByNameHandler)
+	api.POST("/sensors/:sensorName/collect", func(c *gin.Context) {
+		s.CollectFromSensor(c, c.Param("sensorName"))
+	})
 
 	mockService.On("ServiceCollectFromSensorByName", mock.Anything, "s1").Return(errors.New("sensor offline"))
 
@@ -405,7 +474,9 @@ func TestCollectFromSensorByNameHandler_ServiceError(t *testing.T) {
 
 func TestEnableSensorHandler_ServiceError(t *testing.T) {
 	router, api, s, mockService := setupSensorRouter()
-	api.POST("/sensors/:sensorName/enable", s.enableSensorHandler)
+	api.POST("/sensors/:sensorName/enable", func(c *gin.Context) {
+		s.EnableSensor(c, c.Param("sensorName"))
+	})
 
 	mockService.On("ServiceSetEnabledSensorByName", mock.Anything, "s1", true).Return(errors.New("db error"))
 
@@ -418,7 +489,9 @@ func TestEnableSensorHandler_ServiceError(t *testing.T) {
 
 func TestDisableSensorHandler_ServiceError(t *testing.T) {
 	router, api, s, mockService := setupSensorRouter()
-	api.POST("/sensors/:sensorName/disable", s.disableSensorHandler)
+	api.POST("/sensors/:sensorName/disable", func(c *gin.Context) {
+		s.DisableSensor(c, c.Param("sensorName"))
+	})
 
 	mockService.On("ServiceSetEnabledSensorByName", mock.Anything, "s1", false).Return(errors.New("db error"))
 
@@ -431,7 +504,7 @@ func TestDisableSensorHandler_ServiceError(t *testing.T) {
 
 func TestTotalReadingsPerSensorHandler_ServiceError(t *testing.T) {
 	router, api, s, mockService := setupSensorRouter()
-	api.GET("/sensors/readings/total", s.totalReadingsPerSensorHandler)
+	api.GET("/sensors/readings/total", s.GetTotalReadingsPerSensor)
 
 	mockService.On("ServiceGetTotalReadingsForEachSensor", mock.Anything).Return(map[string]int{}, errors.New("db error"))
 
@@ -444,7 +517,18 @@ func TestTotalReadingsPerSensorHandler_ServiceError(t *testing.T) {
 
 func TestGetSensorHealthHistoryByNameHandler_InvalidLimit(t *testing.T) {
 	router, api, s, _ := setupSensorRouter()
-	api.GET("/sensors/:name/health", s.getSensorHealthHistoryByNameHandler)
+	api.GET("/sensors/:name/health", func(c *gin.Context) {
+		var params gen.GetSensorHealthHistoryByNameParams
+		if limitStr := c.Query("limit"); limitStr != "" {
+			limit, err := strconv.Atoi(limitStr)
+			if err != nil || limit <= 0 {
+				c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid limit parameter"})
+				return
+			}
+			params.Limit = &limit
+		}
+		s.GetSensorHealthHistoryByName(c, c.Param("name"), params)
+	})
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/sensors/s1/health?limit=invalid", nil)
@@ -455,7 +539,18 @@ func TestGetSensorHealthHistoryByNameHandler_InvalidLimit(t *testing.T) {
 
 func TestGetSensorHealthHistoryByNameHandler_ServiceError(t *testing.T) {
 	router, api, s, mockService := setupSensorRouter()
-	api.GET("/sensors/:name/health", s.getSensorHealthHistoryByNameHandler)
+	api.GET("/sensors/:name/health", func(c *gin.Context) {
+		var params gen.GetSensorHealthHistoryByNameParams
+		if limitStr := c.Query("limit"); limitStr != "" {
+			limit, err := strconv.Atoi(limitStr)
+			if err != nil || limit <= 0 {
+				c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid limit parameter"})
+				return
+			}
+			params.Limit = &limit
+		}
+		s.GetSensorHealthHistoryByName(c, c.Param("name"), params)
+	})
 
 	mockService.On("ServiceGetSensorHealthHistoryByName", mock.Anything, "s1", 10).Return([]gen.SensorHealthHistory{}, errors.New("db error"))
 
@@ -472,7 +567,9 @@ func TestGetSensorHealthHistoryByNameHandler_ServiceError(t *testing.T) {
 
 func TestGetSensorsByStatusHandler(t *testing.T) {
 	router, api, s, mockService := setupSensorRouter()
-	api.GET("/sensors/status/:status", s.getSensorsByStatusHandler)
+	api.GET("/sensors/status/:status", func(c *gin.Context) {
+		s.GetSensorsByStatus(c, gen.GetSensorsByStatusParamsStatus(c.Param("status")))
+	})
 
 	mockService.On("ServiceGetSensorsByStatus", mock.Anything, "pending").Return([]gen.Sensor{
 		{Id: 1, Name: "auto-sensor", Status: "pending"},
@@ -488,7 +585,9 @@ func TestGetSensorsByStatusHandler(t *testing.T) {
 
 func TestGetSensorsByStatusHandler_Empty(t *testing.T) {
 	router, api, s, mockService := setupSensorRouter()
-	api.GET("/sensors/status/:status", s.getSensorsByStatusHandler)
+	api.GET("/sensors/status/:status", func(c *gin.Context) {
+		s.GetSensorsByStatus(c, gen.GetSensorsByStatusParamsStatus(c.Param("status")))
+	})
 
 	mockService.On("ServiceGetSensorsByStatus", mock.Anything, "pending").Return(nil, nil)
 
@@ -502,7 +601,9 @@ func TestGetSensorsByStatusHandler_Empty(t *testing.T) {
 
 func TestGetSensorsByStatusHandler_Error(t *testing.T) {
 	router, api, s, mockService := setupSensorRouter()
-	api.GET("/sensors/status/:status", s.getSensorsByStatusHandler)
+	api.GET("/sensors/status/:status", func(c *gin.Context) {
+		s.GetSensorsByStatus(c, gen.GetSensorsByStatusParamsStatus(c.Param("status")))
+	})
 
 	mockService.On("ServiceGetSensorsByStatus", mock.Anything, "pending").Return(nil, errors.New("db error"))
 
@@ -515,7 +616,14 @@ func TestGetSensorsByStatusHandler_Error(t *testing.T) {
 
 func TestApproveSensorHandler(t *testing.T) {
 	router, api, s, mockService := setupSensorRouter()
-	api.POST("/sensors/approve/:id", s.approveSensorHandler)
+	api.POST("/sensors/approve/:id", func(c *gin.Context) {
+		var id int
+		if _, err := fmt.Sscan(c.Param("id"), &id); err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid sensor ID"})
+			return
+		}
+		s.ApproveSensor(c, id)
+	})
 
 	mockService.On("ServiceApproveSensor", mock.Anything, 1).Return(nil)
 
@@ -529,7 +637,14 @@ func TestApproveSensorHandler(t *testing.T) {
 
 func TestApproveSensorHandler_InvalidID(t *testing.T) {
 	router, api, s, _ := setupSensorRouter()
-	api.POST("/sensors/approve/:id", s.approveSensorHandler)
+	api.POST("/sensors/approve/:id", func(c *gin.Context) {
+		var id int
+		if _, err := fmt.Sscan(c.Param("id"), &id); err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid sensor ID"})
+			return
+		}
+		s.ApproveSensor(c, id)
+	})
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/sensors/approve/abc", nil)
@@ -540,7 +655,14 @@ func TestApproveSensorHandler_InvalidID(t *testing.T) {
 
 func TestApproveSensorHandler_Error(t *testing.T) {
 	router, api, s, mockService := setupSensorRouter()
-	api.POST("/sensors/approve/:id", s.approveSensorHandler)
+	api.POST("/sensors/approve/:id", func(c *gin.Context) {
+		var id int
+		if _, err := fmt.Sscan(c.Param("id"), &id); err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid sensor ID"})
+			return
+		}
+		s.ApproveSensor(c, id)
+	})
 
 	mockService.On("ServiceApproveSensor", mock.Anything, 1).Return(errors.New("not found"))
 
@@ -553,7 +675,14 @@ func TestApproveSensorHandler_Error(t *testing.T) {
 
 func TestDismissSensorHandler(t *testing.T) {
 	router, api, s, mockService := setupSensorRouter()
-	api.POST("/sensors/dismiss/:id", s.dismissSensorHandler)
+	api.POST("/sensors/dismiss/:id", func(c *gin.Context) {
+		var id int
+		if _, err := fmt.Sscan(c.Param("id"), &id); err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid sensor ID"})
+			return
+		}
+		s.DismissSensor(c, id)
+	})
 
 	mockService.On("ServiceDismissSensor", mock.Anything, 1).Return(nil)
 
@@ -567,7 +696,14 @@ func TestDismissSensorHandler(t *testing.T) {
 
 func TestDismissSensorHandler_InvalidID(t *testing.T) {
 	router, api, s, _ := setupSensorRouter()
-	api.POST("/sensors/dismiss/:id", s.dismissSensorHandler)
+	api.POST("/sensors/dismiss/:id", func(c *gin.Context) {
+		var id int
+		if _, err := fmt.Sscan(c.Param("id"), &id); err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid sensor ID"})
+			return
+		}
+		s.DismissSensor(c, id)
+	})
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/sensors/dismiss/abc", nil)
@@ -578,7 +714,14 @@ func TestDismissSensorHandler_InvalidID(t *testing.T) {
 
 func TestDismissSensorHandler_Error(t *testing.T) {
 	router, api, s, mockService := setupSensorRouter()
-	api.POST("/sensors/dismiss/:id", s.dismissSensorHandler)
+	api.POST("/sensors/dismiss/:id", func(c *gin.Context) {
+		var id int
+		if _, err := fmt.Sscan(c.Param("id"), &id); err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid sensor ID"})
+			return
+		}
+		s.DismissSensor(c, id)
+	})
 
 	mockService.On("ServiceDismissSensor", mock.Anything, 1).Return(errors.New("not found"))
 

--- a/sensor_hub/api/sensor_routes.go
+++ b/sensor_hub/api/sensor_routes.go
@@ -3,6 +3,7 @@ package api
 import (
 	"fmt"
 	"net/http"
+	"strconv"
 
 	"example/sensorHub/api/middleware"
 	gen "example/sensorHub/gen"
@@ -13,24 +14,74 @@ import (
 func (s *Server) RegisterSensorRoutes(router gin.IRouter) {
 	sensorsGroup := router.Group("/sensors")
 	{
-		sensorsGroup.POST("", middleware.AuthRequired(), middleware.RequirePermission("manage_sensors"), s.addSensorHandler)
-		sensorsGroup.PUT("/:id", middleware.AuthRequired(), middleware.RequirePermission("manage_sensors"), s.updateSensorHandler)
-		sensorsGroup.DELETE("/:name", middleware.AuthRequired(), middleware.RequirePermission("delete_sensors"), s.deleteSensorHandler)
-		sensorsGroup.GET("/:name", middleware.AuthRequired(), middleware.RequirePermission("view_sensors"), s.getSensorByNameHandler)
-		sensorsGroup.GET("", middleware.AuthRequired(), middleware.RequirePermission("view_sensors"), s.getAllSensorsHandler)
-		sensorsGroup.GET("/driver/:driver", middleware.AuthRequired(), middleware.RequirePermission("view_sensors"), s.getSensorsByDriverHandler)
-		sensorsGroup.HEAD("/:name", middleware.AuthRequired(), middleware.RequirePermission("view_sensors"), s.sensorExistsHandler)
-		sensorsGroup.POST("/collect", middleware.AuthRequired(), middleware.RequirePermission("trigger_readings"), s.collectAndStoreAllSensorReadingsHandler)
-		sensorsGroup.POST("/collect/:sensorName", middleware.AuthRequired(), middleware.RequirePermission("trigger_readings"), s.collectFromSensorByNameHandler)
-		sensorsGroup.POST("/disable/:sensorName", middleware.AuthRequired(), middleware.RequirePermission("manage_sensors"), s.disableSensorHandler)
-		sensorsGroup.POST("/enable/:sensorName", middleware.AuthRequired(), middleware.RequirePermission("manage_sensors"), s.enableSensorHandler)
-		sensorsGroup.GET("/ws", middleware.AuthRequired(), s.allSensorsWebSocketHandler)
-		sensorsGroup.GET("/ws/:driver", middleware.AuthRequired(), s.sensorWebSocketHandler)
-		sensorsGroup.GET("/health/:name", middleware.AuthRequired(), middleware.RequirePermission("view_sensors"), s.getSensorHealthHistoryByNameHandler)
-		sensorsGroup.GET("/stats/total-readings", middleware.AuthRequired(), middleware.RequirePermission("view_sensors"), s.totalReadingsPerSensorHandler)
-		sensorsGroup.GET("/status/:status", middleware.AuthRequired(), middleware.RequirePermission("view_sensors"), s.getSensorsByStatusHandler)
-		sensorsGroup.POST("/approve/:id", middleware.AuthRequired(), middleware.RequirePermission("manage_sensors"), s.approveSensorHandler)
-		sensorsGroup.POST("/dismiss/:id", middleware.AuthRequired(), middleware.RequirePermission("manage_sensors"), s.dismissSensorHandler)
+		sensorsGroup.POST("", middleware.AuthRequired(), middleware.RequirePermission("manage_sensors"), s.AddSensor)
+		sensorsGroup.PUT("/:id", middleware.AuthRequired(), middleware.RequirePermission("manage_sensors"), func(c *gin.Context) {
+			var id int
+			if _, err := fmt.Sscan(c.Param("id"), &id); err != nil {
+				c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid sensor ID"})
+				return
+			}
+			s.UpdateSensorById(c, id)
+		})
+		sensorsGroup.DELETE("/:name", middleware.AuthRequired(), middleware.RequirePermission("delete_sensors"), func(c *gin.Context) {
+			s.DeleteSensorByName(c, c.Param("name"))
+		})
+		sensorsGroup.GET("/:name", middleware.AuthRequired(), middleware.RequirePermission("view_sensors"), func(c *gin.Context) {
+			s.GetSensorByName(c, c.Param("name"))
+		})
+		sensorsGroup.GET("", middleware.AuthRequired(), middleware.RequirePermission("view_sensors"), s.GetAllSensors)
+		sensorsGroup.GET("/driver/:driver", middleware.AuthRequired(), middleware.RequirePermission("view_sensors"), func(c *gin.Context) {
+			s.GetSensorsByDriver(c, c.Param("driver"))
+		})
+		sensorsGroup.HEAD("/:name", middleware.AuthRequired(), middleware.RequirePermission("view_sensors"), func(c *gin.Context) {
+			s.SensorExists(c, c.Param("name"))
+		})
+		sensorsGroup.POST("/collect", middleware.AuthRequired(), middleware.RequirePermission("trigger_readings"), s.CollectAllSensorReadings)
+		sensorsGroup.POST("/collect/:sensorName", middleware.AuthRequired(), middleware.RequirePermission("trigger_readings"), func(c *gin.Context) {
+			s.CollectFromSensor(c, c.Param("sensorName"))
+		})
+		sensorsGroup.POST("/disable/:sensorName", middleware.AuthRequired(), middleware.RequirePermission("manage_sensors"), func(c *gin.Context) {
+			s.DisableSensor(c, c.Param("sensorName"))
+		})
+		sensorsGroup.POST("/enable/:sensorName", middleware.AuthRequired(), middleware.RequirePermission("manage_sensors"), func(c *gin.Context) {
+			s.EnableSensor(c, c.Param("sensorName"))
+		})
+		sensorsGroup.GET("/ws", middleware.AuthRequired(), s.SubscribeAllSensors)
+		sensorsGroup.GET("/ws/:driver", middleware.AuthRequired(), func(c *gin.Context) {
+			s.SubscribeSensorsByDriver(c, c.Param("driver"))
+		})
+		sensorsGroup.GET("/health/:name", middleware.AuthRequired(), middleware.RequirePermission("view_sensors"), func(c *gin.Context) {
+			var params gen.GetSensorHealthHistoryByNameParams
+			if limitStr := c.Query("limit"); limitStr != "" {
+				limit, err := strconv.Atoi(limitStr)
+				if err != nil || limit <= 0 {
+					c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid limit parameter"})
+					return
+				}
+				params.Limit = &limit
+			}
+			s.GetSensorHealthHistoryByName(c, c.Param("name"), params)
+		})
+		sensorsGroup.GET("/stats/total-readings", middleware.AuthRequired(), middleware.RequirePermission("view_sensors"), s.GetTotalReadingsPerSensor)
+		sensorsGroup.GET("/status/:status", middleware.AuthRequired(), middleware.RequirePermission("view_sensors"), func(c *gin.Context) {
+			s.GetSensorsByStatus(c, gen.GetSensorsByStatusParamsStatus(c.Param("status")))
+		})
+		sensorsGroup.POST("/approve/:id", middleware.AuthRequired(), middleware.RequirePermission("manage_sensors"), func(c *gin.Context) {
+			var id int
+			if _, err := fmt.Sscan(c.Param("id"), &id); err != nil {
+				c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid sensor ID"})
+				return
+			}
+			s.ApproveSensor(c, id)
+		})
+		sensorsGroup.POST("/dismiss/:id", middleware.AuthRequired(), middleware.RequirePermission("manage_sensors"), func(c *gin.Context) {
+			var id int
+			if _, err := fmt.Sscan(c.Param("id"), &id); err != nil {
+				c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid sensor ID"})
+				return
+			}
+			s.DismissSensor(c, id)
+		})
 		sensorsGroup.GET("/by-id/:id/measurement-types", middleware.AuthRequired(), middleware.RequirePermission("view_sensors"), func(c *gin.Context) {
 			var id int
 			if _, err := fmt.Sscan(c.Param("id"), &id); err != nil {


### PR DESCRIPTION
Closes #36

## Summary

Migrates all sensor API handlers to implement `gen.ServerInterface`, following the same pattern established in #34 and #35.

## Changes

- **`sensor_api.go`**: Renamed all 15 sensor handlers to match `ServerInterface` method names. Removed `sensorDetailResponse` local struct (replaced by setting `gen.Sensor.EffectiveRetentionHours` directly). Removed `strconv` import (param parsing now in route closures).
- **`sensor_routes.go`**: Added closures for all parameterised routes to extract typed path/query params before dispatching to handlers. Added `strconv` import for health history limit parsing.
- **`sensor_api_test.go`**: Updated all sensor handler tests to use new method signatures and route closure patterns. Added `strconv` import for health history test closures.

## Handler groups migrated

| Group | Handlers |
|-------|----------|
| Simple renames | `GetAllSensors`, `CollectAllSensorReadings`, `GetTotalReadingsPerSensor`, `SubscribeAllSensors` |
| String path params | `DeleteSensorByName`, `GetSensorByName`, `GetSensorsByDriver`, `SensorExists`, `CollectFromSensor`, `DisableSensor`, `EnableSensor`, `SubscribeSensorsByDriver` |
| Int path params | `UpdateSensorById`, `ApproveSensor`, `DismissSensor` |
| Typed params | `GetSensorsByStatus` (enum), `GetSensorHealthHistoryByName` (query struct with optional limit) |

## Testing

- All unit tests pass: `go test ./api/`
- All 41 integration tests pass: `go test -tags integration -v -timeout 300s ./integration/`