### PR TITLE
Migrate dashboards/api-keys/mqtt/oauth handlers to generated types

### DIFF
--- a/sensor_hub/api/api_key_api.go
+++ b/sensor_hub/api/api_key_api.go
@@ -3,27 +3,18 @@ package api
 import (
 	gen "example/sensorHub/gen"
 	"net/http"
-	"strconv"
-	"time"
 
 	"github.com/gin-gonic/gin"
 )
 
-
-
-type createApiKeyRequest struct {
-	Name      string     `json:"name" binding:"required"`
-	ExpiresAt *time.Time `json:"expires_at"`
-}
-
-type updateExpiryRequest struct {
-	ExpiresAt *time.Time `json:"expires_at"`
-}
-
-func (s *Server) createApiKeyHandler(c *gin.Context) {
+func (s *Server) CreateApiKey(c *gin.Context) {
 	ctx := c.Request.Context()
-	var req createApiKeyRequest
+	var req gen.CreateApiKeyJSONRequestBody
 	if err := c.BindJSON(&req); err != nil {
+		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid request body"})
+		return
+	}
+	if req.Name == "" {
 		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid request body"})
 		return
 	}
@@ -42,7 +33,7 @@ func (s *Server) createApiKeyHandler(c *gin.Context) {
 	})
 }
 
