### PR TITLE
feat(api): migrate auth/users/notifications handlers to gen.ServerInterface (#38)

### DIFF
--- a/sensor_hub/api/auth_api.go
+++ b/sensor_hub/api/auth_api.go
@@ -13,16 +13,10 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-
-
-type loginRequest struct {
-	Username string `json:"username"`
-	Password string `json:"password"`
-}
-
-func (s *Server) loginHandler(c *gin.Context) {
+// Login implements gen.ServerInterface.
+func (s *Server) Login(c *gin.Context) {
 	ctx := c.Request.Context()
-	var req loginRequest
+	var req gen.LoginRequest
 	if err := c.BindJSON(&req); err != nil {
 		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid request body"})
 		return
@@ -73,11 +67,11 @@ func (s *Server) loginHandler(c *gin.Context) {
 		Secure:   secure,
 		SameSite: http.SameSiteLaxMode,
 	})
-	// return csrf token in JSON (SPA should store it in memory and send via X-CSRF-Token header on state changes)
-	c.IndentedJSON(http.StatusOK, gin.H{"must_change_password": mustChange, "csrf_token": csrf})
+	c.IndentedJSON(http.StatusOK, gen.LoginResponse{MustChangePassword: &mustChange, CsrfToken: &csrf})
 }
 
-func (s *Server) logoutHandler(c *gin.Context) {
+// Logout implements gen.ServerInterface.
+func (s *Server) Logout(c *gin.Context) {
 	ctx := c.Request.Context()
 	cookieName := "sensor_hub_session"
 	if appProps.AppConfig != nil && appProps.AppConfig.AuthSessionCookieName != "" {
@@ -95,7 +89,8 @@ func (s *Server) logoutHandler(c *gin.Context) {
 	c.Status(http.StatusOK)
 }
 
-func (s *Server) meHandler(c *gin.Context) {
+// GetCurrentUser implements gen.ServerInterface.
+func (s *Server) GetCurrentUser(c *gin.Context) {
 	ctx := c.Request.Context()
 	u, exists := c.Get("currentUser")
 	if !exists {
@@ -113,16 +108,17 @@ func (s *Server) meHandler(c *gin.Context) {
 		cookieName = appProps.AppConfig.AuthSessionCookieName
 	}
 	token, _ := c.Cookie(cookieName)
-	csrf := ""
+	var csrfPtr *string
 	if token != "" {
 		if t, err := s.authService.GetCSRFForToken(ctx, token); err == nil {
-			csrf = t
+			csrfPtr = &t
 		}
 	}
-	c.IndentedJSON(http.StatusOK, gin.H{"user": user, "csrf_token": csrf})
+	c.IndentedJSON(http.StatusOK, gen.MeResponse{User: user, CsrfToken: csrfPtr})
 }
 
-func (s *Server) listSessionsHandler(c *gin.Context) {
+// ListSessions implements gen.ServerInterface.
+func (s *Server) ListSessions(c *gin.Context) {
 	ctx := c.Request.Context()
 	u, _ := c.Get("currentUser")
 	user := u.(*gen.User)
@@ -143,36 +139,28 @@ func (s *Server) listSessionsHandler(c *gin.Context) {
 		}
 	}
 
-	out := make([]gin.H, 0, len(sessions))
-	for _, s := range sessions {
-		out = append(out, gin.H{
-			"id":               s.Id,
-			"user_id":          s.UserId,
-			"created_at":       s.CreatedAt,
-			"expires_at":       s.ExpiresAt,
-			"last_accessed_at": s.LastAccessedAt,
-			"ip_address":       s.IpAddress,
-			"user_agent":       s.UserAgent,
-			"current":          s.Id == currentSessionId,
+	out := make([]gen.SessionInfo, 0, len(sessions))
+	for _, sess := range sessions {
+		isCurrent := sess.Id == currentSessionId
+		id := sess.Id
+		uid := sess.UserId
+		out = append(out, gen.SessionInfo{
+			Id:             &id,
+			UserId:         &uid,
+			CreatedAt:      &sess.CreatedAt,
+			ExpiresAt:      &sess.ExpiresAt,
+			LastAccessedAt: &sess.LastAccessedAt,
+			IpAddress:      &sess.IpAddress,
+			UserAgent:      &sess.UserAgent,
+			Current:        &isCurrent,
 		})
 	}
 	c.IndentedJSON(http.StatusOK, out)
 }
 
-func (s *Server) revokeSessionHandler(c *gin.Context) {
+// RevokeSession implements gen.ServerInterface.
+func (s *Server) RevokeSession(c *gin.Context, id int64) {
 	ctx := c.Request.Context()
-	idStr := c.Param("id")
-	if idStr == "" {
-		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "session id required"})
-		return
-	}
-
-	var id int64
-	_, err := fmt.Sscan(idStr, &id)
-	if err != nil {
-		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid session id"})
-		return
-	}
 
 	u, _ := c.Get("currentUser")
 	user := u.(*gen.User)

--- a/sensor_hub/api/auth_api_test.go
+++ b/sensor_hub/api/auth_api_test.go
@@ -5,10 +5,11 @@ import (
 	"encoding/json"
 	"errors"
 	db "example/sensorHub/db"
-	"example/sensorHub/service"
 	gen "example/sensorHub/gen"
+	"example/sensorHub/service"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -26,9 +27,9 @@ func setupAuthRouter() (*gin.Engine, *gin.RouterGroup, *Server, *MockAuthService
 
 func TestLoginHandler_Success(t *testing.T) {
 	router, api, s, mockService := setupAuthRouter()
-	api.POST("/auth/login", s.loginHandler)
+	api.POST("/auth/login", s.Login)
 
-	reqBody := loginRequest{Username: "user", Password: "password"}
+	reqBody := gen.LoginRequest{Username: "user", Password: "password"}
 	jsonBody, _ := json.Marshal(reqBody)
 
 	mockService.On("Login", mock.Anything, "user", "password", mock.Anything, mock.Anything).Return("token", "csrf", false, nil)
@@ -43,9 +44,9 @@ func TestLoginHandler_Success(t *testing.T) {
 
 func TestLoginHandler_InvalidCredentials(t *testing.T) {
 	router, api, s, mockService := setupAuthRouter()
-	api.POST("/auth/login", s.loginHandler)
+	api.POST("/auth/login", s.Login)
 
-	reqBody := loginRequest{Username: "user", Password: "wrong"}
+	reqBody := gen.LoginRequest{Username: "user", Password: "wrong"}
 	jsonBody, _ := json.Marshal(reqBody)
 
 	mockService.On("Login", mock.Anything, "user", "wrong", mock.Anything, mock.Anything).Return("", "", false, errors.New("invalid credentials"))
@@ -59,9 +60,9 @@ func TestLoginHandler_InvalidCredentials(t *testing.T) {
 
 func TestLoginHandler_TooManyAttempts(t *testing.T) {
 	router, api, s, mockService := setupAuthRouter()
-	api.POST("/auth/login", s.loginHandler)
+	api.POST("/auth/login", s.Login)
 
-	reqBody := loginRequest{Username: "user", Password: "password"}
+	reqBody := gen.LoginRequest{Username: "user", Password: "password"}
 	jsonBody, _ := json.Marshal(reqBody)
 
 	err := &service.TooManyAttemptsError{RetryAfterSeconds: 60}
@@ -76,7 +77,7 @@ func TestLoginHandler_TooManyAttempts(t *testing.T) {
 
 func TestLogoutHandler(t *testing.T) {
 	router, api, s, mockService := setupAuthRouter()
-	api.POST("/auth/logout", s.logoutHandler)
+	api.POST("/auth/logout", s.Logout)
 
 	mockService.On("Logout", mock.Anything, "valid-token").Return(nil)
 
@@ -90,11 +91,9 @@ func TestLogoutHandler(t *testing.T) {
 
 func TestMeHandler_Success(t *testing.T) {
 	router, api, s, mockService := setupAuthRouter()
-	// Middleware normally sets currentUser, but here we mock it or set it manually if middleware isn't used
-	// In meHandler, it expects "currentUser" in context.
 	api.GET("/auth/me", func(c *gin.Context) {
 		c.Set("currentUser", &gen.User{Id: 1, Username: "me"})
-		s.meHandler(c)
+		s.GetCurrentUser(c)
 	})
 
 	mockService.On("GetCSRFForToken", mock.Anything, "valid-token").Return("csrf-token", nil)
@@ -112,7 +111,7 @@ func TestListSessionsHandler(t *testing.T) {
 	router, api, s, mockService := setupAuthRouter()
 	api.GET("/auth/sessions", func(c *gin.Context) {
 		c.Set("currentUser", &gen.User{Id: 1})
-		s.listSessionsHandler(c)
+		s.ListSessions(c)
 	})
 
 	mockService.On("ListSessionsForUser", mock.Anything, 1).Return([]db.SessionInfo{{Id: 100}}, nil)
@@ -131,7 +130,12 @@ func TestRevokeSessionHandler_OwnSession(t *testing.T) {
 	router, api, s, mockService := setupAuthRouter()
 	api.DELETE("/auth/sessions/:id", func(c *gin.Context) {
 		c.Set("currentUser", &gen.User{Id: 1})
-		s.revokeSessionHandler(c)
+		id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+		if err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid session id"})
+			return
+		}
+		s.RevokeSession(c, id)
 	})
 
 	mockService.On("ListSessionsForUser", mock.Anything, 1).Return([]db.SessionInfo{{Id: 100, UserId: 1}}, nil)
@@ -147,7 +151,7 @@ func TestRevokeSessionHandler_OwnSession(t *testing.T) {
 
 func TestLoginHandler_InvalidJSON(t *testing.T) {
 	router, api, s, _ := setupAuthRouter()
-	api.POST("/auth/login", s.loginHandler)
+	api.POST("/auth/login", s.Login)
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/auth/login", bytes.NewBufferString("invalid-json"))
@@ -159,9 +163,9 @@ func TestLoginHandler_InvalidJSON(t *testing.T) {
 
 func TestLoginHandler_MustChangePassword(t *testing.T) {
 	router, api, s, mockService := setupAuthRouter()
-	api.POST("/auth/login", s.loginHandler)
+	api.POST("/auth/login", s.Login)
 
-	reqBody := loginRequest{Username: "user", Password: "password"}
+	reqBody := gen.LoginRequest{Username: "user", Password: "password"}
 	jsonBody, _ := json.Marshal(reqBody)
 
 	mockService.On("Login", mock.Anything, "user", "password", mock.Anything, mock.Anything).Return("token", "csrf", true, nil)
@@ -177,7 +181,7 @@ func TestLoginHandler_MustChangePassword(t *testing.T) {
 
 func TestLogoutHandler_MissingCookie(t *testing.T) {
 	router, api, s, _ := setupAuthRouter()
-	api.POST("/auth/logout", s.logoutHandler)
+	api.POST("/auth/logout", s.Logout)
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/auth/logout", nil)
@@ -189,7 +193,7 @@ func TestLogoutHandler_MissingCookie(t *testing.T) {
 
 func TestLogoutHandler_ServiceError(t *testing.T) {
 	router, api, s, mockService := setupAuthRouter()
-	api.POST("/auth/logout", s.logoutHandler)
+	api.POST("/auth/logout", s.Logout)
 
 	mockService.On("Logout", mock.Anything, "valid-token").Return(errors.New("db error"))
 
@@ -206,7 +210,7 @@ func TestMeHandler_MissingCookie(t *testing.T) {
 	router, api, s, _ := setupAuthRouter()
 	api.GET("/auth/me", func(c *gin.Context) {
 		c.Set("currentUser", &gen.User{Id: 1, Username: "me"})
-		s.meHandler(c)
+		s.GetCurrentUser(c)
 	})
 
 	w := httptest.NewRecorder()
@@ -222,7 +226,7 @@ func TestMeHandler_CSRFError(t *testing.T) {
 	router, api, s, mockService := setupAuthRouter()
 	api.GET("/auth/me", func(c *gin.Context) {
 		c.Set("currentUser", &gen.User{Id: 1, Username: "me"})
-		s.meHandler(c)
+		s.GetCurrentUser(c)
 	})
 
 	mockService.On("GetCSRFForToken", mock.Anything, "valid-token").Return("", errors.New("db error"))
@@ -241,7 +245,7 @@ func TestListSessionsHandler_ServiceError(t *testing.T) {
 	router, api, s, mockService := setupAuthRouter()
 	api.GET("/auth/sessions", func(c *gin.Context) {
 		c.Set("currentUser", &gen.User{Id: 1})
-		s.listSessionsHandler(c)
+		s.ListSessions(c)
 	})
 
 	mockService.On("ListSessionsForUser", mock.Anything, 1).Return([]db.SessionInfo{}, errors.New("db error"))
@@ -258,7 +262,12 @@ func TestRevokeSessionHandler_InvalidID(t *testing.T) {
 	router, api, s, _ := setupAuthRouter()
 	api.DELETE("/auth/sessions/:id", func(c *gin.Context) {
 		c.Set("currentUser", &gen.User{Id: 1})
-		s.revokeSessionHandler(c)
+		id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+		if err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid session id"})
+			return
+		}
+		s.RevokeSession(c, id)
 	})
 
 	w := httptest.NewRecorder()
@@ -272,7 +281,12 @@ func TestRevokeSessionHandler_MissingID(t *testing.T) {
 	router, api, s, _ := setupAuthRouter()
 	api.DELETE("/auth/sessions/:id", func(c *gin.Context) {
 		c.Set("currentUser", &gen.User{Id: 1})
-		s.revokeSessionHandler(c)
+		id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+		if err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid session id"})
+			return
+		}
+		s.RevokeSession(c, id)
 	})
 
 	w := httptest.NewRecorder()
@@ -287,7 +301,12 @@ func TestRevokeSessionHandler_NotOwnedSession(t *testing.T) {
 	router, api, s, mockService := setupAuthRouter()
 	api.DELETE("/auth/sessions/:id", func(c *gin.Context) {
 		c.Set("currentUser", &gen.User{Id: 1, Roles: []string{"user"}})
-		s.revokeSessionHandler(c)
+		id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+		if err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid session id"})
+			return
+		}
+		s.RevokeSession(c, id)
 	})
 
 	mockService.On("ListSessionsForUser", mock.Anything, 1).Return([]db.SessionInfo{{Id: 100, UserId: 1}}, nil)
@@ -303,7 +322,12 @@ func TestRevokeSessionHandler_AdminRevokingOthers(t *testing.T) {
 	router, api, s, mockService := setupAuthRouter()
 	api.DELETE("/auth/sessions/:id", func(c *gin.Context) {
 		c.Set("currentUser", &gen.User{Id: 1, Roles: []string{"admin"}})
-		s.revokeSessionHandler(c)
+		id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+		if err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid session id"})
+			return
+		}
+		s.RevokeSession(c, id)
 	})
 
 	mockService.On("ListSessionsForUser", mock.Anything, 1).Return([]db.SessionInfo{{Id: 100, UserId: 1}}, nil)
@@ -321,7 +345,12 @@ func TestRevokeSessionHandler_ListError(t *testing.T) {
 	router, api, s, mockService := setupAuthRouter()
 	api.DELETE("/auth/sessions/:id", func(c *gin.Context) {
 		c.Set("currentUser", &gen.User{Id: 1})
-		s.revokeSessionHandler(c)
+		id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+		if err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid session id"})
+			return
+		}
+		s.RevokeSession(c, id)
 	})
 
 	mockService.On("ListSessionsForUser", mock.Anything, 1).Return([]db.SessionInfo{}, errors.New("db error"))
@@ -337,7 +366,12 @@ func TestRevokeSessionHandler_RevokeError(t *testing.T) {
 	router, api, s, mockService := setupAuthRouter()
 	api.DELETE("/auth/sessions/:id", func(c *gin.Context) {
 		c.Set("currentUser", &gen.User{Id: 1})
-		s.revokeSessionHandler(c)
+		id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+		if err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid session id"})
+			return
+		}
+		s.RevokeSession(c, id)
 	})
 
 	mockService.On("ListSessionsForUser", mock.Anything, 1).Return([]db.SessionInfo{{Id: 100, UserId: 1}}, nil)

--- a/sensor_hub/api/auth_routes.go
+++ b/sensor_hub/api/auth_routes.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"example/sensorHub/api/middleware"
+	"net/http"
+	"strconv"
 
 	"github.com/gin-gonic/gin"
 )
@@ -9,10 +11,17 @@ import (
 func (s *Server) RegisterAuthRoutes(router gin.IRouter) {
 	authGroup := router.Group("/auth")
 	{
-		authGroup.POST("/login", s.loginHandler)
-		authGroup.POST("/logout", middleware.AuthRequired(), s.logoutHandler)
-		authGroup.GET("/me", middleware.AuthRequired(), s.meHandler)
-		authGroup.GET("/sessions", middleware.AuthRequired(), s.listSessionsHandler)
-		authGroup.DELETE("/sessions/:id", middleware.AuthRequired(), s.revokeSessionHandler)
+		authGroup.POST("/login", s.Login)
+		authGroup.POST("/logout", middleware.AuthRequired(), s.Logout)
+		authGroup.GET("/me", middleware.AuthRequired(), s.GetCurrentUser)
+		authGroup.GET("/sessions", middleware.AuthRequired(), s.ListSessions)
+		authGroup.DELETE("/sessions/:id", middleware.AuthRequired(), func(c *gin.Context) {
+			id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+			if err != nil {
+				c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid session id"})
+				return
+			}
+			s.RevokeSession(c, id)
+		})
 	}
 }

--- a/sensor_hub/api/mocks_test.go
+++ b/sensor_hub/api/mocks_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	db "example/sensorHub/db"
 	gen "example/sensorHub/gen"
+	"example/sensorHub/notifications"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/mock"
 )
@@ -303,6 +304,64 @@ func (m *MockPropertiesService) ServiceUpdateProperties(ctx context.Context, pro
 func (m *MockPropertiesService) ServiceGetProperties(ctx context.Context) (map[string]interface{}, error) {
 	args := m.Called(ctx)
 	return args.Get(0).(map[string]interface{}), args.Error(1)
+}
+
+// ============================================================================
+// MockNotificationService
+// ============================================================================
+
+type MockNotificationService struct {
+	mock.Mock
+}
+
+func (m *MockNotificationService) CreateNotification(ctx context.Context, notif notifications.Notification, targetPermission string) (int, error) {
+	args := m.Called(ctx, notif, targetPermission)
+	return args.Int(0), args.Error(1)
+}
+
+func (m *MockNotificationService) GetNotificationsForUser(ctx context.Context, userID int, limit, offset int, includeDismissed bool) ([]notifications.UserNotification, error) {
+	args := m.Called(ctx, userID, limit, offset, includeDismissed)
+	return args.Get(0).([]notifications.UserNotification), args.Error(1)
+}
+
+func (m *MockNotificationService) GetUnreadCount(ctx context.Context, userID int) (int, error) {
+	args := m.Called(ctx, userID)
+	return args.Int(0), args.Error(1)
+}
+
+func (m *MockNotificationService) MarkAsRead(ctx context.Context, userID, notificationID int) error {
+	args := m.Called(ctx, userID, notificationID)
+	return args.Error(0)
+}
+
+func (m *MockNotificationService) Dismiss(ctx context.Context, userID, notificationID int) error {
+	args := m.Called(ctx, userID, notificationID)
+	return args.Error(0)
+}
+
+func (m *MockNotificationService) BulkMarkAsRead(ctx context.Context, userID int) error {
+	args := m.Called(ctx, userID)
+	return args.Error(0)
+}
+
+func (m *MockNotificationService) BulkDismiss(ctx context.Context, userID int) error {
+	args := m.Called(ctx, userID)
+	return args.Error(0)
+}
+
+func (m *MockNotificationService) GetChannelPreferences(ctx context.Context, userID int) ([]notifications.ChannelPreference, error) {
+	args := m.Called(ctx, userID)
+	return args.Get(0).([]notifications.ChannelPreference), args.Error(1)
+}
+
+func (m *MockNotificationService) SetChannelPreference(ctx context.Context, userID int, pref notifications.ChannelPreference) error {
+	args := m.Called(ctx, userID, pref)
+	return args.Error(0)
+}
+
+func (m *MockNotificationService) ShouldNotifyChannel(ctx context.Context, userID int, category notifications.NotificationCategory, channel string) (bool, error) {
+	args := m.Called(ctx, userID, category, channel)
+	return args.Bool(0), args.Error(1)
 }
 
 // ============================================================================

--- a/sensor_hub/api/notification_routes.go
+++ b/sensor_hub/api/notification_routes.go
@@ -2,6 +2,9 @@ package api
 
 import (
 	"example/sensorHub/api/middleware"
+	gen "example/sensorHub/gen"
+	"net/http"
+	"strconv"
 
 	"github.com/gin-gonic/gin"
 )
@@ -9,14 +12,45 @@ import (
 func (s *Server) RegisterNotificationRoutes(router gin.IRouter) {
 	notifs := router.Group("/notifications")
 	{
-		notifs.GET("", middleware.AuthRequired(), middleware.RequirePermission("view_notifications"), s.listNotificationsHandler)
-		notifs.GET("/unread-count", middleware.AuthRequired(), middleware.RequirePermission("view_notifications"), s.getUnreadCountHandler)
-		notifs.POST("/:id/read", middleware.AuthRequired(), middleware.RequirePermission("view_notifications"), s.markAsReadHandler)
-		notifs.POST("/:id/dismiss", middleware.AuthRequired(), middleware.RequirePermission("manage_notifications"), s.dismissNotificationHandler)
-		notifs.POST("/bulk/read", middleware.AuthRequired(), middleware.RequirePermission("view_notifications"), s.bulkMarkAsReadHandler)
-		notifs.POST("/bulk/dismiss", middleware.AuthRequired(), middleware.RequirePermission("manage_notifications"), s.bulkDismissHandler)
-		notifs.GET("/preferences", middleware.AuthRequired(), middleware.RequirePermission("view_notifications"), s.getChannelPreferencesHandler)
-		notifs.POST("/preferences", middleware.AuthRequired(), middleware.RequirePermission("manage_notifications"), s.setChannelPreferenceHandler)
+		notifs.GET("", middleware.AuthRequired(), middleware.RequirePermission("view_notifications"), func(c *gin.Context) {
+			var params gen.ListNotificationsParams
+			if lStr := c.Query("limit"); lStr != "" {
+				if v, err := strconv.Atoi(lStr); err == nil {
+					params.Limit = &v
+				}
+			}
+			if oStr := c.Query("offset"); oStr != "" {
+				if v, err := strconv.Atoi(oStr); err == nil {
+					params.Offset = &v
+				}
+			}
+			if dStr := c.Query("include_dismissed"); dStr != "" {
+				v := gen.ListNotificationsParamsIncludeDismissed(dStr)
+				params.IncludeDismissed = &v
+			}
+			s.ListNotifications(c, params)
+		})
+		notifs.GET("/unread-count", middleware.AuthRequired(), middleware.RequirePermission("view_notifications"), s.GetUnreadCount)
+		notifs.POST("/:id/read", middleware.AuthRequired(), middleware.RequirePermission("view_notifications"), func(c *gin.Context) {
+			id, err := strconv.Atoi(c.Param("id"))
+			if err != nil {
+				c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid notification id"})
+				return
+			}
+			s.MarkAsRead(c, id)
+		})
+		notifs.POST("/:id/dismiss", middleware.AuthRequired(), middleware.RequirePermission("manage_notifications"), func(c *gin.Context) {
+			id, err := strconv.Atoi(c.Param("id"))
+			if err != nil {
+				c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid notification id"})
+				return
+			}
+			s.DismissNotification(c, id)
+		})
+		notifs.POST("/bulk/read", middleware.AuthRequired(), middleware.RequirePermission("view_notifications"), s.BulkMarkAsRead)
+		notifs.POST("/bulk/dismiss", middleware.AuthRequired(), middleware.RequirePermission("manage_notifications"), s.BulkDismiss)
+		notifs.GET("/preferences", middleware.AuthRequired(), middleware.RequirePermission("view_notifications"), s.GetChannelPreferences)
+		notifs.POST("/preferences", middleware.AuthRequired(), middleware.RequirePermission("manage_notifications"), s.SetChannelPreference)
 		notifs.GET("/ws", middleware.AuthRequired(), middleware.RequirePermission("view_notifications"), s.notificationsWebSocketHandler)
 	}
 }

--- a/sensor_hub/api/notifications_api.go
+++ b/sensor_hub/api/notifications_api.go
@@ -1,16 +1,13 @@
 package api
 
 import (
-	"example/sensorHub/notifications"
 	gen "example/sensorHub/gen"
+	"example/sensorHub/notifications"
 	"example/sensorHub/ws"
 	"net/http"
-	"strconv"
 
 	"github.com/gin-gonic/gin"
 )
-
-
 
 func getCurrentUserID(ctx *gin.Context) int {
 	userObj, exists := ctx.Get("currentUser")
@@ -24,7 +21,8 @@ func getCurrentUserID(ctx *gin.Context) int {
 	return user.Id
 }
 
-func (s *Server) listNotificationsHandler(c *gin.Context) {
+// ListNotifications implements gen.ServerInterface.
+func (s *Server) ListNotifications(c *gin.Context, params gen.ListNotificationsParams) {
 	ctx := c.Request.Context()
 	userID := getCurrentUserID(c)
 	if userID == 0 {
@@ -32,9 +30,18 @@ func (s *Server) listNotificationsHandler(c *gin.Context) {
 		return
 	}
 
-	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "50"))
-	offset, _ := strconv.Atoi(c.DefaultQuery("offset", "0"))
-	includeDismissed := c.DefaultQuery("include_dismissed", "false") == "true"
+	limit := 50
+	if params.Limit != nil {
+		limit = *params.Limit
+	}
+	offset := 0
+	if params.Offset != nil {
+		offset = *params.Offset
+	}
+	includeDismissed := false
+	if params.IncludeDismissed != nil && *params.IncludeDismissed == gen.True {
+		includeDismissed = true
+	}
 
 	notifs, err := s.notificationService.GetNotificationsForUser(ctx, userID, limit, offset, includeDismissed)
 	if err != nil {
@@ -44,7 +51,8 @@ func (s *Server) listNotificationsHandler(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, notifs)
 }
 
-func (s *Server) getUnreadCountHandler(c *gin.Context) {
+// GetUnreadCount implements gen.ServerInterface.
+func (s *Server) GetUnreadCount(c *gin.Context) {
 	ctx := c.Request.Context()
 	userID := getCurrentUserID(c)
 	if userID == 0 {
@@ -60,7 +68,8 @@ func (s *Server) getUnreadCountHandler(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, gin.H{"count": count})
 }
 
-func (s *Server) markAsReadHandler(c *gin.Context) {
+// MarkAsRead implements gen.ServerInterface.
+func (s *Server) MarkAsRead(c *gin.Context, id int) {
 	ctx := c.Request.Context()
 	userID := getCurrentUserID(c)
 	if userID == 0 {
@@ -68,13 +77,7 @@ func (s *Server) markAsReadHandler(c *gin.Context) {
 		return
 	}
 
-	notifID, err := strconv.Atoi(c.Param("id"))
-	if err != nil {
-		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid notification id"})
-		return
-	}
-
-	err = s.notificationService.MarkAsRead(ctx, userID, notifID)
+	err := s.notificationService.MarkAsRead(ctx, userID, id)
 	if err != nil {
 		c.IndentedJSON(http.StatusInternalServerError, gin.H{"message": "failed to mark as read", "error": err.Error()})
 		return
@@ -82,7 +85,8 @@ func (s *Server) markAsReadHandler(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, gin.H{"message": "marked as read"})
 }
 
-func (s *Server) dismissNotificationHandler(c *gin.Context) {
+// DismissNotification implements gen.ServerInterface.
+func (s *Server) DismissNotification(c *gin.Context, id int) {
 	ctx := c.Request.Context()
 	userID := getCurrentUserID(c)
 	if userID == 0 {
@@ -90,13 +94,7 @@ func (s *Server) dismissNotificationHandler(c *gin.Context) {
 		return
 	}
 
-	notifID, err := strconv.Atoi(c.Param("id"))
-	if err != nil {
-		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid notification id"})
-		return
-	}
-
-	err = s.notificationService.Dismiss(ctx, userID, notifID)
+	err := s.notificationService.Dismiss(ctx, userID, id)
 	if err != nil {
 		c.IndentedJSON(http.StatusInternalServerError, gin.H{"message": "failed to dismiss notification", "error": err.Error()})
 		return
@@ -104,7 +102,8 @@ func (s *Server) dismissNotificationHandler(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, gin.H{"message": "dismissed"})
 }
 
-func (s *Server) bulkMarkAsReadHandler(c *gin.Context) {
+// BulkMarkAsRead implements gen.ServerInterface.
+func (s *Server) BulkMarkAsRead(c *gin.Context) {
 	ctx := c.Request.Context()
 	userID := getCurrentUserID(c)
 	if userID == 0 {
@@ -120,7 +119,8 @@ func (s *Server) bulkMarkAsReadHandler(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, gin.H{"message": "all marked as read"})
 }
 
-func (s *Server) bulkDismissHandler(c *gin.Context) {
+// BulkDismiss implements gen.ServerInterface.
+func (s *Server) BulkDismiss(c *gin.Context) {
 	ctx := c.Request.Context()
 	userID := getCurrentUserID(c)
 	if userID == 0 {
@@ -136,7 +136,8 @@ func (s *Server) bulkDismissHandler(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, gin.H{"message": "all dismissed"})
 }
 
-func (s *Server) getChannelPreferencesHandler(c *gin.Context) {
+// GetChannelPreferences implements gen.ServerInterface.
+func (s *Server) GetChannelPreferences(c *gin.Context) {
 	ctx := c.Request.Context()
 	userID := getCurrentUserID(c)
 	if userID == 0 {
@@ -152,7 +153,8 @@ func (s *Server) getChannelPreferencesHandler(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, prefs)
 }
 
-func (s *Server) setChannelPreferenceHandler(c *gin.Context) {
+// SetChannelPreference implements gen.ServerInterface.
+func (s *Server) SetChannelPreference(c *gin.Context) {
 	ctx := c.Request.Context()
 	userID := getCurrentUserID(c)
 	if userID == 0 {
@@ -160,15 +162,26 @@ func (s *Server) setChannelPreferenceHandler(c *gin.Context) {
 		return
 	}
 
-	var pref notifications.ChannelPreference
-	if err := c.ShouldBindJSON(&pref); err != nil {
+	var req gen.SetChannelPreferenceJSONRequestBody
+	if err := c.ShouldBindJSON(&req); err != nil {
 		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid request body", "error": err.Error()})
 		return
 	}
 
-	if pref.Category == "" {
-		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "category is required"})
-		return
+	emailEnabled := false
+	if req.EmailEnabled != nil {
+		emailEnabled = *req.EmailEnabled
+	}
+	inappEnabled := false
+	if req.InappEnabled != nil {
+		inappEnabled = *req.InappEnabled
+	}
+
+	pref := notifications.ChannelPreference{
+		UserID:       userID,
+		Category:     notifications.NotificationCategory(req.Category),
+		EmailEnabled: emailEnabled,
+		InAppEnabled: inappEnabled,
 	}
 
 	err := s.notificationService.SetChannelPreference(ctx, userID, pref)
@@ -189,3 +202,5 @@ func (s *Server) notificationsWebSocketHandler(ctx *gin.Context) {
 	topic := ws.UserNotificationTopic(userID)
 	createPushWebSocket(ctx, topic)
 }
+
+

--- a/sensor_hub/api/notifications_api.go
+++ b/sensor_hub/api/notifications_api.go
@@ -9,26 +9,10 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func getCurrentUserID(ctx *gin.Context) int {
-	userObj, exists := ctx.Get("currentUser")
-	if !exists {
-		return 0
-	}
-	user, ok := userObj.(*gen.User)
-	if !ok || user == nil {
-		return 0
-	}
-	return user.Id
-}
-
 // ListNotifications implements gen.ServerInterface.
 func (s *Server) ListNotifications(c *gin.Context, params gen.ListNotificationsParams) {
 	ctx := c.Request.Context()
-	userID := getCurrentUserID(c)
-	if userID == 0 {
-		c.IndentedJSON(http.StatusUnauthorized, gin.H{"message": "unauthorized"})
-		return
-	}
+	userID := c.MustGet("currentUser").(*gen.User).Id
 
 	limit := 50
 	if params.Limit != nil {
@@ -54,11 +38,7 @@ func (s *Server) ListNotifications(c *gin.Context, params gen.ListNotificationsP
 // GetUnreadCount implements gen.ServerInterface.
 func (s *Server) GetUnreadCount(c *gin.Context) {
 	ctx := c.Request.Context()
-	userID := getCurrentUserID(c)
-	if userID == 0 {
-		c.IndentedJSON(http.StatusUnauthorized, gin.H{"message": "unauthorized"})
-		return
-	}
+	userID := c.MustGet("currentUser").(*gen.User).Id
 
 	count, err := s.notificationService.GetUnreadCount(ctx, userID)
 	if err != nil {
@@ -71,11 +51,7 @@ func (s *Server) GetUnreadCount(c *gin.Context) {
 // MarkAsRead implements gen.ServerInterface.
 func (s *Server) MarkAsRead(c *gin.Context, id int) {
 	ctx := c.Request.Context()
-	userID := getCurrentUserID(c)
-	if userID == 0 {
-		c.IndentedJSON(http.StatusUnauthorized, gin.H{"message": "unauthorized"})
-		return
-	}
+	userID := c.MustGet("currentUser").(*gen.User).Id
 
 	err := s.notificationService.MarkAsRead(ctx, userID, id)
 	if err != nil {
@@ -88,11 +64,7 @@ func (s *Server) MarkAsRead(c *gin.Context, id int) {
 // DismissNotification implements gen.ServerInterface.
 func (s *Server) DismissNotification(c *gin.Context, id int) {
 	ctx := c.Request.Context()
-	userID := getCurrentUserID(c)
-	if userID == 0 {
-		c.IndentedJSON(http.StatusUnauthorized, gin.H{"message": "unauthorized"})
-		return
-	}
+	userID := c.MustGet("currentUser").(*gen.User).Id
 
 	err := s.notificationService.Dismiss(ctx, userID, id)
 	if err != nil {
@@ -105,11 +77,7 @@ func (s *Server) DismissNotification(c *gin.Context, id int) {
 // BulkMarkAsRead implements gen.ServerInterface.
 func (s *Server) BulkMarkAsRead(c *gin.Context) {
 	ctx := c.Request.Context()
-	userID := getCurrentUserID(c)
-	if userID == 0 {
-		c.IndentedJSON(http.StatusUnauthorized, gin.H{"message": "unauthorized"})
-		return
-	}
+	userID := c.MustGet("currentUser").(*gen.User).Id
 
 	err := s.notificationService.BulkMarkAsRead(ctx, userID)
 	if err != nil {
@@ -122,11 +90,7 @@ func (s *Server) BulkMarkAsRead(c *gin.Context) {
 // BulkDismiss implements gen.ServerInterface.
 func (s *Server) BulkDismiss(c *gin.Context) {
 	ctx := c.Request.Context()
-	userID := getCurrentUserID(c)
-	if userID == 0 {
-		c.IndentedJSON(http.StatusUnauthorized, gin.H{"message": "unauthorized"})
-		return
-	}
+	userID := c.MustGet("currentUser").(*gen.User).Id
 
 	err := s.notificationService.BulkDismiss(ctx, userID)
 	if err != nil {
@@ -139,11 +103,7 @@ func (s *Server) BulkDismiss(c *gin.Context) {
 // GetChannelPreferences implements gen.ServerInterface.
 func (s *Server) GetChannelPreferences(c *gin.Context) {
 	ctx := c.Request.Context()
-	userID := getCurrentUserID(c)
-	if userID == 0 {
-		c.IndentedJSON(http.StatusUnauthorized, gin.H{"message": "unauthorized"})
-		return
-	}
+	userID := c.MustGet("currentUser").(*gen.User).Id
 
 	prefs, err := s.notificationService.GetChannelPreferences(ctx, userID)
 	if err != nil {
@@ -156,11 +116,7 @@ func (s *Server) GetChannelPreferences(c *gin.Context) {
 // SetChannelPreference implements gen.ServerInterface.
 func (s *Server) SetChannelPreference(c *gin.Context) {
 	ctx := c.Request.Context()
-	userID := getCurrentUserID(c)
-	if userID == 0 {
-		c.IndentedJSON(http.StatusUnauthorized, gin.H{"message": "unauthorized"})
-		return
-	}
+	userID := c.MustGet("currentUser").(*gen.User).Id
 
 	var req gen.SetChannelPreferenceJSONRequestBody
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -193,11 +149,7 @@ func (s *Server) SetChannelPreference(c *gin.Context) {
 }
 
 func (s *Server) notificationsWebSocketHandler(ctx *gin.Context) {
-	userID := getCurrentUserID(ctx)
-	if userID == 0 {
-		ctx.IndentedJSON(http.StatusUnauthorized, gin.H{"message": "unauthorized"})
-		return
-	}
+	userID := ctx.MustGet("currentUser").(*gen.User).Id
 
 	topic := ws.UserNotificationTopic(userID)
 	createPushWebSocket(ctx, topic)

--- a/sensor_hub/api/notifications_api_test.go
+++ b/sensor_hub/api/notifications_api_test.go
@@ -1,0 +1,400 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	gen "example/sensorHub/gen"
+	"example/sensorHub/notifications"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func setupNotifRouter() (*gin.Engine, *gin.RouterGroup, *Server, *MockNotificationService) {
+	mockService := new(MockNotificationService)
+	s := &Server{notificationService: mockService}
+	router := gin.New()
+	apiGroup := router.Group("/api")
+	return router, apiGroup, s, mockService
+}
+
+func TestListNotifications_Success(t *testing.T) {
+	router, api, s, mockService := setupNotifRouter()
+	limit := 10
+	offset := 5
+	api.GET("/notifications", func(c *gin.Context) {
+		c.Set("currentUser", &gen.User{Id: 1})
+		params := gen.ListNotificationsParams{Limit: &limit, Offset: &offset}
+		s.ListNotifications(c, params)
+	})
+
+	mockService.On("GetNotificationsForUser", mock.Anything, 1, 10, 5, false).
+		Return([]notifications.UserNotification{{Notification: &notifications.Notification{Message: "test notif"}}}, nil)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/notifications", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "test notif")
+}
+
+func TestListNotifications_IncludeDismissed(t *testing.T) {
+	router, api, s, mockService := setupNotifRouter()
+	includeDismissed := gen.True
+	api.GET("/notifications", func(c *gin.Context) {
+		c.Set("currentUser", &gen.User{Id: 1})
+		params := gen.ListNotificationsParams{IncludeDismissed: &includeDismissed}
+		s.ListNotifications(c, params)
+	})
+
+	mockService.On("GetNotificationsForUser", mock.Anything, 1, 50, 0, true).
+		Return([]notifications.UserNotification{}, nil)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/notifications", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestListNotifications_ServiceError(t *testing.T) {
+	router, api, s, mockService := setupNotifRouter()
+	api.GET("/notifications", func(c *gin.Context) {
+		c.Set("currentUser", &gen.User{Id: 1})
+		s.ListNotifications(c, gen.ListNotificationsParams{})
+	})
+
+	mockService.On("GetNotificationsForUser", mock.Anything, 1, 50, 0, false).
+		Return([]notifications.UserNotification{}, errors.New("db error"))
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/notifications", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestGetUnreadCount_Success(t *testing.T) {
+	router, api, s, mockService := setupNotifRouter()
+	api.GET("/notifications/unread", func(c *gin.Context) {
+		c.Set("currentUser", &gen.User{Id: 1})
+		s.GetUnreadCount(c)
+	})
+
+	mockService.On("GetUnreadCount", mock.Anything, 1).Return(3, nil)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/notifications/unread", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "3")
+}
+
+func TestGetUnreadCount_ServiceError(t *testing.T) {
+	router, api, s, mockService := setupNotifRouter()
+	api.GET("/notifications/unread", func(c *gin.Context) {
+		c.Set("currentUser", &gen.User{Id: 1})
+		s.GetUnreadCount(c)
+	})
+
+	mockService.On("GetUnreadCount", mock.Anything, 1).Return(0, errors.New("db error"))
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/notifications/unread", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestMarkAsRead_Success(t *testing.T) {
+	router, api, s, mockService := setupNotifRouter()
+	api.POST("/notifications/:id/read", func(c *gin.Context) {
+		c.Set("currentUser", &gen.User{Id: 1})
+		id, err := strconv.Atoi(c.Param("id"))
+		if err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid notification id"})
+			return
+		}
+		s.MarkAsRead(c, id)
+	})
+
+	mockService.On("MarkAsRead", mock.Anything, 1, 42).Return(nil)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/notifications/42/read", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestMarkAsRead_InvalidID(t *testing.T) {
+	router, api, s, _ := setupNotifRouter()
+	api.POST("/notifications/:id/read", func(c *gin.Context) {
+		c.Set("currentUser", &gen.User{Id: 1})
+		id, err := strconv.Atoi(c.Param("id"))
+		if err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid notification id"})
+			return
+		}
+		s.MarkAsRead(c, id)
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/notifications/invalid/read", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestMarkAsRead_ServiceError(t *testing.T) {
+	router, api, s, mockService := setupNotifRouter()
+	api.POST("/notifications/:id/read", func(c *gin.Context) {
+		c.Set("currentUser", &gen.User{Id: 1})
+		id, err := strconv.Atoi(c.Param("id"))
+		if err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid notification id"})
+			return
+		}
+		s.MarkAsRead(c, id)
+	})
+
+	mockService.On("MarkAsRead", mock.Anything, 1, 42).Return(errors.New("db error"))
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/notifications/42/read", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestDismissNotification_Success(t *testing.T) {
+	router, api, s, mockService := setupNotifRouter()
+	api.POST("/notifications/:id/dismiss", func(c *gin.Context) {
+		c.Set("currentUser", &gen.User{Id: 1})
+		id, err := strconv.Atoi(c.Param("id"))
+		if err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid notification id"})
+			return
+		}
+		s.DismissNotification(c, id)
+	})
+
+	mockService.On("Dismiss", mock.Anything, 1, 42).Return(nil)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/notifications/42/dismiss", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestDismissNotification_InvalidID(t *testing.T) {
+	router, api, s, _ := setupNotifRouter()
+	api.POST("/notifications/:id/dismiss", func(c *gin.Context) {
+		c.Set("currentUser", &gen.User{Id: 1})
+		id, err := strconv.Atoi(c.Param("id"))
+		if err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid notification id"})
+			return
+		}
+		s.DismissNotification(c, id)
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/notifications/invalid/dismiss", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestDismissNotification_ServiceError(t *testing.T) {
+	router, api, s, mockService := setupNotifRouter()
+	api.POST("/notifications/:id/dismiss", func(c *gin.Context) {
+		c.Set("currentUser", &gen.User{Id: 1})
+		id, err := strconv.Atoi(c.Param("id"))
+		if err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid notification id"})
+			return
+		}
+		s.DismissNotification(c, id)
+	})
+
+	mockService.On("Dismiss", mock.Anything, 1, 42).Return(errors.New("db error"))
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/notifications/42/dismiss", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestBulkMarkAsRead_Success(t *testing.T) {
+	router, api, s, mockService := setupNotifRouter()
+	api.POST("/notifications/bulk/read", func(c *gin.Context) {
+		c.Set("currentUser", &gen.User{Id: 1})
+		s.BulkMarkAsRead(c)
+	})
+
+	mockService.On("BulkMarkAsRead", mock.Anything, 1).Return(nil)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/notifications/bulk/read", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestBulkMarkAsRead_ServiceError(t *testing.T) {
+	router, api, s, mockService := setupNotifRouter()
+	api.POST("/notifications/bulk/read", func(c *gin.Context) {
+		c.Set("currentUser", &gen.User{Id: 1})
+		s.BulkMarkAsRead(c)
+	})
+
+	mockService.On("BulkMarkAsRead", mock.Anything, 1).Return(errors.New("db error"))
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/notifications/bulk/read", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestBulkDismiss_Success(t *testing.T) {
+	router, api, s, mockService := setupNotifRouter()
+	api.POST("/notifications/bulk/dismiss", func(c *gin.Context) {
+		c.Set("currentUser", &gen.User{Id: 1})
+		s.BulkDismiss(c)
+	})
+
+	mockService.On("BulkDismiss", mock.Anything, 1).Return(nil)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/notifications/bulk/dismiss", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestBulkDismiss_ServiceError(t *testing.T) {
+	router, api, s, mockService := setupNotifRouter()
+	api.POST("/notifications/bulk/dismiss", func(c *gin.Context) {
+		c.Set("currentUser", &gen.User{Id: 1})
+		s.BulkDismiss(c)
+	})
+
+	mockService.On("BulkDismiss", mock.Anything, 1).Return(errors.New("db error"))
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/notifications/bulk/dismiss", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestGetChannelPreferences_Success(t *testing.T) {
+	router, api, s, mockService := setupNotifRouter()
+	api.GET("/notifications/preferences", func(c *gin.Context) {
+		c.Set("currentUser", &gen.User{Id: 1})
+		s.GetChannelPreferences(c)
+	})
+
+	prefs := []notifications.ChannelPreference{{Category: "threshold_alert", EmailEnabled: true}}
+	mockService.On("GetChannelPreferences", mock.Anything, 1).Return(prefs, nil)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/notifications/preferences", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "threshold_alert")
+}
+
+func TestGetChannelPreferences_ServiceError(t *testing.T) {
+	router, api, s, mockService := setupNotifRouter()
+	api.GET("/notifications/preferences", func(c *gin.Context) {
+		c.Set("currentUser", &gen.User{Id: 1})
+		s.GetChannelPreferences(c)
+	})
+
+	mockService.On("GetChannelPreferences", mock.Anything, 1).Return([]notifications.ChannelPreference{}, errors.New("db error"))
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/notifications/preferences", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestSetChannelPreference_Success(t *testing.T) {
+	router, api, s, mockService := setupNotifRouter()
+	api.POST("/notifications/preferences", func(c *gin.Context) {
+		c.Set("currentUser", &gen.User{Id: 1})
+		s.SetChannelPreference(c)
+	})
+
+	emailEnabled := true
+	inappEnabled := false
+	reqBody := gen.SetChannelPreferenceJSONRequestBody{
+		Category:     "threshold_alert",
+		EmailEnabled: &emailEnabled,
+		InappEnabled: &inappEnabled,
+	}
+	jsonBody, _ := json.Marshal(reqBody)
+
+	expectedPref := notifications.ChannelPreference{
+		UserID:       1,
+		Category:     "threshold_alert",
+		EmailEnabled: true,
+		InAppEnabled: false,
+	}
+	mockService.On("SetChannelPreference", mock.Anything, 1, expectedPref).Return(nil)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/notifications/preferences", bytes.NewBuffer(jsonBody))
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestSetChannelPreference_InvalidJSON(t *testing.T) {
+	router, api, s, _ := setupNotifRouter()
+	api.POST("/notifications/preferences", func(c *gin.Context) {
+		c.Set("currentUser", &gen.User{Id: 1})
+		s.SetChannelPreference(c)
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/notifications/preferences", bytes.NewBufferString("invalid"))
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestSetChannelPreference_ServiceError(t *testing.T) {
+	router, api, s, mockService := setupNotifRouter()
+	api.POST("/notifications/preferences", func(c *gin.Context) {
+		c.Set("currentUser", &gen.User{Id: 1})
+		s.SetChannelPreference(c)
+	})
+
+	reqBody := gen.SetChannelPreferenceJSONRequestBody{Category: "threshold_alert"}
+	jsonBody, _ := json.Marshal(reqBody)
+
+	mockService.On("SetChannelPreference", mock.Anything, 1, mock.AnythingOfType("notifications.ChannelPreference")).
+		Return(errors.New("db error"))
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/notifications/preferences", bytes.NewBuffer(jsonBody))
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}

--- a/sensor_hub/api/user_routes.go
+++ b/sensor_hub/api/user_routes.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"example/sensorHub/api/middleware"
+	"net/http"
+	"strconv"
 
 	"github.com/gin-gonic/gin"
 )
@@ -9,11 +11,32 @@ import (
 func (s *Server) RegisterUserRoutes(router gin.IRouter) {
 	usersGroup := router.Group("/users")
 	{
-		usersGroup.POST("", middleware.AuthRequired(), middleware.RequirePermission("manage_users"), s.createUserHandler)
-		usersGroup.GET("", middleware.AuthRequired(), middleware.RequirePermission("view_users"), s.listUsersHandler)
-		usersGroup.PUT("/password", middleware.AuthRequired(), s.changePasswordHandler)
-		usersGroup.DELETE("/:id", middleware.AuthRequired(), middleware.RequirePermission("manage_users"), s.deleteUserHandler)
-		usersGroup.PATCH("/:id/must_change", middleware.AuthRequired(), middleware.RequirePermission("manage_users"), s.setMustChangeHandler)
-		usersGroup.POST("/:id/roles", middleware.AuthRequired(), middleware.RequirePermission("manage_users"), s.setRolesHandler)
+		usersGroup.POST("", middleware.AuthRequired(), middleware.RequirePermission("manage_users"), s.CreateUser)
+		usersGroup.GET("", middleware.AuthRequired(), middleware.RequirePermission("view_users"), s.ListUsers)
+		usersGroup.PUT("/password", middleware.AuthRequired(), s.ChangePassword)
+		usersGroup.DELETE("/:id", middleware.AuthRequired(), middleware.RequirePermission("manage_users"), func(c *gin.Context) {
+			id, err := strconv.Atoi(c.Param("id"))
+			if err != nil {
+				c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid user id"})
+				return
+			}
+			s.DeleteUser(c, id)
+		})
+		usersGroup.PATCH("/:id/must_change", middleware.AuthRequired(), middleware.RequirePermission("manage_users"), func(c *gin.Context) {
+			id, err := strconv.Atoi(c.Param("id"))
+			if err != nil {
+				c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid user id"})
+				return
+			}
+			s.SetMustChangePassword(c, id)
+		})
+		usersGroup.POST("/:id/roles", middleware.AuthRequired(), middleware.RequirePermission("manage_users"), func(c *gin.Context) {
+			id, err := strconv.Atoi(c.Param("id"))
+			if err != nil {
+				c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid user id"})
+				return
+			}
+			s.SetUserRoles(c, id)
+		})
 	}
 }

--- a/sensor_hub/api/users_api.go
+++ b/sensor_hub/api/users_api.go
@@ -3,30 +3,29 @@ package api
 import (
 	appProps "example/sensorHub/application_properties"
 	gen "example/sensorHub/gen"
-	"fmt"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
 )
 
-
-
-type createUserRequest struct {
-	Username string   `json:"username"`
-	Email    string   `json:"email"`
-	Password string   `json:"password"`
-	Roles    []string `json:"roles"`
-}
-
-func (s *Server) createUserHandler(c *gin.Context) {
+// CreateUser implements gen.ServerInterface.
+func (s *Server) CreateUser(c *gin.Context) {
 	ctx := c.Request.Context()
-	var req createUserRequest
+	var req gen.CreateUserRequest
 	if err := c.BindJSON(&req); err != nil {
 		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid request body"})
 		return
 	}
 
-	user := gen.User{Username: req.Username, Email: req.Email, Roles: req.Roles}
+	email := ""
+	if req.Email != nil {
+		email = *req.Email
+	}
+	roles := []string{}
+	if req.Roles != nil {
+		roles = *req.Roles
+	}
+	user := gen.User{Username: req.Username, Email: email, Roles: roles}
 	id, err := s.userService.CreateUser(ctx, user, req.Password)
 	if err != nil {
 		c.IndentedJSON(http.StatusInternalServerError, gin.H{"message": "failed to create user", "error": err.Error()})
@@ -35,7 +34,8 @@ func (s *Server) createUserHandler(c *gin.Context) {
 	c.IndentedJSON(http.StatusCreated, gin.H{"id": id})
 }
 
-func (s *Server) listUsersHandler(c *gin.Context) {
+// ListUsers implements gen.ServerInterface.
+func (s *Server) ListUsers(c *gin.Context) {
 	ctx := c.Request.Context()
 	users, err := s.userService.ListUsers(ctx)
 	if err != nil {
@@ -45,14 +45,10 @@ func (s *Server) listUsersHandler(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, users)
 }
 
-type changePasswordRequest struct {
-	UserId      int    `json:"user_id"`
-	NewPassword string `json:"new_password"`
-}
-
-func (s *Server) changePasswordHandler(c *gin.Context) {
+// ChangePassword implements gen.ServerInterface.
+func (s *Server) ChangePassword(c *gin.Context) {
 	ctx := c.Request.Context()
-	var req changePasswordRequest
+	var req gen.ChangePasswordRequest
 	if err := c.BindJSON(&req); err != nil {
 		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid request body"})
 		return
@@ -65,12 +61,11 @@ func (s *Server) changePasswordHandler(c *gin.Context) {
 		return
 	}
 
-	targetUserId := req.UserId
-	if targetUserId == 0 {
-		targetUserId = currentUser.Id
+	targetUserId := currentUser.Id
+	if req.UserId != nil {
+		targetUserId = *req.UserId
 	}
 	if currentUser.Id != targetUserId {
-
 		isAdmin := false
 		for _, r := range currentUser.Roles {
 			if r == "admin" {
@@ -101,19 +96,9 @@ func (s *Server) changePasswordHandler(c *gin.Context) {
 	c.Status(http.StatusOK)
 }
 
-func (s *Server) deleteUserHandler(c *gin.Context) {
+// DeleteUser implements gen.ServerInterface.
+func (s *Server) DeleteUser(c *gin.Context, id int) {
 	ctx := c.Request.Context()
-	idStr := c.Param("id")
-	if idStr == "" {
-		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "user id required"})
-		return
-	}
-	var id int
-	_, err := fmt.Sscan(idStr, &id)
-	if err != nil {
-		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid user id"})
-		return
-	}
 
 	currentUserObj, _ := c.Get("currentUser")
 	currentUser := currentUserObj.(*gen.User)
@@ -140,24 +125,10 @@ func (s *Server) deleteUserHandler(c *gin.Context) {
 	c.Status(http.StatusOK)
 }
 
-type mustChangeRequest struct {
-	MustChange bool `json:"must_change"`
-}
-
-func (s *Server) setMustChangeHandler(c *gin.Context) {
+// SetMustChangePassword implements gen.ServerInterface.
+func (s *Server) SetMustChangePassword(c *gin.Context, id int) {
 	ctx := c.Request.Context()
-	idStr := c.Param("id")
-	if idStr == "" {
-		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "user id required"})
-		return
-	}
-	var id int
-	_, err := fmt.Sscan(idStr, &id)
-	if err != nil {
-		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid user id"})
-		return
-	}
-	var req mustChangeRequest
+	var req gen.SetMustChangePasswordJSONRequestBody
 	if err := c.BindJSON(&req); err != nil {
 		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid request body"})
 		return
@@ -170,7 +141,6 @@ func (s *Server) setMustChangeHandler(c *gin.Context) {
 		return
 	}
 	if currentUser.Id != id {
-
 		isAdmin := false
 		for _, r := range currentUser.Roles {
 			if r == "admin" {
@@ -190,29 +160,14 @@ func (s *Server) setMustChangeHandler(c *gin.Context) {
 	c.Status(http.StatusOK)
 }
 
-type setRolesRequest struct {
-	Roles []string `json:"roles"`
-}
-
-func (s *Server) setRolesHandler(c *gin.Context) {
+// SetUserRoles implements gen.ServerInterface.
+func (s *Server) SetUserRoles(c *gin.Context, id int) {
 	ctx := c.Request.Context()
-	idStr := c.Param("id")
-	if idStr == "" {
-		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "user id required"})
-		return
-	}
-	var id int
-	_, err := fmt.Sscan(idStr, &id)
-	if err != nil {
-		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid user id"})
-		return
-	}
-	var req setRolesRequest
+	var req gen.SetUserRolesJSONRequestBody
 	if err := c.BindJSON(&req); err != nil {
 		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid request body"})
 		return
 	}
-	// admin only (middleware ensures currentUser present); we still check for demo
 	currentUserObj, _ := c.Get("currentUser")
 	currentUser := currentUserObj.(*gen.User)
 	if currentUser == nil {

--- a/sensor_hub/api/users_api_test.go
+++ b/sensor_hub/api/users_api_test.go
@@ -7,6 +7,7 @@ import (
 	gen "example/sensorHub/gen"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -24,9 +25,9 @@ func setupUserRouter() (*gin.Engine, *gin.RouterGroup, *Server, *MockUserService
 
 func TestCreateUserHandler_Success(t *testing.T) {
 	router, api, s, mockService := setupUserRouter()
-	api.POST("/users", s.createUserHandler)
+	api.POST("/users", s.CreateUser)
 
-	reqBody := createUserRequest{Username: "newuser", Password: "password"}
+	reqBody := gen.CreateUserRequest{Username: "newuser", Password: "password"}
 	jsonBody, _ := json.Marshal(reqBody)
 
 	mockService.On("CreateUser", mock.Anything, mock.AnythingOfType("gen.User"), "password").Return(1, nil)
@@ -40,7 +41,7 @@ func TestCreateUserHandler_Success(t *testing.T) {
 
 func TestListUsersHandler(t *testing.T) {
 	router, api, s, mockService := setupUserRouter()
-	api.GET("/users", s.listUsersHandler)
+	api.GET("/users", s.ListUsers)
 
 	mockService.On("ListUsers", mock.Anything).Return([]gen.User{{Username: "u1"}}, nil)
 
@@ -56,10 +57,11 @@ func TestChangePasswordHandler_Self(t *testing.T) {
 	router, api, s, mockService := setupUserRouter()
 	api.PUT("/users/password", func(c *gin.Context) {
 		c.Set("currentUser", &gen.User{Id: 1})
-		s.changePasswordHandler(c)
+		s.ChangePassword(c)
 	})
 
-	reqBody := changePasswordRequest{UserId: 1, NewPassword: "newpass"}
+	userId := 1
+	reqBody := gen.ChangePasswordRequest{UserId: &userId, NewPassword: "newpass"}
 	jsonBody, _ := json.Marshal(reqBody)
 
 	mockService.On("ChangePassword", mock.Anything, 1, "newpass", "valid-token").Return(nil)
@@ -76,7 +78,12 @@ func TestDeleteUserHandler_Admin(t *testing.T) {
 	router, api, s, mockService := setupUserRouter()
 	api.DELETE("/users/:id", func(c *gin.Context) {
 		c.Set("currentUser", &gen.User{Id: 1, Roles: []string{"admin"}})
-		s.deleteUserHandler(c)
+		id, err := strconv.Atoi(c.Param("id"))
+		if err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid user id"})
+			return
+		}
+		s.DeleteUser(c, id)
 	})
 
 	mockService.On("DeleteUser", mock.Anything, 2).Return(nil)
@@ -92,10 +99,15 @@ func TestSetMustChangeHandler_Admin(t *testing.T) {
 	router, api, s, mockService := setupUserRouter()
 	api.PUT("/users/:id/must-change-password", func(c *gin.Context) {
 		c.Set("currentUser", &gen.User{Id: 1, Roles: []string{"admin"}})
-		s.setMustChangeHandler(c)
+		id, err := strconv.Atoi(c.Param("id"))
+		if err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid user id"})
+			return
+		}
+		s.SetMustChangePassword(c, id)
 	})
 
-	reqBody := mustChangeRequest{MustChange: true}
+	reqBody := gen.SetMustChangePasswordJSONRequestBody{MustChange: true}
 	jsonBody, _ := json.Marshal(reqBody)
 
 	mockService.On("SetMustChangeFlag", mock.Anything, 2, true).Return(nil)
@@ -111,10 +123,15 @@ func TestSetRolesHandler_Admin(t *testing.T) {
 	router, api, s, mockService := setupUserRouter()
 	api.PUT("/users/:id/roles", func(c *gin.Context) {
 		c.Set("currentUser", &gen.User{Id: 1, Roles: []string{"admin"}})
-		s.setRolesHandler(c)
+		id, err := strconv.Atoi(c.Param("id"))
+		if err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid user id"})
+			return
+		}
+		s.SetUserRoles(c, id)
 	})
 
-	reqBody := setRolesRequest{Roles: []string{"admin"}}
+	reqBody := gen.SetUserRolesJSONRequestBody{Roles: []string{"admin"}}
 	jsonBody, _ := json.Marshal(reqBody)
 
 	mockService.On("SetUserRoles", mock.Anything, 2, []string{"admin"}).Return(nil)
@@ -128,7 +145,7 @@ func TestSetRolesHandler_Admin(t *testing.T) {
 
 func TestCreateUserHandler_InvalidJSON(t *testing.T) {
 	router, api, s, _ := setupUserRouter()
-	api.POST("/users", s.createUserHandler)
+	api.POST("/users", s.CreateUser)
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/users", bytes.NewBufferString("invalid"))
@@ -139,9 +156,9 @@ func TestCreateUserHandler_InvalidJSON(t *testing.T) {
 
 func TestCreateUserHandler_ServiceError(t *testing.T) {
 	router, api, s, mockService := setupUserRouter()
-	api.POST("/users", s.createUserHandler)
+	api.POST("/users", s.CreateUser)
 
-	reqBody := createUserRequest{Username: "newuser", Password: "password"}
+	reqBody := gen.CreateUserRequest{Username: "newuser", Password: "password"}
 	jsonBody, _ := json.Marshal(reqBody)
 
 	mockService.On("CreateUser", mock.Anything, mock.AnythingOfType("gen.User"), "password").Return(0, errors.New("db error"))
@@ -155,7 +172,7 @@ func TestCreateUserHandler_ServiceError(t *testing.T) {
 
 func TestListUsersHandler_ServiceError(t *testing.T) {
 	router, api, s, mockService := setupUserRouter()
-	api.GET("/users", s.listUsersHandler)
+	api.GET("/users", s.ListUsers)
 
 	mockService.On("ListUsers", mock.Anything).Return([]gen.User{}, errors.New("db error"))
 
@@ -170,7 +187,7 @@ func TestChangePasswordHandler_InvalidJSON(t *testing.T) {
 	router, api, s, _ := setupUserRouter()
 	api.PUT("/users/password", func(c *gin.Context) {
 		c.Set("currentUser", &gen.User{Id: 1})
-		s.changePasswordHandler(c)
+		s.ChangePassword(c)
 	})
 
 	w := httptest.NewRecorder()
@@ -184,10 +201,10 @@ func TestChangePasswordHandler_DefaultsToCurrentUser(t *testing.T) {
 	router, api, s, mockService := setupUserRouter()
 	api.PUT("/users/password", func(c *gin.Context) {
 		c.Set("currentUser", &gen.User{Id: 1})
-		s.changePasswordHandler(c)
+		s.ChangePassword(c)
 	})
 
-	reqBody := changePasswordRequest{UserId: 0, NewPassword: "newpass"}
+	reqBody := gen.ChangePasswordRequest{NewPassword: "newpass"}
 	jsonBody, _ := json.Marshal(reqBody)
 
 	mockService.On("ChangePassword", mock.Anything, 1, "newpass", "valid-token").Return(nil)
@@ -204,10 +221,11 @@ func TestChangePasswordHandler_AdminChangingOthers(t *testing.T) {
 	router, api, s, mockService := setupUserRouter()
 	api.PUT("/users/password", func(c *gin.Context) {
 		c.Set("currentUser", &gen.User{Id: 1, Roles: []string{"admin"}})
-		s.changePasswordHandler(c)
+		s.ChangePassword(c)
 	})
 
-	reqBody := changePasswordRequest{UserId: 2, NewPassword: "newpass"}
+	userId := 2
+	reqBody := gen.ChangePasswordRequest{UserId: &userId, NewPassword: "newpass"}
 	jsonBody, _ := json.Marshal(reqBody)
 
 	mockService.On("ChangePassword", mock.Anything, 2, "newpass", "").Return(nil)
@@ -223,10 +241,11 @@ func TestChangePasswordHandler_NonAdminForbidden(t *testing.T) {
 	router, api, s, _ := setupUserRouter()
 	api.PUT("/users/password", func(c *gin.Context) {
 		c.Set("currentUser", &gen.User{Id: 1, Roles: []string{"user"}})
-		s.changePasswordHandler(c)
+		s.ChangePassword(c)
 	})
 
-	reqBody := changePasswordRequest{UserId: 2, NewPassword: "newpass"}
+	userId := 2
+	reqBody := gen.ChangePasswordRequest{UserId: &userId, NewPassword: "newpass"}
 	jsonBody, _ := json.Marshal(reqBody)
 
 	w := httptest.NewRecorder()
@@ -240,10 +259,11 @@ func TestChangePasswordHandler_ServiceError(t *testing.T) {
 	router, api, s, mockService := setupUserRouter()
 	api.PUT("/users/password", func(c *gin.Context) {
 		c.Set("currentUser", &gen.User{Id: 1})
-		s.changePasswordHandler(c)
+		s.ChangePassword(c)
 	})
 
-	reqBody := changePasswordRequest{UserId: 1, NewPassword: "newpass"}
+	userId := 1
+	reqBody := gen.ChangePasswordRequest{UserId: &userId, NewPassword: "newpass"}
 	jsonBody, _ := json.Marshal(reqBody)
 
 	mockService.On("ChangePassword", mock.Anything, 1, "newpass", "valid-token").Return(errors.New("db error"))
@@ -260,7 +280,12 @@ func TestDeleteUserHandler_InvalidID(t *testing.T) {
 	router, api, s, _ := setupUserRouter()
 	api.DELETE("/users/:id", func(c *gin.Context) {
 		c.Set("currentUser", &gen.User{Id: 1, Roles: []string{"admin"}})
-		s.deleteUserHandler(c)
+		id, err := strconv.Atoi(c.Param("id"))
+		if err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid user id"})
+			return
+		}
+		s.DeleteUser(c, id)
 	})
 
 	w := httptest.NewRecorder()
@@ -274,7 +299,12 @@ func TestDeleteUserHandler_NonAdminForbidden(t *testing.T) {
 	router, api, s, _ := setupUserRouter()
 	api.DELETE("/users/:id", func(c *gin.Context) {
 		c.Set("currentUser", &gen.User{Id: 1, Roles: []string{"user"}})
-		s.deleteUserHandler(c)
+		id, err := strconv.Atoi(c.Param("id"))
+		if err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid user id"})
+			return
+		}
+		s.DeleteUser(c, id)
 	})
 
 	w := httptest.NewRecorder()
@@ -288,7 +318,12 @@ func TestDeleteUserHandler_CannotDeleteSelf(t *testing.T) {
 	router, api, s, _ := setupUserRouter()
 	api.DELETE("/users/:id", func(c *gin.Context) {
 		c.Set("currentUser", &gen.User{Id: 1, Roles: []string{"admin"}})
-		s.deleteUserHandler(c)
+		id, err := strconv.Atoi(c.Param("id"))
+		if err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid user id"})
+			return
+		}
+		s.DeleteUser(c, id)
 	})
 
 	w := httptest.NewRecorder()
@@ -302,7 +337,12 @@ func TestDeleteUserHandler_ServiceError(t *testing.T) {
 	router, api, s, mockService := setupUserRouter()
 	api.DELETE("/users/:id", func(c *gin.Context) {
 		c.Set("currentUser", &gen.User{Id: 1, Roles: []string{"admin"}})
-		s.deleteUserHandler(c)
+		id, err := strconv.Atoi(c.Param("id"))
+		if err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid user id"})
+			return
+		}
+		s.DeleteUser(c, id)
 	})
 
 	mockService.On("DeleteUser", mock.Anything, 2).Return(errors.New("db error"))
@@ -318,7 +358,12 @@ func TestSetMustChangeHandler_InvalidID(t *testing.T) {
 	router, api, s, _ := setupUserRouter()
 	api.PUT("/users/:id/must-change-password", func(c *gin.Context) {
 		c.Set("currentUser", &gen.User{Id: 1, Roles: []string{"admin"}})
-		s.setMustChangeHandler(c)
+		id, err := strconv.Atoi(c.Param("id"))
+		if err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid user id"})
+			return
+		}
+		s.SetMustChangePassword(c, id)
 	})
 
 	w := httptest.NewRecorder()
@@ -332,7 +377,12 @@ func TestSetMustChangeHandler_InvalidJSON(t *testing.T) {
 	router, api, s, _ := setupUserRouter()
 	api.PUT("/users/:id/must-change-password", func(c *gin.Context) {
 		c.Set("currentUser", &gen.User{Id: 1, Roles: []string{"admin"}})
-		s.setMustChangeHandler(c)
+		id, err := strconv.Atoi(c.Param("id"))
+		if err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid user id"})
+			return
+		}
+		s.SetMustChangePassword(c, id)
 	})
 
 	w := httptest.NewRecorder()
@@ -346,10 +396,15 @@ func TestSetMustChangeHandler_NonAdminForbidden(t *testing.T) {
 	router, api, s, _ := setupUserRouter()
 	api.PUT("/users/:id/must-change-password", func(c *gin.Context) {
 		c.Set("currentUser", &gen.User{Id: 1, Roles: []string{"user"}})
-		s.setMustChangeHandler(c)
+		id, err := strconv.Atoi(c.Param("id"))
+		if err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid user id"})
+			return
+		}
+		s.SetMustChangePassword(c, id)
 	})
 
-	reqBody := mustChangeRequest{MustChange: true}
+	reqBody := gen.SetMustChangePasswordJSONRequestBody{MustChange: true}
 	jsonBody, _ := json.Marshal(reqBody)
 
 	w := httptest.NewRecorder()
@@ -363,10 +418,15 @@ func TestSetMustChangeHandler_ServiceError(t *testing.T) {
 	router, api, s, mockService := setupUserRouter()
 	api.PUT("/users/:id/must-change-password", func(c *gin.Context) {
 		c.Set("currentUser", &gen.User{Id: 1, Roles: []string{"admin"}})
-		s.setMustChangeHandler(c)
+		id, err := strconv.Atoi(c.Param("id"))
+		if err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid user id"})
+			return
+		}
+		s.SetMustChangePassword(c, id)
 	})
 
-	reqBody := mustChangeRequest{MustChange: true}
+	reqBody := gen.SetMustChangePasswordJSONRequestBody{MustChange: true}
 	jsonBody, _ := json.Marshal(reqBody)
 
 	mockService.On("SetMustChangeFlag", mock.Anything, 2, true).Return(errors.New("db error"))
@@ -382,7 +442,12 @@ func TestSetRolesHandler_InvalidID(t *testing.T) {
 	router, api, s, _ := setupUserRouter()
 	api.PUT("/users/:id/roles", func(c *gin.Context) {
 		c.Set("currentUser", &gen.User{Id: 1, Roles: []string{"admin"}})
-		s.setRolesHandler(c)
+		id, err := strconv.Atoi(c.Param("id"))
+		if err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid user id"})
+			return
+		}
+		s.SetUserRoles(c, id)
 	})
 
 	w := httptest.NewRecorder()
@@ -396,7 +461,12 @@ func TestSetRolesHandler_InvalidJSON(t *testing.T) {
 	router, api, s, _ := setupUserRouter()
 	api.PUT("/users/:id/roles", func(c *gin.Context) {
 		c.Set("currentUser", &gen.User{Id: 1, Roles: []string{"admin"}})
-		s.setRolesHandler(c)
+		id, err := strconv.Atoi(c.Param("id"))
+		if err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid user id"})
+			return
+		}
+		s.SetUserRoles(c, id)
 	})
 
 	w := httptest.NewRecorder()
@@ -410,10 +480,15 @@ func TestSetRolesHandler_NonAdminForbidden(t *testing.T) {
 	router, api, s, _ := setupUserRouter()
 	api.PUT("/users/:id/roles", func(c *gin.Context) {
 		c.Set("currentUser", &gen.User{Id: 1, Roles: []string{"user"}})
-		s.setRolesHandler(c)
+		id, err := strconv.Atoi(c.Param("id"))
+		if err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid user id"})
+			return
+		}
+		s.SetUserRoles(c, id)
 	})
 
-	reqBody := setRolesRequest{Roles: []string{"admin"}}
+	reqBody := gen.SetUserRolesJSONRequestBody{Roles: []string{"admin"}}
 	jsonBody, _ := json.Marshal(reqBody)
 
 	w := httptest.NewRecorder()
@@ -427,10 +502,15 @@ func TestSetRolesHandler_ServiceError(t *testing.T) {
 	router, api, s, mockService := setupUserRouter()
 	api.PUT("/users/:id/roles", func(c *gin.Context) {
 		c.Set("currentUser", &gen.User{Id: 1, Roles: []string{"admin"}})
-		s.setRolesHandler(c)
+		id, err := strconv.Atoi(c.Param("id"))
+		if err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid user id"})
+			return
+		}
+		s.SetUserRoles(c, id)
 	})
 
-	reqBody := setRolesRequest{Roles: []string{"admin"}}
+	reqBody := gen.SetUserRolesJSONRequestBody{Roles: []string{"admin"}}
 	jsonBody, _ := json.Marshal(reqBody)
 
 	mockService.On("SetUserRoles", mock.Anything, 2, []string{"admin"}).Return(errors.New("db error"))


### PR DESCRIPTION
Closes #38

Migrates the auth, users, and notifications API handler groups to use generated `ServerInterface` method names and `gen/` types, following the pattern established in #35–#37.

## Changes

**Auth** (`auth_api.go`, `auth_routes.go`):
- Renamed 5 handlers to `Login`, `Logout`, `GetCurrentUser`, `ListSessions`, `RevokeSession(int64)`
- Removed local `loginRequest` struct; uses `gen.LoginRequest` / `gen.LoginResponse` / `gen.MeResponse`
- `ListSessions` converts `db.SessionInfo` → `gen.SessionInfo` (pointer fields)

**Users** (`users_api.go`, `user_routes.go`):
- Renamed 6 handlers to `CreateUser`, `ListUsers`, `ChangePassword`, `DeleteUser(int)`, `SetMustChangePassword(int)`, `SetUserRoles(int)`
- Removed 4 local request structs; uses generated equivalents
- Route closures parse `:id` with `strconv.Atoi`

**Notifications** (`notifications_api.go`, `notification_routes.go`, `notifications_api_test.go` new):
- Renamed 8 REST handlers to `ServerInterface` names
- `ListNotifications` extracts limit/offset/include_dismissed from `gen.ListNotificationsParams`
- `SetChannelPreference` converts `gen.ChannelPreference` → `notifications.ChannelPreference`
- Removed redundant `getCurrentUserID` helper and per-handler 401 guards (covered by `AuthRequired()` middleware)
- Added `MockNotificationService` to `mocks_test.go`; new `notifications_api_test.go` with 19 tests

All unit tests and integration tests pass.