-func (s *Server) listApiKeysHandler(c *gin.Context) {
+func (s *Server) ListApiKeys(c *gin.Context) {
 	ctx := c.Request.Context()
 	user := c.MustGet("currentUser").(*gen.User)
 
@@ -55,14 +46,8 @@ func (s *Server) listApiKeysHandler(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, keys)
 }
 
-func (s *Server) updateApiKeyExpiryHandler(c *gin.Context) {
-	id, err := strconv.Atoi(c.Param("id"))
-	if err != nil {
-		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid key id"})
-		return
-	}
-
-	var req updateExpiryRequest
+func (s *Server) UpdateApiKeyExpiry(c *gin.Context, id int) {
+	var req gen.UpdateApiKeyExpiryJSONRequestBody
 	if err := c.BindJSON(&req); err != nil {
 		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid request body"})
 		return
@@ -79,13 +64,7 @@ func (s *Server) updateApiKeyExpiryHandler(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, gin.H{"message": "expiry updated"})
 }
 
-func (s *Server) revokeApiKeyHandler(c *gin.Context) {
-	id, err := strconv.Atoi(c.Param("id"))
-	if err != nil {
-		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid key id"})
-		return
-	}
-
+func (s *Server) RevokeApiKey(c *gin.Context, id int) {
 	ctx := c.Request.Context()
 	user := c.MustGet("currentUser").(*gen.User)
 
@@ -97,13 +76,7 @@ func (s *Server) revokeApiKeyHandler(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, gin.H{"message": "api key revoked"})
 }
 
-func (s *Server) deleteApiKeyHandler(c *gin.Context) {
-	id, err := strconv.Atoi(c.Param("id"))
-	if err != nil {
-		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid key id"})
-		return
-	}
-
+func (s *Server) DeleteApiKey(c *gin.Context, id int) {
 	ctx := c.Request.Context()
 	user := c.MustGet("currentUser").(*gen.User)
 

--- a/sensor_hub/api/api_key_api_test.go
+++ b/sensor_hub/api/api_key_api_test.go
@@ -1,0 +1,269 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	db "example/sensorHub/db"
+	gen "example/sensorHub/gen"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func setupApiKeyRouter(method, path string, handler gin.HandlerFunc, userID int) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	apiGroup := router.Group("/api")
+	apiGroup.Use(func(c *gin.Context) {
+		c.Set("currentUser", &gen.User{Id: userID})
+		c.Next()
+	})
+	apiGroup.Handle(method, path, handler)
+	return router
+}
+
+func withApiKeyID(s *Server, h func(*gin.Context, int)) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		id, err := strconv.Atoi(c.Param("id"))
+		if err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid key id"})
+			return
+		}
+		h(c, id)
+	}
+}
+
+// --- ListApiKeys ---
+
+func TestListApiKeys_Success(t *testing.T) {
+	mockSvc := new(MockApiKeyService)
+	s := &Server{apiKeyService: mockSvc}
+
+	keys := []db.ApiKey{{Id: 1, Name: "my-key", UserId: 1}}
+	mockSvc.On("ListApiKeysForUser", mock.Anything, 1).Return(keys, nil)
+
+	router := setupApiKeyRouter("GET", "/api-keys", s.ListApiKeys, 1)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/api-keys", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "my-key")
+	mockSvc.AssertExpectations(t)
+}
+
+func TestListApiKeys_Error(t *testing.T) {
+	mockSvc := new(MockApiKeyService)
+	s := &Server{apiKeyService: mockSvc}
+
+	mockSvc.On("ListApiKeysForUser", mock.Anything, 1).Return([]db.ApiKey{}, errors.New("db error"))
+
+	router := setupApiKeyRouter("GET", "/api-keys", s.ListApiKeys, 1)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/api-keys", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	mockSvc.AssertExpectations(t)
+}
+
+// --- CreateApiKey ---
+
+func TestCreateApiKey_Success(t *testing.T) {
+	mockSvc := new(MockApiKeyService)
+	s := &Server{apiKeyService: mockSvc}
+
+	expires := time.Now().Add(24 * time.Hour)
+	mockSvc.On("CreateApiKey", mock.Anything, "test-key", 1, mock.AnythingOfType("*time.Time")).Return("prefix.secret", nil)
+
+	body, _ := json.Marshal(map[string]interface{}{"name": "test-key", "expires_at": expires})
+	router := setupApiKeyRouter("POST", "/api-keys", s.CreateApiKey, 1)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/api-keys", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+	assert.Contains(t, w.Body.String(), "prefix.secret")
+	mockSvc.AssertExpectations(t)
+}
+
+func TestCreateApiKey_MissingName(t *testing.T) {
+	mockSvc := new(MockApiKeyService)
+	s := &Server{apiKeyService: mockSvc}
+
+	body := []byte(`{"expires_at": null}`)
+	router := setupApiKeyRouter("POST", "/api-keys", s.CreateApiKey, 1)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/api-keys", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestCreateApiKey_Error(t *testing.T) {
+	mockSvc := new(MockApiKeyService)
+	s := &Server{apiKeyService: mockSvc}
+
+	mockSvc.On("CreateApiKey", mock.Anything, "test-key", 1, mock.Anything).Return("", errors.New("db error"))
+
+	body := []byte(`{"name":"test-key"}`)
+	router := setupApiKeyRouter("POST", "/api-keys", s.CreateApiKey, 1)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/api-keys", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	mockSvc.AssertExpectations(t)
+}
+
+// --- UpdateApiKeyExpiry ---
+
+func TestUpdateApiKeyExpiry_Success(t *testing.T) {
+	mockSvc := new(MockApiKeyService)
+	s := &Server{apiKeyService: mockSvc}
+
+	expires := time.Now().Add(48 * time.Hour)
+	mockSvc.On("UpdateApiKeyExpiry", mock.Anything, 5, 1, mock.AnythingOfType("*time.Time")).Return(nil)
+
+	body, _ := json.Marshal(map[string]interface{}{"expires_at": expires})
+	router := setupApiKeyRouter("PATCH", "/api-keys/:id/expiry", withApiKeyID(s, s.UpdateApiKeyExpiry), 1)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("PATCH", "/api/api-keys/5/expiry", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "expiry updated")
+	mockSvc.AssertExpectations(t)
+}
+
+func TestUpdateApiKeyExpiry_InvalidID(t *testing.T) {
+	mockSvc := new(MockApiKeyService)
+	s := &Server{apiKeyService: mockSvc}
+
+	router := setupApiKeyRouter("PATCH", "/api-keys/:id/expiry", withApiKeyID(s, s.UpdateApiKeyExpiry), 1)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("PATCH", "/api/api-keys/abc/expiry", bytes.NewReader([]byte(`{}`)))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestUpdateApiKeyExpiry_Error(t *testing.T) {
+	mockSvc := new(MockApiKeyService)
+	s := &Server{apiKeyService: mockSvc}
+
+	mockSvc.On("UpdateApiKeyExpiry", mock.Anything, 5, 1, mock.Anything).Return(errors.New("not found"))
+
+	body := []byte(`{"expires_at": null}`)
+	router := setupApiKeyRouter("PATCH", "/api-keys/:id/expiry", withApiKeyID(s, s.UpdateApiKeyExpiry), 1)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("PATCH", "/api/api-keys/5/expiry", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	mockSvc.AssertExpectations(t)
+}
+
+// --- RevokeApiKey ---
+
+func TestRevokeApiKey_Success(t *testing.T) {
+	mockSvc := new(MockApiKeyService)
+	s := &Server{apiKeyService: mockSvc}
+
+	mockSvc.On("RevokeApiKey", mock.Anything, 3, 1).Return(nil)
+
+	router := setupApiKeyRouter("POST", "/api-keys/:id/revoke", withApiKeyID(s, s.RevokeApiKey), 1)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/api-keys/3/revoke", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "api key revoked")
+	mockSvc.AssertExpectations(t)
+}
+
+func TestRevokeApiKey_InvalidID(t *testing.T) {
+	mockSvc := new(MockApiKeyService)
+	s := &Server{apiKeyService: mockSvc}
+
+	router := setupApiKeyRouter("POST", "/api-keys/:id/revoke", withApiKeyID(s, s.RevokeApiKey), 1)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/api-keys/abc/revoke", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestRevokeApiKey_Error(t *testing.T) {
+	mockSvc := new(MockApiKeyService)
+	s := &Server{apiKeyService: mockSvc}
+
+	mockSvc.On("RevokeApiKey", mock.Anything, 3, 1).Return(errors.New("not found"))
+
+	router := setupApiKeyRouter("POST", "/api-keys/:id/revoke", withApiKeyID(s, s.RevokeApiKey), 1)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/api-keys/3/revoke", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	mockSvc.AssertExpectations(t)
+}
+
+// --- DeleteApiKey ---
+
+func TestDeleteApiKey_Success(t *testing.T) {
+	mockSvc := new(MockApiKeyService)
+	s := &Server{apiKeyService: mockSvc}
+
+	mockSvc.On("DeleteApiKey", mock.Anything, 7, 1).Return(nil)
+
+	router := setupApiKeyRouter("DELETE", "/api-keys/:id", withApiKeyID(s, s.DeleteApiKey), 1)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("DELETE", "/api/api-keys/7", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "api key deleted")
+	mockSvc.AssertExpectations(t)
+}
+
+func TestDeleteApiKey_InvalidID(t *testing.T) {
+	mockSvc := new(MockApiKeyService)
+	s := &Server{apiKeyService: mockSvc}
+
+	router := setupApiKeyRouter("DELETE", "/api-keys/:id", withApiKeyID(s, s.DeleteApiKey), 1)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("DELETE", "/api/api-keys/abc", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestDeleteApiKey_Error(t *testing.T) {
+	mockSvc := new(MockApiKeyService)
+	s := &Server{apiKeyService: mockSvc}
+
+	mockSvc.On("DeleteApiKey", mock.Anything, 7, 1).Return(errors.New("forbidden"))
+
+	router := setupApiKeyRouter("DELETE", "/api-keys/:id", withApiKeyID(s, s.DeleteApiKey), 1)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("DELETE", "/api/api-keys/7", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	mockSvc.AssertExpectations(t)
+}

--- a/sensor_hub/api/api_key_routes.go
+++ b/sensor_hub/api/api_key_routes.go
@@ -1,6 +1,9 @@
 package api
 
 import (
+	"net/http"
+	"strconv"
+
 	"example/sensorHub/api/middleware"
 
 	"github.com/gin-gonic/gin"
@@ -9,10 +12,31 @@ import (
 func (s *Server) RegisterApiKeyRoutes(router gin.IRouter) {
 	keysGroup := router.Group("/api-keys")
 	{
-		keysGroup.POST("", middleware.AuthRequired(), middleware.RequirePermission("manage_api_keys"), s.createApiKeyHandler)
-		keysGroup.GET("", middleware.AuthRequired(), middleware.RequirePermission("manage_api_keys"), s.listApiKeysHandler)
-		keysGroup.PATCH("/:id/expiry", middleware.AuthRequired(), middleware.RequirePermission("manage_api_keys"), s.updateApiKeyExpiryHandler)
-		keysGroup.POST("/:id/revoke", middleware.AuthRequired(), middleware.RequirePermission("manage_api_keys"), s.revokeApiKeyHandler)
-		keysGroup.DELETE("/:id", middleware.AuthRequired(), middleware.RequirePermission("manage_api_keys"), s.deleteApiKeyHandler)
+		keysGroup.POST("", middleware.AuthRequired(), middleware.RequirePermission("manage_api_keys"), s.CreateApiKey)
+		keysGroup.GET("", middleware.AuthRequired(), middleware.RequirePermission("manage_api_keys"), s.ListApiKeys)
+		keysGroup.PATCH("/:id/expiry", middleware.AuthRequired(), middleware.RequirePermission("manage_api_keys"), func(c *gin.Context) {
+			id, err := strconv.Atoi(c.Param("id"))
+			if err != nil {
+				c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid key id"})
+				return
+			}
+			s.UpdateApiKeyExpiry(c, id)
+		})
+		keysGroup.POST("/:id/revoke", middleware.AuthRequired(), middleware.RequirePermission("manage_api_keys"), func(c *gin.Context) {
+			id, err := strconv.Atoi(c.Param("id"))
+			if err != nil {
+				c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid key id"})
+				return
+			}
+			s.RevokeApiKey(c, id)
+		})
+		keysGroup.DELETE("/:id", middleware.AuthRequired(), middleware.RequirePermission("manage_api_keys"), func(c *gin.Context) {
+			id, err := strconv.Atoi(c.Param("id"))
+			if err != nil {
+				c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid key id"})
+				return
+			}
+			s.DeleteApiKey(c, id)
+		})
 	}
 }

--- a/sensor_hub/api/auth_api.go
+++ b/sensor_hub/api/auth_api.go
@@ -13,7 +13,6 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// Login implements gen.ServerInterface.
 func (s *Server) Login(c *gin.Context) {
 	ctx := c.Request.Context()
 	var req gen.LoginRequest
@@ -70,7 +69,6 @@ func (s *Server) Login(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, gen.LoginResponse{MustChangePassword: &mustChange, CsrfToken: &csrf})
 }
 
-// Logout implements gen.ServerInterface.
 func (s *Server) Logout(c *gin.Context) {
 	ctx := c.Request.Context()
 	cookieName := "sensor_hub_session"
@@ -89,7 +87,6 @@ func (s *Server) Logout(c *gin.Context) {
 	c.Status(http.StatusOK)
 }
 
-// GetCurrentUser implements gen.ServerInterface.
 func (s *Server) GetCurrentUser(c *gin.Context) {
 	ctx := c.Request.Context()
 	u, exists := c.Get("currentUser")
@@ -117,7 +114,6 @@ func (s *Server) GetCurrentUser(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, gen.MeResponse{User: user, CsrfToken: csrfPtr})
 }
 
-// ListSessions implements gen.ServerInterface.
 func (s *Server) ListSessions(c *gin.Context) {
 	ctx := c.Request.Context()
 	u, _ := c.Get("currentUser")
@@ -158,7 +154,6 @@ func (s *Server) ListSessions(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, out)
 }
 
-// RevokeSession implements gen.ServerInterface.
 func (s *Server) RevokeSession(c *gin.Context, id int64) {
 	ctx := c.Request.Context()
 

--- a/sensor_hub/api/dashboard_api.go
+++ b/sensor_hub/api/dashboard_api.go
@@ -2,16 +2,13 @@ package api
 
 import (
 	"net/http"
-	"strconv"
 
 	gen "example/sensorHub/gen"
 
 	"github.com/gin-gonic/gin"
 )
 
-
-
-func (s *Server) listDashboardsHandler(c *gin.Context) {
+func (s *Server) ListDashboards(c *gin.Context) {
 	ctx := c.Request.Context()
 	user := c.MustGet("currentUser").(*gen.User)
 
@@ -26,13 +23,8 @@ func (s *Server) listDashboardsHandler(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, dashboards)
 }
 
-func (s *Server) getDashboardHandler(c *gin.Context) {
+func (s *Server) GetDashboard(c *gin.Context, id int) {
 	ctx := c.Request.Context()
-	id, err := strconv.Atoi(c.Param("id"))
-	if err != nil {
-		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid dashboard ID"})
-		return
-	}
 
 	dashboard, err := s.dashboardService.ServiceGetDashboard(ctx, id)
 	if err != nil {
@@ -46,7 +38,7 @@ func (s *Server) getDashboardHandler(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, dashboard)
 }
 
-func (s *Server) createDashboardHandler(c *gin.Context) {
+func (s *Server) CreateDashboard(c *gin.Context) {
 	ctx := c.Request.Context()
 	user := c.MustGet("currentUser").(*gen.User)
 
@@ -68,14 +60,9 @@ func (s *Server) createDashboardHandler(c *gin.Context) {
 	c.IndentedJSON(http.StatusCreated, gin.H{"id": id})
 }
 
-func (s *Server) updateDashboardHandler(c *gin.Context) {
+func (s *Server) UpdateDashboard(c *gin.Context, id int) {
 	ctx := c.Request.Context()
 	user := c.MustGet("currentUser").(*gen.User)
-	id, err := strconv.Atoi(c.Param("id"))
-	if err != nil {
-		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid dashboard ID"})
-		return
-	}
 
 	var req gen.UpdateDashboardRequest
 	if err := c.BindJSON(&req); err != nil {
@@ -90,14 +77,9 @@ func (s *Server) updateDashboardHandler(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, gin.H{"message": "Dashboard updated"})
 }
 
-func (s *Server) deleteDashboardHandler(c *gin.Context) {
+func (s *Server) DeleteDashboard(c *gin.Context, id int) {
 	ctx := c.Request.Context()
 	user := c.MustGet("currentUser").(*gen.User)
-	id, err := strconv.Atoi(c.Param("id"))
-	if err != nil {
-		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid dashboard ID"})
-		return
-	}
 
 	if err := s.dashboardService.ServiceDeleteDashboard(ctx, user.Id, id); err != nil {
 		c.IndentedJSON(http.StatusInternalServerError, gin.H{"message": err.Error()})
@@ -106,14 +88,9 @@ func (s *Server) deleteDashboardHandler(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, gin.H{"message": "Dashboard deleted"})
 }
 
-func (s *Server) shareDashboardHandler(c *gin.Context) {
+func (s *Server) ShareDashboard(c *gin.Context, id int) {
 	ctx := c.Request.Context()
 	user := c.MustGet("currentUser").(*gen.User)
-	id, err := strconv.Atoi(c.Param("id"))
-	if err != nil {
-		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid dashboard ID"})
-		return
-	}
 
 	var req gen.ShareDashboardRequest
 	if err := c.BindJSON(&req); err != nil {
@@ -128,14 +105,9 @@ func (s *Server) shareDashboardHandler(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, gin.H{"message": "Dashboard shared"})
 }
 
-func (s *Server) setDefaultDashboardHandler(c *gin.Context) {
+func (s *Server) SetDefaultDashboard(c *gin.Context, id int) {
 	ctx := c.Request.Context()
 	user := c.MustGet("currentUser").(*gen.User)
-	id, err := strconv.Atoi(c.Param("id"))
-	if err != nil {
-		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid dashboard ID"})
-		return
-	}
 
 	if err := s.dashboardService.ServiceSetDefaultDashboard(ctx, user.Id, id); err != nil {
 		c.IndentedJSON(http.StatusInternalServerError, gin.H{"message": err.Error()})

--- a/sensor_hub/api/dashboard_api_test.go
+++ b/sensor_hub/api/dashboard_api_test.go
@@ -8,6 +8,7 @@ import (
 	gen "example/sensorHub/gen"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 	"time"
 
@@ -102,7 +103,7 @@ func TestListDashboardsHandler(t *testing.T) {
 	expected := []gen.Dashboard{sampleDashboard()}
 	mockSvc.On("ServiceListDashboards", mock.Anything, 1).Return(expected, nil)
 
-	router := setupDashboardRouter("GET", "/dashboards/", s.listDashboardsHandler, 1)
+	router := setupDashboardRouter("GET", "/dashboards/", s.ListDashboards, 1)
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/dashboards/", nil)
 	router.ServeHTTP(w, req)
@@ -118,7 +119,7 @@ func TestListDashboardsHandler_EmptyReturnsArray(t *testing.T) {
 
 	mockSvc.On("ServiceListDashboards", mock.Anything, 1).Return(nil, nil)
 
-	router := setupDashboardRouter("GET", "/dashboards/", s.listDashboardsHandler, 1)
+	router := setupDashboardRouter("GET", "/dashboards/", s.ListDashboards, 1)
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/dashboards/", nil)
 	router.ServeHTTP(w, req)
@@ -134,7 +135,7 @@ func TestListDashboardsHandler_Error(t *testing.T) {
 
 	mockSvc.On("ServiceListDashboards", mock.Anything, 1).Return(nil, errors.New("db error"))
 
-	router := setupDashboardRouter("GET", "/dashboards/", s.listDashboardsHandler, 1)
+	router := setupDashboardRouter("GET", "/dashboards/", s.ListDashboards, 1)
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/dashboards/", nil)
 	router.ServeHTTP(w, req)
@@ -145,6 +146,17 @@ func TestListDashboardsHandler_Error(t *testing.T) {
 
 // --- Get ---
 
+func withDashboardID(s *Server, h func(*gin.Context, int)) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		id, err := strconv.Atoi(c.Param("id"))
+		if err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid dashboard ID"})
+			return
+		}
+		h(c, id)
+	}
+}
+
 func TestGetDashboardHandler(t *testing.T) {
 	mockSvc := new(mockDashboardService)
 	s := &Server{dashboardService: mockSvc}
@@ -152,7 +164,7 @@ func TestGetDashboardHandler(t *testing.T) {
 	d := sampleDashboard()
 	mockSvc.On("ServiceGetDashboard", mock.Anything, 1).Return(&d, nil)
 
-	router := setupDashboardRouter("GET", "/dashboards/:id", s.getDashboardHandler, 1)
+	router := setupDashboardRouter("GET", "/dashboards/:id", withDashboardID(s, s.GetDashboard), 1)
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/dashboards/1", nil)
 	router.ServeHTTP(w, req)
@@ -168,7 +180,7 @@ func TestGetDashboardHandler_NotFound(t *testing.T) {
 
 	mockSvc.On("ServiceGetDashboard", mock.Anything, 99).Return(nil, nil)
 
-	router := setupDashboardRouter("GET", "/dashboards/:id", s.getDashboardHandler, 1)
+	router := setupDashboardRouter("GET", "/dashboards/:id", withDashboardID(s, s.GetDashboard), 1)
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/dashboards/99", nil)
 	router.ServeHTTP(w, req)
@@ -181,7 +193,7 @@ func TestGetDashboardHandler_InvalidID(t *testing.T) {
 	mockSvc := new(mockDashboardService)
 	s := &Server{dashboardService: mockSvc}
 
-	router := setupDashboardRouter("GET", "/dashboards/:id", s.getDashboardHandler, 1)
+	router := setupDashboardRouter("GET", "/dashboards/:id", withDashboardID(s, s.GetDashboard), 1)
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/dashboards/abc", nil)
 	router.ServeHTTP(w, req)
@@ -200,7 +212,7 @@ func TestCreateDashboardHandler(t *testing.T) {
 	})).Return(42, nil)
 
 	body, _ := json.Marshal(gen.CreateDashboardRequest{Name: "New Dashboard"})
-	router := setupDashboardRouter("POST", "/dashboards/", s.createDashboardHandler, 1)
+	router := setupDashboardRouter("POST", "/dashboards/", s.CreateDashboard, 1)
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/dashboards/", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -215,7 +227,7 @@ func TestCreateDashboardHandler_InvalidBody(t *testing.T) {
 	mockSvc := new(mockDashboardService)
 	s := &Server{dashboardService: mockSvc}
 
-	router := setupDashboardRouter("POST", "/dashboards/", s.createDashboardHandler, 1)
+	router := setupDashboardRouter("POST", "/dashboards/", s.CreateDashboard, 1)
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/dashboards/", bytes.NewReader([]byte(`{}`)))
 	req.Header.Set("Content-Type", "application/json")
@@ -231,7 +243,7 @@ func TestCreateDashboardHandler_Error(t *testing.T) {
 	mockSvc.On("ServiceCreateDashboard", mock.Anything, 1, mock.Anything).Return(0, errors.New("db error"))
 
 	body, _ := json.Marshal(gen.CreateDashboardRequest{Name: "Fail"})
-	router := setupDashboardRouter("POST", "/dashboards/", s.createDashboardHandler, 1)
+	router := setupDashboardRouter("POST", "/dashboards/", s.CreateDashboard, 1)
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/dashboards/", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -250,7 +262,7 @@ func TestUpdateDashboardHandler(t *testing.T) {
 	mockSvc.On("ServiceUpdateDashboard", mock.Anything, 1, 5, mock.Anything).Return(nil)
 
 	body := []byte(`{"name":"Renamed"}`)
-	router := setupDashboardRouter("PUT", "/dashboards/:id", s.updateDashboardHandler, 1)
+	router := setupDashboardRouter("PUT", "/dashboards/:id", withDashboardID(s, s.UpdateDashboard), 1)
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("PUT", "/api/dashboards/5", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -265,7 +277,7 @@ func TestUpdateDashboardHandler_InvalidID(t *testing.T) {
 	mockSvc := new(mockDashboardService)
 	s := &Server{dashboardService: mockSvc}
 
-	router := setupDashboardRouter("PUT", "/dashboards/:id", s.updateDashboardHandler, 1)
+	router := setupDashboardRouter("PUT", "/dashboards/:id", withDashboardID(s, s.UpdateDashboard), 1)
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("PUT", "/api/dashboards/xyz", bytes.NewReader([]byte(`{"name":"X"}`)))
 	req.Header.Set("Content-Type", "application/json")
@@ -281,7 +293,7 @@ func TestUpdateDashboardHandler_Error(t *testing.T) {
 	mockSvc.On("ServiceUpdateDashboard", mock.Anything, 1, 5, mock.Anything).Return(errors.New("not owner"))
 
 	body := []byte(`{"name":"X"}`)
-	router := setupDashboardRouter("PUT", "/dashboards/:id", s.updateDashboardHandler, 1)
+	router := setupDashboardRouter("PUT", "/dashboards/:id", withDashboardID(s, s.UpdateDashboard), 1)
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("PUT", "/api/dashboards/5", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -300,7 +312,7 @@ func TestDeleteDashboardHandler(t *testing.T) {
 
 	mockSvc.On("ServiceDeleteDashboard", mock.Anything, 1, 3).Return(nil)
 
-	router := setupDashboardRouter("DELETE", "/dashboards/:id", s.deleteDashboardHandler, 1)
+	router := setupDashboardRouter("DELETE", "/dashboards/:id", withDashboardID(s, s.DeleteDashboard), 1)
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("DELETE", "/api/dashboards/3", nil)
 	router.ServeHTTP(w, req)
@@ -314,7 +326,7 @@ func TestDeleteDashboardHandler_InvalidID(t *testing.T) {
 	mockSvc := new(mockDashboardService)
 	s := &Server{dashboardService: mockSvc}
 
-	router := setupDashboardRouter("DELETE", "/dashboards/:id", s.deleteDashboardHandler, 1)
+	router := setupDashboardRouter("DELETE", "/dashboards/:id", withDashboardID(s, s.DeleteDashboard), 1)
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("DELETE", "/api/dashboards/abc", nil)
 	router.ServeHTTP(w, req)
@@ -328,7 +340,7 @@ func TestDeleteDashboardHandler_Error(t *testing.T) {
 
 	mockSvc.On("ServiceDeleteDashboard", mock.Anything, 1, 3).Return(errors.New("forbidden"))
 
-	router := setupDashboardRouter("DELETE", "/dashboards/:id", s.deleteDashboardHandler, 1)
+	router := setupDashboardRouter("DELETE", "/dashboards/:id", withDashboardID(s, s.DeleteDashboard), 1)
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("DELETE", "/api/dashboards/3", nil)
 	router.ServeHTTP(w, req)
@@ -346,7 +358,7 @@ func TestShareDashboardHandler(t *testing.T) {
 	mockSvc.On("ServiceShareDashboard", mock.Anything, 1, 5, 2).Return(nil)
 
 	body, _ := json.Marshal(gen.ShareDashboardRequest{TargetUserId: 2})
-	router := setupDashboardRouter("POST", "/dashboards/:id/share", s.shareDashboardHandler, 1)
+	router := setupDashboardRouter("POST", "/dashboards/:id/share", withDashboardID(s, s.ShareDashboard), 1)
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/dashboards/5/share", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -361,7 +373,7 @@ func TestShareDashboardHandler_InvalidID(t *testing.T) {
 	mockSvc := new(mockDashboardService)
 	s := &Server{dashboardService: mockSvc}
 
-	router := setupDashboardRouter("POST", "/dashboards/:id/share", s.shareDashboardHandler, 1)
+	router := setupDashboardRouter("POST", "/dashboards/:id/share", withDashboardID(s, s.ShareDashboard), 1)
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/dashboards/abc/share", bytes.NewReader([]byte(`{"target_user_id":2}`)))
 	req.Header.Set("Content-Type", "application/json")
@@ -377,7 +389,7 @@ func TestShareDashboardHandler_Error(t *testing.T) {
 	mockSvc.On("ServiceShareDashboard", mock.Anything, 1, 5, 2).Return(errors.New("not found"))
 
 	body, _ := json.Marshal(gen.ShareDashboardRequest{TargetUserId: 2})
-	router := setupDashboardRouter("POST", "/dashboards/:id/share", s.shareDashboardHandler, 1)
+	router := setupDashboardRouter("POST", "/dashboards/:id/share", withDashboardID(s, s.ShareDashboard), 1)
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/dashboards/5/share", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -395,7 +407,7 @@ func TestSetDefaultDashboardHandler(t *testing.T) {
 
 	mockSvc.On("ServiceSetDefaultDashboard", mock.Anything, 1, 7).Return(nil)
 
-	router := setupDashboardRouter("PUT", "/dashboards/:id/default", s.setDefaultDashboardHandler, 1)
+	router := setupDashboardRouter("PUT", "/dashboards/:id/default", withDashboardID(s, s.SetDefaultDashboard), 1)
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("PUT", "/api/dashboards/7/default", nil)
 	router.ServeHTTP(w, req)
@@ -409,7 +421,7 @@ func TestSetDefaultDashboardHandler_InvalidID(t *testing.T) {
 	mockSvc := new(mockDashboardService)
 	s := &Server{dashboardService: mockSvc}
 
-	router := setupDashboardRouter("PUT", "/dashboards/:id/default", s.setDefaultDashboardHandler, 1)
+	router := setupDashboardRouter("PUT", "/dashboards/:id/default", withDashboardID(s, s.SetDefaultDashboard), 1)
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("PUT", "/api/dashboards/abc/default", nil)
 	router.ServeHTTP(w, req)
@@ -423,7 +435,7 @@ func TestSetDefaultDashboardHandler_Error(t *testing.T) {
 
 	mockSvc.On("ServiceSetDefaultDashboard", mock.Anything, 1, 7).Return(errors.New("db error"))
 
-	router := setupDashboardRouter("PUT", "/dashboards/:id/default", s.setDefaultDashboardHandler, 1)
+	router := setupDashboardRouter("PUT", "/dashboards/:id/default", withDashboardID(s, s.SetDefaultDashboard), 1)
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("PUT", "/api/dashboards/7/default", nil)
 	router.ServeHTTP(w, req)

--- a/sensor_hub/api/dashboard_routes.go
+++ b/sensor_hub/api/dashboard_routes.go
@@ -1,6 +1,9 @@
 package api
 
 import (
+	"net/http"
+	"strconv"
+
 	"example/sensorHub/api/middleware"
 
 	"github.com/gin-gonic/gin"
@@ -9,12 +12,47 @@ import (
 func (s *Server) RegisterDashboardRoutes(router gin.IRouter) {
 	group := router.Group("/dashboards")
 	{
-		group.GET("", middleware.AuthRequired(), middleware.RequirePermission("view_dashboards"), s.listDashboardsHandler)
-		group.POST("", middleware.AuthRequired(), middleware.RequirePermission("manage_dashboards"), s.createDashboardHandler)
-		group.GET("/:id", middleware.AuthRequired(), middleware.RequirePermission("view_dashboards"), s.getDashboardHandler)
-		group.PUT("/:id", middleware.AuthRequired(), middleware.RequirePermission("manage_dashboards"), s.updateDashboardHandler)
-		group.DELETE("/:id", middleware.AuthRequired(), middleware.RequirePermission("manage_dashboards"), s.deleteDashboardHandler)
-		group.POST("/:id/share", middleware.AuthRequired(), middleware.RequirePermission("manage_dashboards"), s.shareDashboardHandler)
-		group.PUT("/:id/default", middleware.AuthRequired(), middleware.RequirePermission("manage_dashboards"), s.setDefaultDashboardHandler)
+		group.GET("", middleware.AuthRequired(), middleware.RequirePermission("view_dashboards"), s.ListDashboards)
+		group.POST("", middleware.AuthRequired(), middleware.RequirePermission("manage_dashboards"), s.CreateDashboard)
+		group.GET("/:id", middleware.AuthRequired(), middleware.RequirePermission("view_dashboards"), func(c *gin.Context) {
+			id, err := strconv.Atoi(c.Param("id"))
+			if err != nil {
+				c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid dashboard ID"})
+				return
+			}
+			s.GetDashboard(c, id)
+		})
+		group.PUT("/:id", middleware.AuthRequired(), middleware.RequirePermission("manage_dashboards"), func(c *gin.Context) {
+			id, err := strconv.Atoi(c.Param("id"))
+			if err != nil {
+				c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid dashboard ID"})
+				return
+			}
+			s.UpdateDashboard(c, id)
+		})
+		group.DELETE("/:id", middleware.AuthRequired(), middleware.RequirePermission("manage_dashboards"), func(c *gin.Context) {
+			id, err := strconv.Atoi(c.Param("id"))
+			if err != nil {
+				c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid dashboard ID"})
+				return
+			}
+			s.DeleteDashboard(c, id)
+		})
+		group.POST("/:id/share", middleware.AuthRequired(), middleware.RequirePermission("manage_dashboards"), func(c *gin.Context) {
+			id, err := strconv.Atoi(c.Param("id"))
+			if err != nil {
+				c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid dashboard ID"})
+				return
+			}
+			s.ShareDashboard(c, id)
+		})
+		group.PUT("/:id/default", middleware.AuthRequired(), middleware.RequirePermission("manage_dashboards"), func(c *gin.Context) {
+			id, err := strconv.Atoi(c.Param("id"))
+			if err != nil {
+				c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid dashboard ID"})
+				return
+			}
+			s.SetDefaultDashboard(c, id)
+		})
 	}
 }

--- a/sensor_hub/api/driver_api.go
+++ b/sensor_hub/api/driver_api.go
@@ -8,7 +8,6 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// ListDrivers implements gen.ServerInterface.
 func (s *Server) ListDrivers(c *gin.Context, params gen.ListDriversParams) {
 	allDrivers := drivers.All()
 

--- a/sensor_hub/api/health_api.go
+++ b/sensor_hub/api/health_api.go
@@ -6,7 +6,6 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// GetHealth implements gen.ServerInterface.
 func (s *Server) GetHealth(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"status": "ok"})
 }

--- a/sensor_hub/api/mocks_test.go
+++ b/sensor_hub/api/mocks_test.go
@@ -7,6 +7,7 @@ import (
 	"example/sensorHub/notifications"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/mock"
+	"time"
 )
 
 // setupTestRouter creates a test router registering a single GET handler.
@@ -362,6 +363,47 @@ func (m *MockNotificationService) SetChannelPreference(ctx context.Context, user
 func (m *MockNotificationService) ShouldNotifyChannel(ctx context.Context, userID int, category notifications.NotificationCategory, channel string) (bool, error) {
 	args := m.Called(ctx, userID, category, channel)
 	return args.Bool(0), args.Error(1)
+}
+
+// ============================================================================
+// MockApiKeyService
+// ============================================================================
+
+type MockApiKeyService struct {
+	mock.Mock
+}
+
+func (m *MockApiKeyService) CreateApiKey(ctx context.Context, name string, userId int, expiresAt *time.Time) (string, error) {
+	args := m.Called(ctx, name, userId, expiresAt)
+	return args.String(0), args.Error(1)
+}
+
+func (m *MockApiKeyService) ListApiKeysForUser(ctx context.Context, userId int) ([]db.ApiKey, error) {
+	args := m.Called(ctx, userId)
+	return args.Get(0).([]db.ApiKey), args.Error(1)
+}
+
+func (m *MockApiKeyService) UpdateApiKeyExpiry(ctx context.Context, keyId int, userId int, expiresAt *time.Time) error {
+	args := m.Called(ctx, keyId, userId, expiresAt)
+	return args.Error(0)
+}
+
+func (m *MockApiKeyService) RevokeApiKey(ctx context.Context, keyId int, userId int) error {
+	args := m.Called(ctx, keyId, userId)
+	return args.Error(0)
+}
+
+func (m *MockApiKeyService) DeleteApiKey(ctx context.Context, keyId int, userId int) error {
+	args := m.Called(ctx, keyId, userId)
+	return args.Error(0)
+}
+
+func (m *MockApiKeyService) ValidateApiKey(ctx context.Context, rawKey string) (*gen.User, error) {
+	args := m.Called(ctx, rawKey)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*gen.User), args.Error(1)
 }
 
 // ============================================================================

--- a/sensor_hub/api/mqtt_api.go
+++ b/sensor_hub/api/mqtt_api.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"net/http"
-	"strconv"
 	"strings"
 
 	gen "example/sensorHub/gen"
@@ -55,7 +54,7 @@ func isDuplicateError(err error) bool {
 // Broker handlers
 // ============================================================================
 
-func (s *Server) listBrokersHandler(c *gin.Context) {
+func (s *Server) ListMqttBrokers(c *gin.Context) {
 	ctx := c.Request.Context()
 
 	brokers, err := s.mqttService.GetAllBrokers(ctx)
@@ -69,13 +68,8 @@ func (s *Server) listBrokersHandler(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, brokers)
 }
 
-func (s *Server) getBrokerHandler(c *gin.Context) {
+func (s *Server) GetMqttBroker(c *gin.Context, id int) {
 	ctx := c.Request.Context()
-	id, err := strconv.Atoi(c.Param("id"))
-	if err != nil {
-		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid broker ID"})
-		return
-	}
 
 	broker, err := s.mqttService.GetBrokerByID(ctx, id)
 	if err != nil {
@@ -89,7 +83,7 @@ func (s *Server) getBrokerHandler(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, broker)
 }
 
-func (s *Server) createBrokerHandler(c *gin.Context) {
+func (s *Server) CreateMqttBroker(c *gin.Context) {
 	ctx := c.Request.Context()
 
 	var broker gen.MQTTBroker
@@ -114,13 +108,8 @@ func (s *Server) createBrokerHandler(c *gin.Context) {
 	c.IndentedJSON(http.StatusCreated, gin.H{"id": id})
 }
 
-func (s *Server) updateBrokerHandler(c *gin.Context) {
+func (s *Server) UpdateMqttBroker(c *gin.Context, id int) {
 	ctx := c.Request.Context()
-	id, err := strconv.Atoi(c.Param("id"))
-	if err != nil {
-		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid broker ID"})
-		return
-	}
 
 	var broker gen.MQTTBroker
 	if err := c.BindJSON(&broker); err != nil {
@@ -140,13 +129,8 @@ func (s *Server) updateBrokerHandler(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, gin.H{"message": "Broker updated"})
 }
 
-func (s *Server) deleteBrokerHandler(c *gin.Context) {
+func (s *Server) DeleteMqttBroker(c *gin.Context, id int) {
 	ctx := c.Request.Context()
-	id, err := strconv.Atoi(c.Param("id"))
-	if err != nil {
-		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid broker ID"})
-		return
-	}
 
 	if err := s.mqttService.DeleteBroker(ctx, id); err != nil {
 		if isNotFoundError(err) {
@@ -163,17 +147,11 @@ func (s *Server) deleteBrokerHandler(c *gin.Context) {
 // Subscription handlers
 // ============================================================================
 
-func (s *Server) listSubscriptionsHandler(c *gin.Context) {
+func (s *Server) ListMqttSubscriptions(c *gin.Context, params gen.ListMqttSubscriptionsParams) {
 	ctx := c.Request.Context()
 
-	// If broker_id query param is set, filter by broker
-	if brokerParam := c.Query("broker_id"); brokerParam != "" {
-		brokerID, err := strconv.Atoi(brokerParam)
-		if err != nil {
-			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid broker_id parameter"})
-			return
-		}
-		subs, err := s.mqttService.GetSubscriptionsByBrokerID(ctx, brokerID)
+	if params.BrokerId != nil {
+		subs, err := s.mqttService.GetSubscriptionsByBrokerID(ctx, *params.BrokerId)
 		if err != nil {
 			c.IndentedJSON(http.StatusInternalServerError, gin.H{"message": "Error listing subscriptions"})
 			return
@@ -196,13 +174,8 @@ func (s *Server) listSubscriptionsHandler(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, subs)
 }
 
-func (s *Server) getSubscriptionHandler(c *gin.Context) {
+func (s *Server) GetMqttSubscription(c *gin.Context, id int) {
 	ctx := c.Request.Context()
-	id, err := strconv.Atoi(c.Param("id"))
-	if err != nil {
-		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid subscription ID"})
-		return
-	}
 
 	sub, err := s.mqttService.GetSubscriptionByID(ctx, id)
 	if err != nil {
@@ -216,7 +189,7 @@ func (s *Server) getSubscriptionHandler(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, sub)
 }
 
-func (s *Server) createSubscriptionHandler(c *gin.Context) {
+func (s *Server) CreateMqttSubscription(c *gin.Context) {
 	ctx := c.Request.Context()
 
 	var sub gen.MQTTSubscription
@@ -237,13 +210,8 @@ func (s *Server) createSubscriptionHandler(c *gin.Context) {
 	c.IndentedJSON(http.StatusCreated, gin.H{"id": id})
 }
 
-func (s *Server) updateSubscriptionHandler(c *gin.Context) {
+func (s *Server) UpdateMqttSubscription(c *gin.Context, id int) {
 	ctx := c.Request.Context()
-	id, err := strconv.Atoi(c.Param("id"))
-	if err != nil {
-		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid subscription ID"})
-		return
-	}
 
 	var sub gen.MQTTSubscription
 	if err := c.BindJSON(&sub); err != nil {
@@ -263,13 +231,8 @@ func (s *Server) updateSubscriptionHandler(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, gin.H{"message": "Subscription updated"})
 }
 
-func (s *Server) deleteSubscriptionHandler(c *gin.Context) {
+func (s *Server) DeleteMqttSubscription(c *gin.Context, id int) {
 	ctx := c.Request.Context()
-	id, err := strconv.Atoi(c.Param("id"))
-	if err != nil {
-		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid subscription ID"})
-		return
-	}
 
 	if err := s.mqttService.DeleteSubscription(ctx, id); err != nil {
 		if isNotFoundError(err) {
@@ -286,7 +249,7 @@ func (s *Server) deleteSubscriptionHandler(c *gin.Context) {
 // Stats handler
 // ============================================================================
 
-func (s *Server) mqttStatsHandler(c *gin.Context) {
+func (s *Server) GetMqttStats(c *gin.Context) {
 	if s.mqttStatsProvider == nil {
 		c.IndentedJSON(http.StatusServiceUnavailable, gin.H{"message": "MQTT stats not available"})
 		return

--- a/sensor_hub/api/mqtt_api_test.go
+++ b/sensor_hub/api/mqtt_api_test.go
@@ -7,8 +7,10 @@ import (
 	"errors"
 	"example/sensorHub/service"
 	gen "example/sensorHub/gen"
+	mqttpkg "example/sensorHub/mqtt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -101,6 +103,22 @@ func (m *mockMQTTService) DeleteSubscription(ctx context.Context, id int) error 
 func (m *mockMQTTService) SetSubscriptionNotifier(n service.SubscriptionNotifier) {}
 
 // ============================================================================
+// Mock MQTT stats provider
+// ============================================================================
+
+type mockMQTTStatsProvider struct{ mock.Mock }
+
+func (m *mockMQTTStatsProvider) Stats() map[int]mqttpkg.BrokerStats {
+	args := m.Called()
+	return args.Get(0).(map[int]mqttpkg.BrokerStats)
+}
+
+func (m *mockMQTTStatsProvider) IsConnected(brokerID int) bool {
+	args := m.Called(brokerID)
+	return args.Bool(0)
+}
+
+// ============================================================================
 // Test helpers
 // ============================================================================
 
@@ -118,6 +136,44 @@ func newMQTTMock() (*Server, *mockMQTTService) {
 	return s, m
 }
 
+func withBrokerID(s *Server, h func(*gin.Context, int)) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		id, err := strconv.Atoi(c.Param("id"))
+		if err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid broker ID"})
+			return
+		}
+		h(c, id)
+	}
+}
+
+func withSubscriptionID(s *Server, h func(*gin.Context, int)) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		id, err := strconv.Atoi(c.Param("id"))
+		if err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid subscription ID"})
+			return
+		}
+		h(c, id)
+	}
+}
+
+// listSubscriptionsClosureHandler simulates the route closure for ListMqttSubscriptions.
+func listSubscriptionsClosureHandler(s *Server) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var params gen.ListMqttSubscriptionsParams
+		if brokerParam := c.Query("broker_id"); brokerParam != "" {
+			id, err := strconv.Atoi(brokerParam)
+			if err != nil {
+				c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid broker_id parameter"})
+				return
+			}
+			params.BrokerId = &id
+		}
+		s.ListMqttSubscriptions(c, params)
+	}
+}
+
 // ============================================================================
 // Broker tests
 // ============================================================================
@@ -127,7 +183,7 @@ func TestListBrokersHandler_Success(t *testing.T) {
 	expected := []gen.MQTTBroker{{Id: ptrInt(1), Name: "b1"}, {Id: ptrInt(2), Name: "b2"}}
 	svc.On("GetAllBrokers", mock.Anything).Return(expected, nil)
 
-	router := setupMQTTRouter("GET", "/mqtt/brokers", s.listBrokersHandler)
+	router := setupMQTTRouter("GET", "/mqtt/brokers", s.ListMqttBrokers)
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/mqtt/brokers", nil)
 	router.ServeHTTP(w, req)
@@ -141,7 +197,7 @@ func TestListBrokersHandler_Empty(t *testing.T) {
 	s, svc := newMQTTMock()
 	svc.On("GetAllBrokers", mock.Anything).Return(nil, nil)
 
-	router := setupMQTTRouter("GET", "/mqtt/brokers", s.listBrokersHandler)
+	router := setupMQTTRouter("GET", "/mqtt/brokers", s.ListMqttBrokers)
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/mqtt/brokers", nil)
 	router.ServeHTTP(w, req)
@@ -154,7 +210,7 @@ func TestListBrokersHandler_Error(t *testing.T) {
 	s, svc := newMQTTMock()
 	svc.On("GetAllBrokers", mock.Anything).Return(nil, errors.New("db error"))
 
-	router := setupMQTTRouter("GET", "/mqtt/brokers", s.listBrokersHandler)
+	router := setupMQTTRouter("GET", "/mqtt/brokers", s.ListMqttBrokers)
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/mqtt/brokers", nil)
 	router.ServeHTTP(w, req)
@@ -167,7 +223,7 @@ func TestGetBrokerHandler_Success(t *testing.T) {
 	broker := &gen.MQTTBroker{Id: ptrInt(1), Name: "test-broker", Host: "mqtt.local", Port: 1883}
 	svc.On("GetBrokerByID", mock.Anything, 1).Return(broker, nil)
 
-	router := setupMQTTRouter("GET", "/mqtt/brokers/:id", s.getBrokerHandler)
+	router := setupMQTTRouter("GET", "/mqtt/brokers/:id", withBrokerID(s, s.GetMqttBroker))
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/mqtt/brokers/1", nil)
 	router.ServeHTTP(w, req)
@@ -180,7 +236,7 @@ func TestGetBrokerHandler_NotFound(t *testing.T) {
 	s, svc := newMQTTMock()
 	svc.On("GetBrokerByID", mock.Anything, 99).Return(nil, nil)
 
-	router := setupMQTTRouter("GET", "/mqtt/brokers/:id", s.getBrokerHandler)
+	router := setupMQTTRouter("GET", "/mqtt/brokers/:id", withBrokerID(s, s.GetMqttBroker))
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/mqtt/brokers/99", nil)
 	router.ServeHTTP(w, req)
@@ -191,7 +247,7 @@ func TestGetBrokerHandler_NotFound(t *testing.T) {
 func TestGetBrokerHandler_InvalidID(t *testing.T) {
 	s, _ := newMQTTMock()
 
-	router := setupMQTTRouter("GET", "/mqtt/brokers/:id", s.getBrokerHandler)
+	router := setupMQTTRouter("GET", "/mqtt/brokers/:id", withBrokerID(s, s.GetMqttBroker))
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/mqtt/brokers/abc", nil)
 	router.ServeHTTP(w, req)
@@ -204,7 +260,7 @@ func TestCreateBrokerHandler_Success(t *testing.T) {
 	svc.On("AddBroker", mock.Anything, mock.AnythingOfType("gen.MQTTBroker")).Return(1, nil)
 
 	body, _ := json.Marshal(gen.MQTTBroker{Name: "new-broker", Type: "external", Host: "mqtt.local", Port: 1883})
-	router := setupMQTTRouter("POST", "/mqtt/brokers", s.createBrokerHandler)
+	router := setupMQTTRouter("POST", "/mqtt/brokers", s.CreateMqttBroker)
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/mqtt/brokers", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -217,7 +273,7 @@ func TestCreateBrokerHandler_Success(t *testing.T) {
 func TestCreateBrokerHandler_InvalidBody(t *testing.T) {
 	s, _ := newMQTTMock()
 
-	router := setupMQTTRouter("POST", "/mqtt/brokers", s.createBrokerHandler)
+	router := setupMQTTRouter("POST", "/mqtt/brokers", s.CreateMqttBroker)
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/mqtt/brokers", bytes.NewReader([]byte("not json")))
 	req.Header.Set("Content-Type", "application/json")
@@ -231,7 +287,7 @@ func TestCreateBrokerHandler_ServiceError(t *testing.T) {
 	svc.On("AddBroker", mock.Anything, mock.AnythingOfType("gen.MQTTBroker")).Return(0, errors.New("validation failed"))
 
 	body, _ := json.Marshal(gen.MQTTBroker{Name: "bad"})
-	router := setupMQTTRouter("POST", "/mqtt/brokers", s.createBrokerHandler)
+	router := setupMQTTRouter("POST", "/mqtt/brokers", s.CreateMqttBroker)
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/mqtt/brokers", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -246,7 +302,7 @@ func TestUpdateBrokerHandler_Success(t *testing.T) {
 	svc.On("UpdateBroker", mock.Anything, mock.AnythingOfType("gen.MQTTBroker")).Return(nil)
 
 	body, _ := json.Marshal(gen.MQTTBroker{Name: "updated", Type: "external", Host: "mqtt.local", Port: 1883})
-	router := setupMQTTRouter("PUT", "/mqtt/brokers/:id", s.updateBrokerHandler)
+	router := setupMQTTRouter("PUT", "/mqtt/brokers/:id", withBrokerID(s, s.UpdateMqttBroker))
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("PUT", "/api/mqtt/brokers/1", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -260,7 +316,7 @@ func TestDeleteBrokerHandler_Success(t *testing.T) {
 	s, svc := newMQTTMock()
 	svc.On("DeleteBroker", mock.Anything, 1).Return(nil)
 
-	router := setupMQTTRouter("DELETE", "/mqtt/brokers/:id", s.deleteBrokerHandler)
+	router := setupMQTTRouter("DELETE", "/mqtt/brokers/:id", withBrokerID(s, s.DeleteMqttBroker))
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("DELETE", "/api/mqtt/brokers/1", nil)
 	router.ServeHTTP(w, req)
@@ -278,7 +334,7 @@ func TestListSubscriptionsHandler_All(t *testing.T) {
 	expected := []gen.MQTTSubscription{{Id: ptrInt(1), TopicPattern: "zigbee2mqtt/+"}}
 	svc.On("GetAllSubscriptions", mock.Anything).Return(expected, nil)
 
-	router := setupMQTTRouter("GET", "/mqtt/subscriptions", s.listSubscriptionsHandler)
+	router := setupMQTTRouter("GET", "/mqtt/subscriptions", listSubscriptionsClosureHandler(s))
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/mqtt/subscriptions", nil)
 	router.ServeHTTP(w, req)
@@ -292,7 +348,7 @@ func TestListSubscriptionsHandler_ByBroker(t *testing.T) {
 	expected := []gen.MQTTSubscription{{Id: ptrInt(1), BrokerId: 2, TopicPattern: "rtl_433/+"}}
 	svc.On("GetSubscriptionsByBrokerID", mock.Anything, 2).Return(expected, nil)
 
-	router := setupMQTTRouter("GET", "/mqtt/subscriptions", s.listSubscriptionsHandler)
+	router := setupMQTTRouter("GET", "/mqtt/subscriptions", listSubscriptionsClosureHandler(s))
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/mqtt/subscriptions?broker_id=2", nil)
 	router.ServeHTTP(w, req)
@@ -304,7 +360,7 @@ func TestListSubscriptionsHandler_ByBroker(t *testing.T) {
 func TestListSubscriptionsHandler_InvalidBrokerID(t *testing.T) {
 	s, _ := newMQTTMock()
 
-	router := setupMQTTRouter("GET", "/mqtt/subscriptions", s.listSubscriptionsHandler)
+	router := setupMQTTRouter("GET", "/mqtt/subscriptions", listSubscriptionsClosureHandler(s))
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/mqtt/subscriptions?broker_id=abc", nil)
 	router.ServeHTTP(w, req)
@@ -317,7 +373,7 @@ func TestGetSubscriptionHandler_Success(t *testing.T) {
 	sub := &gen.MQTTSubscription{Id: ptrInt(1), TopicPattern: "zigbee2mqtt/+", DriverType: "mqtt-zigbee2mqtt"}
 	svc.On("GetSubscriptionByID", mock.Anything, 1).Return(sub, nil)
 
-	router := setupMQTTRouter("GET", "/mqtt/subscriptions/:id", s.getSubscriptionHandler)
+	router := setupMQTTRouter("GET", "/mqtt/subscriptions/:id", withSubscriptionID(s, s.GetMqttSubscription))
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/mqtt/subscriptions/1", nil)
 	router.ServeHTTP(w, req)
@@ -330,7 +386,7 @@ func TestGetSubscriptionHandler_NotFound(t *testing.T) {
 	s, svc := newMQTTMock()
 	svc.On("GetSubscriptionByID", mock.Anything, 99).Return(nil, nil)
 
-	router := setupMQTTRouter("GET", "/mqtt/subscriptions/:id", s.getSubscriptionHandler)
+	router := setupMQTTRouter("GET", "/mqtt/subscriptions/:id", withSubscriptionID(s, s.GetMqttSubscription))
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/mqtt/subscriptions/99", nil)
 	router.ServeHTTP(w, req)
@@ -343,7 +399,7 @@ func TestCreateSubscriptionHandler_Success(t *testing.T) {
 	svc.On("AddSubscription", mock.Anything, mock.AnythingOfType("gen.MQTTSubscription")).Return(1, nil)
 
 	body, _ := json.Marshal(gen.MQTTSubscription{BrokerId: 1, TopicPattern: "zigbee2mqtt/+", DriverType: "mqtt-zigbee2mqtt"})
-	router := setupMQTTRouter("POST", "/mqtt/subscriptions", s.createSubscriptionHandler)
+	router := setupMQTTRouter("POST", "/mqtt/subscriptions", s.CreateMqttSubscription)
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/mqtt/subscriptions", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -358,7 +414,7 @@ func TestCreateSubscriptionHandler_ServiceError(t *testing.T) {
 	svc.On("AddSubscription", mock.Anything, mock.AnythingOfType("gen.MQTTSubscription")).Return(0, errors.New("driver not found"))
 
 	body, _ := json.Marshal(gen.MQTTSubscription{BrokerId: 1, TopicPattern: "test/+", DriverType: "bad"})
-	router := setupMQTTRouter("POST", "/mqtt/subscriptions", s.createSubscriptionHandler)
+	router := setupMQTTRouter("POST", "/mqtt/subscriptions", s.CreateMqttSubscription)
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/mqtt/subscriptions", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -373,7 +429,7 @@ func TestUpdateSubscriptionHandler_Success(t *testing.T) {
 	svc.On("UpdateSubscription", mock.Anything, mock.AnythingOfType("gen.MQTTSubscription")).Return(nil)
 
 	body, _ := json.Marshal(gen.MQTTSubscription{BrokerId: 1, TopicPattern: "updated/+", DriverType: "mqtt-zigbee2mqtt"})
-	router := setupMQTTRouter("PUT", "/mqtt/subscriptions/:id", s.updateSubscriptionHandler)
+	router := setupMQTTRouter("PUT", "/mqtt/subscriptions/:id", withSubscriptionID(s, s.UpdateMqttSubscription))
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("PUT", "/api/mqtt/subscriptions/1", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -387,7 +443,7 @@ func TestDeleteSubscriptionHandler_Success(t *testing.T) {
 	s, svc := newMQTTMock()
 	svc.On("DeleteSubscription", mock.Anything, 1).Return(nil)
 
-	router := setupMQTTRouter("DELETE", "/mqtt/subscriptions/:id", s.deleteSubscriptionHandler)
+	router := setupMQTTRouter("DELETE", "/mqtt/subscriptions/:id", withSubscriptionID(s, s.DeleteMqttSubscription))
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("DELETE", "/api/mqtt/subscriptions/1", nil)
 	router.ServeHTTP(w, req)
@@ -401,7 +457,7 @@ func TestValidateTopicPattern_ViaAPI(t *testing.T) {
 	svc.On("AddSubscription", mock.Anything, mock.AnythingOfType("gen.MQTTSubscription")).Return(0, errors.New("topic pattern must not contain spaces"))
 
 	body, _ := json.Marshal(gen.MQTTSubscription{BrokerId: 1, TopicPattern: "bad topic", DriverType: "mqtt-test"})
-	router := setupMQTTRouter("POST", "/mqtt/subscriptions", s.createSubscriptionHandler)
+	router := setupMQTTRouter("POST", "/mqtt/subscriptions", s.CreateMqttSubscription)
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/mqtt/subscriptions", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -409,6 +465,40 @@ func TestValidateTopicPattern_ViaAPI(t *testing.T) {
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Contains(t, w.Body.String(), "topic pattern must not contain spaces")
+}
+
+// ============================================================================
+// Stats tests
+// ============================================================================
+
+func TestGetMqttStatsHandler_Success(t *testing.T) {
+	statsProvider := new(mockMQTTStatsProvider)
+	s := &Server{mqttStatsProvider: statsProvider}
+
+	statsMap := map[int]mqttpkg.BrokerStats{
+		1: {BrokerID: 1, Connected: true},
+	}
+	statsProvider.On("Stats").Return(statsMap)
+
+	router := setupMQTTRouter("GET", "/mqtt/stats", s.GetMqttStats)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/mqtt/stats", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "broker_id")
+	statsProvider.AssertExpectations(t)
+}
+
+func TestGetMqttStatsHandler_Unavailable(t *testing.T) {
+	s := &Server{mqttStatsProvider: nil}
+
+	router := setupMQTTRouter("GET", "/mqtt/stats", s.GetMqttStats)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/mqtt/stats", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
 }
 
 func ptrInt(i int) *int { return &i }

--- a/sensor_hub/api/mqtt_routes.go
+++ b/sensor_hub/api/mqtt_routes.go
@@ -1,6 +1,10 @@
 package api
 
 import (
+	"net/http"
+	"strconv"
+
+	gen "example/sensorHub/gen"
 	"example/sensorHub/api/middleware"
 
 	"github.com/gin-gonic/gin"
@@ -9,21 +13,74 @@ import (
 func (s *Server) RegisterMQTTRoutes(router gin.IRouter) {
 	brokers := router.Group("/mqtt/brokers")
 	{
-		brokers.GET("", middleware.AuthRequired(), middleware.RequirePermission("view_mqtt"), s.listBrokersHandler)
-		brokers.POST("", middleware.AuthRequired(), middleware.RequirePermission("manage_mqtt"), s.createBrokerHandler)
-		brokers.GET("/:id", middleware.AuthRequired(), middleware.RequirePermission("view_mqtt"), s.getBrokerHandler)
-		brokers.PUT("/:id", middleware.AuthRequired(), middleware.RequirePermission("manage_mqtt"), s.updateBrokerHandler)
-		brokers.DELETE("/:id", middleware.AuthRequired(), middleware.RequirePermission("manage_mqtt"), s.deleteBrokerHandler)
+		brokers.GET("", middleware.AuthRequired(), middleware.RequirePermission("view_mqtt"), s.ListMqttBrokers)
+		brokers.POST("", middleware.AuthRequired(), middleware.RequirePermission("manage_mqtt"), s.CreateMqttBroker)
+		brokers.GET("/:id", middleware.AuthRequired(), middleware.RequirePermission("view_mqtt"), func(c *gin.Context) {
+			id, err := strconv.Atoi(c.Param("id"))
+			if err != nil {
+				c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid broker ID"})
+				return
+			}
+			s.GetMqttBroker(c, id)
+		})
+		brokers.PUT("/:id", middleware.AuthRequired(), middleware.RequirePermission("manage_mqtt"), func(c *gin.Context) {
+			id, err := strconv.Atoi(c.Param("id"))
+			if err != nil {
+				c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid broker ID"})
+				return
+			}
+			s.UpdateMqttBroker(c, id)
+		})
+		brokers.DELETE("/:id", middleware.AuthRequired(), middleware.RequirePermission("manage_mqtt"), func(c *gin.Context) {
+			id, err := strconv.Atoi(c.Param("id"))
+			if err != nil {
+				c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid broker ID"})
+				return
+			}
+			s.DeleteMqttBroker(c, id)
+		})
 	}
 
 	subscriptions := router.Group("/mqtt/subscriptions")
 	{
-		subscriptions.GET("", middleware.AuthRequired(), middleware.RequirePermission("view_mqtt"), s.listSubscriptionsHandler)
-		subscriptions.POST("", middleware.AuthRequired(), middleware.RequirePermission("manage_mqtt"), s.createSubscriptionHandler)
-		subscriptions.GET("/:id", middleware.AuthRequired(), middleware.RequirePermission("view_mqtt"), s.getSubscriptionHandler)
-		subscriptions.PUT("/:id", middleware.AuthRequired(), middleware.RequirePermission("manage_mqtt"), s.updateSubscriptionHandler)
-		subscriptions.DELETE("/:id", middleware.AuthRequired(), middleware.RequirePermission("manage_mqtt"), s.deleteSubscriptionHandler)
+		subscriptions.GET("", middleware.AuthRequired(), middleware.RequirePermission("view_mqtt"), func(c *gin.Context) {
+			var params gen.ListMqttSubscriptionsParams
+			if brokerParam := c.Query("broker_id"); brokerParam != "" {
+				id, err := strconv.Atoi(brokerParam)
+				if err != nil {
+					c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid broker_id parameter"})
+					return
+				}
+				params.BrokerId = &id
+			}
+			s.ListMqttSubscriptions(c, params)
+		})
+		subscriptions.POST("", middleware.AuthRequired(), middleware.RequirePermission("manage_mqtt"), s.CreateMqttSubscription)
+		subscriptions.GET("/:id", middleware.AuthRequired(), middleware.RequirePermission("view_mqtt"), func(c *gin.Context) {
+			id, err := strconv.Atoi(c.Param("id"))
+			if err != nil {
+				c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid subscription ID"})
+				return
+			}
+			s.GetMqttSubscription(c, id)
+		})
+		subscriptions.PUT("/:id", middleware.AuthRequired(), middleware.RequirePermission("manage_mqtt"), func(c *gin.Context) {
+			id, err := strconv.Atoi(c.Param("id"))
+			if err != nil {
+				c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid subscription ID"})
+				return
+			}
+			s.UpdateMqttSubscription(c, id)
+		})
+		subscriptions.DELETE("/:id", middleware.AuthRequired(), middleware.RequirePermission("manage_mqtt"), func(c *gin.Context) {
+			id, err := strconv.Atoi(c.Param("id"))
+			if err != nil {
+				c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid subscription ID"})
+				return
+			}
+			s.DeleteMqttSubscription(c, id)
+		})
 	}
 
-	router.GET("/mqtt/stats", middleware.AuthRequired(), middleware.RequirePermission("view_mqtt"), s.mqttStatsHandler)
+	router.GET("/mqtt/stats", middleware.AuthRequired(), middleware.RequirePermission("view_mqtt"), s.GetMqttStats)
 }

--- a/sensor_hub/api/notifications_api.go
+++ b/sensor_hub/api/notifications_api.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// ListNotifications implements gen.ServerInterface.
 func (s *Server) ListNotifications(c *gin.Context, params gen.ListNotificationsParams) {
 	ctx := c.Request.Context()
 	userID := c.MustGet("currentUser").(*gen.User).Id
@@ -35,7 +34,6 @@ func (s *Server) ListNotifications(c *gin.Context, params gen.ListNotificationsP
 	c.IndentedJSON(http.StatusOK, notifs)
 }
 
-// GetUnreadCount implements gen.ServerInterface.
 func (s *Server) GetUnreadCount(c *gin.Context) {
 	ctx := c.Request.Context()
 	userID := c.MustGet("currentUser").(*gen.User).Id
@@ -48,7 +46,6 @@ func (s *Server) GetUnreadCount(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, gin.H{"count": count})
 }
 
-// MarkAsRead implements gen.ServerInterface.
 func (s *Server) MarkAsRead(c *gin.Context, id int) {
 	ctx := c.Request.Context()
 	userID := c.MustGet("currentUser").(*gen.User).Id
@@ -61,7 +58,6 @@ func (s *Server) MarkAsRead(c *gin.Context, id int) {
 	c.IndentedJSON(http.StatusOK, gin.H{"message": "marked as read"})
 }
 
-// DismissNotification implements gen.ServerInterface.
 func (s *Server) DismissNotification(c *gin.Context, id int) {
 	ctx := c.Request.Context()
 	userID := c.MustGet("currentUser").(*gen.User).Id
@@ -74,7 +70,6 @@ func (s *Server) DismissNotification(c *gin.Context, id int) {
 	c.IndentedJSON(http.StatusOK, gin.H{"message": "dismissed"})
 }
 
-// BulkMarkAsRead implements gen.ServerInterface.
 func (s *Server) BulkMarkAsRead(c *gin.Context) {
 	ctx := c.Request.Context()
 	userID := c.MustGet("currentUser").(*gen.User).Id
@@ -87,7 +82,6 @@ func (s *Server) BulkMarkAsRead(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, gin.H{"message": "all marked as read"})
 }
 
-// BulkDismiss implements gen.ServerInterface.
 func (s *Server) BulkDismiss(c *gin.Context) {
 	ctx := c.Request.Context()
 	userID := c.MustGet("currentUser").(*gen.User).Id
@@ -100,7 +94,6 @@ func (s *Server) BulkDismiss(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, gin.H{"message": "all dismissed"})
 }
 
-// GetChannelPreferences implements gen.ServerInterface.
 func (s *Server) GetChannelPreferences(c *gin.Context) {
 	ctx := c.Request.Context()
 	userID := c.MustGet("currentUser").(*gen.User).Id
@@ -113,7 +106,6 @@ func (s *Server) GetChannelPreferences(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, prefs)
 }
 
-// SetChannelPreference implements gen.ServerInterface.
 func (s *Server) SetChannelPreference(c *gin.Context) {
 	ctx := c.Request.Context()
 	userID := c.MustGet("currentUser").(*gen.User).Id

--- a/sensor_hub/api/oauth_api.go
+++ b/sensor_hub/api/oauth_api.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"sync"
 
+	gen "example/sensorHub/gen"
+
 	"github.com/gin-gonic/gin"
 )
 
@@ -26,7 +28,7 @@ var pendingStates = struct {
 	states map[string]bool
 }{states: make(map[string]bool)}
 
-func (s *Server) oauthStatusHandler(c *gin.Context) {
+func (s *Server) GetOAuthStatus(c *gin.Context) {
 	ctx := c.Request.Context()
 	if s.oauthService == nil {
 		c.IndentedJSON(http.StatusServiceUnavailable, gin.H{"message": "OAuth not configured"})
@@ -36,7 +38,7 @@ func (s *Server) oauthStatusHandler(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, status)
 }
 
-func (s *Server) oauthAuthorizeHandler(c *gin.Context) {
+func (s *Server) GetOAuthAuthorizeUrl(c *gin.Context) {
 	ctx := c.Request.Context()
 	if s.oauthService == nil {
 		c.IndentedJSON(http.StatusServiceUnavailable, gin.H{"message": "OAuth not configured"})
@@ -65,22 +67,16 @@ func (s *Server) oauthAuthorizeHandler(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, gin.H{"auth_url": authURL, "state": state})
 }
 
-// oauthSubmitCodeRequest is the request body for submitting an authorization code
-type oauthSubmitCodeRequest struct {
-	Code  string `json:"code" binding:"required"`
-	State string `json:"state" binding:"required"`
-}
-
-// oauthSubmitCodeHandler handles manual submission of the authorization code
-// This is used with the out-of-band OAuth flow where Google displays the code on screen
-func (s *Server) oauthSubmitCodeHandler(c *gin.Context) {
+// SubmitOAuthCode handles manual submission of the authorization code.
+// This is used with the out-of-band OAuth flow where Google displays the code on screen.
+func (s *Server) SubmitOAuthCode(c *gin.Context) {
 	ctx := c.Request.Context()
 	if s.oauthService == nil {
 		c.IndentedJSON(http.StatusServiceUnavailable, gin.H{"message": "OAuth not configured"})
 		return
 	}
 
-	var req oauthSubmitCodeRequest
+	var req gen.SubmitOAuthCodeJSONRequestBody
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid request", "error": err.Error()})
 		return
@@ -105,8 +101,8 @@ func (s *Server) oauthSubmitCodeHandler(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, gin.H{"message": "OAuth authorization successful"})
 }
 
-// oauthReloadHandler reloads credentials and token from disk
-func (s *Server) oauthReloadHandler(c *gin.Context) {
+// ReloadOAuth reloads credentials and token from disk.
+func (s *Server) ReloadOAuth(c *gin.Context) {
 	ctx := c.Request.Context()
 	if s.oauthService == nil {
 		c.IndentedJSON(http.StatusServiceUnavailable, gin.H{"message": "OAuth not configured"})

--- a/sensor_hub/api/oauth_api_test.go
+++ b/sensor_hub/api/oauth_api_test.go
@@ -27,7 +27,7 @@ func TestGetOAuthStatus_Success(t *testing.T) {
 	router, api, s, mockService := setupOAuthRouter()
 	api.GET("/oauth/status", func(c *gin.Context) {
 		c.Set("currentUser", &gen.User{Id: 1, Username: "admin", Roles: []string{"admin"}})
-		s.oauthStatusHandler(c)
+		s.GetOAuthStatus(c)
 	})
 
 	mockService.On("GetStatus", mock.Anything).Return(map[string]interface{}{
@@ -48,7 +48,7 @@ func TestGetOAuthStatus_ServiceUnavailable(t *testing.T) {
 	router := gin.New()
 	apiGroup := router.Group("/api")
 	s := &Server{oauthService: nil}
-	apiGroup.GET("/oauth/status", s.oauthStatusHandler)
+	apiGroup.GET("/oauth/status", s.GetOAuthStatus)
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/oauth/status", nil)
@@ -61,7 +61,7 @@ func TestGetOAuthAuthURL_Success(t *testing.T) {
 	router, api, s, mockService := setupOAuthRouter()
 	api.GET("/oauth/authorize", func(c *gin.Context) {
 		c.Set("currentUser", &gen.User{Id: 1, Username: "admin", Roles: []string{"admin"}})
-		s.oauthAuthorizeHandler(c)
+		s.GetOAuthAuthorizeUrl(c)
 	})
 
 	mockService.On("GetAuthURL", mock.Anything, mock.Anything).Return("https://accounts.google.com/oauth?state=abc", nil)
@@ -79,7 +79,7 @@ func TestGetOAuthAuthURL_Error(t *testing.T) {
 	router, api, s, mockService := setupOAuthRouter()
 	api.GET("/oauth/authorize", func(c *gin.Context) {
 		c.Set("currentUser", &gen.User{Id: 1, Username: "admin", Roles: []string{"admin"}})
-		s.oauthAuthorizeHandler(c)
+		s.GetOAuthAuthorizeUrl(c)
 	})
 
 	mockService.On("GetAuthURL", mock.Anything, mock.Anything).Return("", errors.New("not configured"))
@@ -97,11 +97,11 @@ func TestOAuthSubmitCode_Success(t *testing.T) {
 	// First get a state token
 	api.GET("/oauth/authorize", func(c *gin.Context) {
 		c.Set("currentUser", &gen.User{Id: 1, Username: "admin", Roles: []string{"admin"}})
-		s.oauthAuthorizeHandler(c)
+		s.GetOAuthAuthorizeUrl(c)
 	})
 	api.POST("/oauth/submit-code", func(c *gin.Context) {
 		c.Set("currentUser", &gen.User{Id: 1, Username: "admin", Roles: []string{"admin"}})
-		s.oauthSubmitCodeHandler(c)
+		s.SubmitOAuthCode(c)
 	})
 
 	mockService.On("GetAuthURL", mock.Anything, mock.Anything).Return("https://accounts.google.com/oauth", nil)
@@ -132,7 +132,7 @@ func TestOAuthSubmitCode_InvalidState(t *testing.T) {
 	router, api, s, _ := setupOAuthRouter()
 	api.POST("/oauth/submit-code", func(c *gin.Context) {
 		c.Set("currentUser", &gen.User{Id: 1, Username: "admin", Roles: []string{"admin"}})
-		s.oauthSubmitCodeHandler(c)
+		s.SubmitOAuthCode(c)
 	})
 
 	body, _ := json.Marshal(map[string]string{"code": "test-code", "state": "invalid-state"})
@@ -149,7 +149,7 @@ func TestOAuthSubmitCode_MissingFields(t *testing.T) {
 	router, api, s, _ := setupOAuthRouter()
 	api.POST("/oauth/submit-code", func(c *gin.Context) {
 		c.Set("currentUser", &gen.User{Id: 1, Username: "admin", Roles: []string{"admin"}})
-		s.oauthSubmitCodeHandler(c)
+		s.SubmitOAuthCode(c)
 	})
 
 	body, _ := json.Marshal(map[string]string{"code": "test-code"}) // missing state
@@ -166,11 +166,11 @@ func TestOAuthSubmitCode_ExchangeError(t *testing.T) {
 
 	api.GET("/oauth/authorize", func(c *gin.Context) {
 		c.Set("currentUser", &gen.User{Id: 1, Username: "admin", Roles: []string{"admin"}})
-		s.oauthAuthorizeHandler(c)
+		s.GetOAuthAuthorizeUrl(c)
 	})
 	api.POST("/oauth/submit-code", func(c *gin.Context) {
 		c.Set("currentUser", &gen.User{Id: 1, Username: "admin", Roles: []string{"admin"}})
-		s.oauthSubmitCodeHandler(c)
+		s.SubmitOAuthCode(c)
 	})
 
 	mockService.On("GetAuthURL", mock.Anything, mock.Anything).Return("https://accounts.google.com/oauth", nil)
@@ -198,7 +198,7 @@ func TestOAuthReload_Success(t *testing.T) {
 	router, api, s, mockService := setupOAuthRouter()
 	api.POST("/oauth/reload", func(c *gin.Context) {
 		c.Set("currentUser", &gen.User{Id: 1, Username: "admin", Roles: []string{"admin"}})
-		s.oauthReloadHandler(c)
+		s.ReloadOAuth(c)
 	})
 
 	mockService.On("Reload", mock.Anything).Return(nil)
@@ -216,7 +216,7 @@ func TestOAuthReload_Error(t *testing.T) {
 	router, api, s, mockService := setupOAuthRouter()
 	api.POST("/oauth/reload", func(c *gin.Context) {
 		c.Set("currentUser", &gen.User{Id: 1, Username: "admin", Roles: []string{"admin"}})
-		s.oauthReloadHandler(c)
+		s.ReloadOAuth(c)
 	})
 
 	mockService.On("Reload", mock.Anything).Return(errors.New("credentials not found"))
@@ -233,7 +233,7 @@ func TestOAuthReload_ServiceUnavailable(t *testing.T) {
 	router := gin.New()
 	apiGroup := router.Group("/api")
 	s := &Server{oauthService: nil}
-	apiGroup.POST("/oauth/reload", s.oauthReloadHandler)
+	apiGroup.POST("/oauth/reload", s.ReloadOAuth)
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/oauth/reload", nil)

--- a/sensor_hub/api/oauth_routes.go
+++ b/sensor_hub/api/oauth_routes.go
@@ -9,16 +9,9 @@ import (
 func (s *Server) RegisterOAuthRoutes(router gin.IRouter) {
 	oauthGroup := router.Group("/oauth")
 	{
-		// Status endpoint requires manage_oauth permission
-		oauthGroup.GET("/status", middleware.AuthRequired(), middleware.RequirePermission("manage_oauth"), s.oauthStatusHandler)
-
-		// Authorize endpoint requires manage_oauth permission
-		oauthGroup.GET("/authorize", middleware.AuthRequired(), middleware.RequirePermission("manage_oauth"), s.oauthAuthorizeHandler)
-
-		// Submit code endpoint (for out-of-band flow) requires manage_oauth permission
-		oauthGroup.POST("/submit-code", middleware.AuthRequired(), middleware.RequirePermission("manage_oauth"), s.oauthSubmitCodeHandler)
-
-		// Reload endpoint to re-read credentials from disk
-		oauthGroup.POST("/reload", middleware.AuthRequired(), middleware.RequirePermission("manage_oauth"), s.oauthReloadHandler)
+		oauthGroup.GET("/status", middleware.AuthRequired(), middleware.RequirePermission("manage_oauth"), s.GetOAuthStatus)
+		oauthGroup.GET("/authorize", middleware.AuthRequired(), middleware.RequirePermission("manage_oauth"), s.GetOAuthAuthorizeUrl)
+		oauthGroup.POST("/submit-code", middleware.AuthRequired(), middleware.RequirePermission("manage_oauth"), s.SubmitOAuthCode)
+		oauthGroup.POST("/reload", middleware.AuthRequired(), middleware.RequirePermission("manage_oauth"), s.ReloadOAuth)
 	}
 }

--- a/sensor_hub/api/properties_api.go
+++ b/sensor_hub/api/properties_api.go
@@ -10,7 +10,6 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// UpdateProperties implements gen.ServerInterface.
 func (s *Server) UpdateProperties(c *gin.Context) {
 	ctx := c.Request.Context()
 	var requestBody gen.UpdatePropertiesJSONRequestBody
@@ -29,7 +28,6 @@ func (s *Server) UpdateProperties(c *gin.Context) {
 	c.IndentedJSON(http.StatusAccepted, gin.H{"message": "Property updated successfully"})
 }
 
-// GetProperties implements gen.ServerInterface.
 func (s *Server) GetProperties(c *gin.Context) {
 	ctx := c.Request.Context()
 	properties, err := s.propertiesService.ServiceGetProperties(ctx)
@@ -45,7 +43,6 @@ func (s *Server) GetProperties(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, result)
 }
 
-// PropertiesWebSocket implements gen.ServerInterface.
 func (s *Server) PropertiesWebSocket(c *gin.Context) {
 	ctx := c.Request.Context()
 	properties, err := s.propertiesService.ServiceGetProperties(ctx)

--- a/sensor_hub/api/readings_api.go
+++ b/sensor_hub/api/readings_api.go
@@ -12,7 +12,6 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// GetReadingsBetweenDates implements gen.ServerInterface.
 // Query parameters arrive pre-parsed in params; start/end are still normalised here.
 func (s *Server) GetReadingsBetweenDates(c *gin.Context, params gen.GetReadingsBetweenDatesParams) {
 	ctx := c.Request.Context()

--- a/sensor_hub/api/roles_api.go
+++ b/sensor_hub/api/roles_api.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// ListRoles implements gen.ServerInterface.
 func (s *Server) ListRoles(c *gin.Context) {
 	ctx := c.Request.Context()
 	roles, err := s.roleService.ListRoles(ctx)
@@ -24,7 +23,6 @@ func (s *Server) ListRoles(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, result)
 }
 
-// ListPermissions implements gen.ServerInterface.
 func (s *Server) ListPermissions(c *gin.Context) {
 	ctx := c.Request.Context()
 	perms, err := s.roleService.ListPermissions(ctx)
@@ -35,7 +33,6 @@ func (s *Server) ListPermissions(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, convertPermissions(perms))
 }
 
-// GetRolePermissions implements gen.ServerInterface.
 func (s *Server) GetRolePermissions(c *gin.Context, id int) {
 	ctx := c.Request.Context()
 	perms, err := s.roleService.ListPermissionsForRole(ctx, id)
@@ -46,7 +43,6 @@ func (s *Server) GetRolePermissions(c *gin.Context, id int) {
 	c.IndentedJSON(http.StatusOK, convertPermissions(perms))
 }
 
-// AssignPermission implements gen.ServerInterface.
 func (s *Server) AssignPermission(c *gin.Context, id int) {
 	ctx := c.Request.Context()
 	var req gen.AssignPermissionJSONRequestBody
@@ -61,7 +57,6 @@ func (s *Server) AssignPermission(c *gin.Context, id int) {
 	c.Status(http.StatusOK)
 }
 
-// RemovePermission implements gen.ServerInterface.
 func (s *Server) RemovePermission(c *gin.Context, id int, pid int) {
 	ctx := c.Request.Context()
 	if err := s.roleService.RemovePermission(ctx, id, pid); err != nil {

--- a/sensor_hub/api/sensor_api.go
+++ b/sensor_hub/api/sensor_api.go
@@ -22,7 +22,6 @@ func computeEffectiveRetentionHours(sensor gen.Sensor) int {
 	return appProps.AppConfig.SensorDataRetentionDays * 24
 }
 
-// AddSensor implements gen.ServerInterface.
 func (s *Server) AddSensor(c *gin.Context) {
 	ctx := c.Request.Context()
 	var sensor gen.Sensor
@@ -38,7 +37,6 @@ func (s *Server) AddSensor(c *gin.Context) {
 	c.IndentedJSON(http.StatusCreated, gin.H{"message": "Sensor added successfully"})
 }
 
-// UpdateSensorById implements gen.ServerInterface.
 // The id is extracted by the route closure; merge-patch semantics are preserved.
 func (s *Server) UpdateSensorById(c *gin.Context, id int) {
 	ctx := c.Request.Context()
@@ -122,7 +120,6 @@ func (s *Server) UpdateSensorById(c *gin.Context, id int) {
 	c.IndentedJSON(http.StatusOK, gin.H{"message": "Sensor updated successfully"})
 }
 
-// DeleteSensorByName implements gen.ServerInterface.
 func (s *Server) DeleteSensorByName(c *gin.Context, name string) {
 	ctx := c.Request.Context()
 	err := s.sensorService.ServiceDeleteSensorByName(ctx, name)
@@ -133,7 +130,6 @@ func (s *Server) DeleteSensorByName(c *gin.Context, name string) {
 	c.IndentedJSON(http.StatusOK, gin.H{"message": "Sensor deleted successfully"})
 }
 
-// GetSensorByName implements gen.ServerInterface.
 // It returns the sensor with effective_retention_hours computed and set directly on gen.Sensor.
 func (s *Server) GetSensorByName(c *gin.Context, name string) {
 	ctx := c.Request.Context()
@@ -152,7 +148,6 @@ func (s *Server) GetSensorByName(c *gin.Context, name string) {
 	c.IndentedJSON(http.StatusOK, masked)
 }
 
-// GetAllSensors implements gen.ServerInterface.
 func (s *Server) GetAllSensors(c *gin.Context) {
 	ctx := c.Request.Context()
 	sensors, err := s.sensorService.ServiceGetAllSensors(ctx)
@@ -163,7 +158,6 @@ func (s *Server) GetAllSensors(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, maskSensitiveConfigSlice(sensors))
 }
 
-// GetSensorsByDriver implements gen.ServerInterface.
 func (s *Server) GetSensorsByDriver(c *gin.Context, driver string) {
 	ctx := c.Request.Context()
 	sensors, err := s.sensorService.ServiceGetSensorsByDriver(ctx, driver)
@@ -174,7 +168,6 @@ func (s *Server) GetSensorsByDriver(c *gin.Context, driver string) {
 	c.IndentedJSON(http.StatusOK, maskSensitiveConfigSlice(sensors))
 }
 
-// SensorExists implements gen.ServerInterface.
 func (s *Server) SensorExists(c *gin.Context, name string) {
 	ctx := c.Request.Context()
 	exists, err := s.sensorService.ServiceSensorExists(ctx, name)
@@ -189,7 +182,6 @@ func (s *Server) SensorExists(c *gin.Context, name string) {
 	}
 }
 
-// CollectAllSensorReadings implements gen.ServerInterface.
 func (s *Server) CollectAllSensorReadings(c *gin.Context) {
 	ctx := c.Request.Context()
 	err := s.sensorService.ServiceCollectAndStoreAllSensorReadings(ctx)
@@ -200,7 +192,6 @@ func (s *Server) CollectAllSensorReadings(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, gin.H{"message": "Sensor readings collected and stored successfully"})
 }
 
-// CollectFromSensor implements gen.ServerInterface.
 func (s *Server) CollectFromSensor(c *gin.Context, sensorName string) {
 	ctx := c.Request.Context()
 	err := s.sensorService.ServiceCollectFromSensorByName(ctx, sensorName)
@@ -211,7 +202,6 @@ func (s *Server) CollectFromSensor(c *gin.Context, sensorName string) {
 	c.IndentedJSON(http.StatusOK, gin.H{"message": "Sensor reading collected successfully"})
 }
 
-// DisableSensor implements gen.ServerInterface.
 func (s *Server) DisableSensor(c *gin.Context, sensorName string) {
 	ctx := c.Request.Context()
 	err := s.sensorService.ServiceSetEnabledSensorByName(ctx, sensorName, false)
@@ -222,7 +212,6 @@ func (s *Server) DisableSensor(c *gin.Context, sensorName string) {
 	c.IndentedJSON(http.StatusOK, gin.H{"message": "Sensor disabled successfully"})
 }
 
-// EnableSensor implements gen.ServerInterface.
 func (s *Server) EnableSensor(c *gin.Context, sensorName string) {
 	ctx := c.Request.Context()
 	err := s.sensorService.ServiceSetEnabledSensorByName(ctx, sensorName, true)
@@ -233,7 +222,6 @@ func (s *Server) EnableSensor(c *gin.Context, sensorName string) {
 	c.IndentedJSON(http.StatusOK, gin.H{"message": "Sensor enabled successfully"})
 }
 
-// SubscribeAllSensors implements gen.ServerInterface.
 func (s *Server) SubscribeAllSensors(c *gin.Context) {
 	ctx := c.Request.Context()
 	topic := "sensors:all"
@@ -254,7 +242,6 @@ func (s *Server) SubscribeAllSensors(c *gin.Context) {
 	ws.BroadcastToTopic(topic, active)
 }
 
-// SubscribeSensorsByDriver implements gen.ServerInterface.
 func (s *Server) SubscribeSensorsByDriver(c *gin.Context, driver string) {
 	ctx := c.Request.Context()
 
@@ -270,7 +257,6 @@ func (s *Server) SubscribeSensorsByDriver(c *gin.Context, driver string) {
 	ws.BroadcastToTopic(topic, sensors)
 }
 
-// GetSensorHealthHistoryByName implements gen.ServerInterface.
 // Limit defaults to the app config value when params.Limit is nil.
 func (s *Server) GetSensorHealthHistoryByName(c *gin.Context, name string, params gen.GetSensorHealthHistoryByNameParams) {
 	ctx := c.Request.Context()
@@ -292,7 +278,6 @@ func (s *Server) GetSensorHealthHistoryByName(c *gin.Context, name string, param
 	c.IndentedJSON(http.StatusOK, healthHistory)
 }
 
-// GetTotalReadingsPerSensor implements gen.ServerInterface.
 func (s *Server) GetTotalReadingsPerSensor(c *gin.Context) {
 	ctx := c.Request.Context()
 	stats, err := s.sensorService.ServiceGetTotalReadingsForEachSensor(ctx)
@@ -338,7 +323,6 @@ func maskSensitiveConfigSlice(sensors []gen.Sensor) []gen.Sensor {
 	return result
 }
 
-// GetSensorsByStatus implements gen.ServerInterface.
 func (s *Server) GetSensorsByStatus(c *gin.Context, status gen.GetSensorsByStatusParamsStatus) {
 	ctx := c.Request.Context()
 	sensors, err := s.sensorService.ServiceGetSensorsByStatus(ctx, string(status))
@@ -352,7 +336,6 @@ func (s *Server) GetSensorsByStatus(c *gin.Context, status gen.GetSensorsByStatu
 	c.IndentedJSON(http.StatusOK, maskSensitiveConfigSlice(sensors))
 }
 
-// ApproveSensor implements gen.ServerInterface.
 func (s *Server) ApproveSensor(c *gin.Context, id int) {
 	ctx := c.Request.Context()
 	if err := s.sensorService.ServiceApproveSensor(ctx, id); err != nil {
@@ -362,7 +345,6 @@ func (s *Server) ApproveSensor(c *gin.Context, id int) {
 	c.IndentedJSON(http.StatusOK, gin.H{"message": "Sensor approved"})
 }
 
-// DismissSensor implements gen.ServerInterface.
 func (s *Server) DismissSensor(c *gin.Context, id int) {
 	ctx := c.Request.Context()
 	if err := s.sensorService.ServiceDismissSensor(ctx, id); err != nil {

--- a/sensor_hub/api/users_api.go
+++ b/sensor_hub/api/users_api.go
@@ -8,7 +8,6 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// CreateUser implements gen.ServerInterface.
 func (s *Server) CreateUser(c *gin.Context) {
 	ctx := c.Request.Context()
 	var req gen.CreateUserRequest
@@ -34,7 +33,6 @@ func (s *Server) CreateUser(c *gin.Context) {
 	c.IndentedJSON(http.StatusCreated, gin.H{"id": id})
 }
 
-// ListUsers implements gen.ServerInterface.
 func (s *Server) ListUsers(c *gin.Context) {
 	ctx := c.Request.Context()
 	users, err := s.userService.ListUsers(ctx)
@@ -45,7 +43,6 @@ func (s *Server) ListUsers(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, users)
 }
 
-// ChangePassword implements gen.ServerInterface.
 func (s *Server) ChangePassword(c *gin.Context) {
 	ctx := c.Request.Context()
 	var req gen.ChangePasswordRequest
@@ -96,7 +93,6 @@ func (s *Server) ChangePassword(c *gin.Context) {
 	c.Status(http.StatusOK)
 }
 
-// DeleteUser implements gen.ServerInterface.
 func (s *Server) DeleteUser(c *gin.Context, id int) {
 	ctx := c.Request.Context()
 
@@ -125,7 +121,6 @@ func (s *Server) DeleteUser(c *gin.Context, id int) {
 	c.Status(http.StatusOK)
 }
 
-// SetMustChangePassword implements gen.ServerInterface.
 func (s *Server) SetMustChangePassword(c *gin.Context, id int) {
 	ctx := c.Request.Context()
 	var req gen.SetMustChangePasswordJSONRequestBody
@@ -160,7 +155,6 @@ func (s *Server) SetMustChangePassword(c *gin.Context, id int) {
 	c.Status(http.StatusOK)
 }
 
-// SetUserRoles implements gen.ServerInterface.
 func (s *Server) SetUserRoles(c *gin.Context, id int) {
 	ctx := c.Request.Context()
 	var req gen.SetUserRolesJSONRequestBody


### PR DESCRIPTION
Closes #39

## Summary

Migrates all remaining API handler groups to use generated types from `gen/` with method names matching `gen.ServerInterface`. This is the last handler migration before generated route registration (#40).

## Changes

**Dashboard (7 handlers):** `ListDashboards`, `CreateDashboard`, `GetDashboard`, `UpdateDashboard`, `DeleteDashboard`, `ShareDashboard`, `SetDefaultDashboard` — int path params moved to route closures.

**API Keys (5 handlers):** `ListApiKeys`, `CreateApiKey`, `UpdateApiKeyExpiry`, `RevokeApiKey`, `DeleteApiKey` — local request structs replaced with `gen.*JSONRequestBody` types.

**MQTT (11 handlers):** `ListMqttBrokers`, `CreateMqttBroker`, `GetMqttBroker`, `UpdateMqttBroker`, `DeleteMqttBroker`, `ListMqttSubscriptions`, `CreateMqttSubscription`, `GetMqttSubscription`, `UpdateMqttSubscription`, `DeleteMqttSubscription`, `GetMqttStats` — `ListMqttSubscriptions` now takes `gen.ListMqttSubscriptionsParams`.

**OAuth (4 handlers):** `GetOAuthStatus`, `GetOAuthAuthorizeUrl`, `SubmitOAuthCode`, `ReloadOAuth` — local `oauthSubmitCodeRequest` replaced with `gen.SubmitOAuthCodeJSONRequestBody`.

**Cleanup:** Removed `// Foo implements gen.ServerInterface.` comments from all API handler files across the codebase — they add noise without value.

## Pattern

Follows the closure pattern established in #35–#38: id path params are parsed in route files, handlers receive typed values directly.

## Testing

- All unit tests pass (`go test ./api/...`)
- All 101 integration tests pass