### PR TITLE
Fix #51: preserve immutable IDs when updating alert rules

### DIFF
--- a/sensor_hub/api/alert_api.go
+++ b/sensor_hub/api/alert_api.go
@@ -92,8 +92,23 @@ func (s *Server) UpdateAlertRule(c *gin.Context, id int) {
 		return
 	}
 
+	existing, err := s.alertService.ServiceGetAlertRuleByID(ctx, id)
+	if err != nil {
+		slog.Error("error fetching alert rule for update", "id", id, "error", err)
+		c.IndentedJSON(http.StatusInternalServerError, gin.H{"message": "Error fetching alert rule", "error": err.Error()})
+		return
+	}
+	if existing == nil {
+		c.IndentedJSON(http.StatusNotFound, gin.H{"message": "Alert rule not found"})
+		return
+	}
+
 	rule := toAlertingRule(genRule)
 	rule.ID = id
+	// SensorID and MeasurementTypeId are immutable for the lifetime of an Alert Rule.
+	// Preserve them from the existing rule so clients only need to send mutable fields.
+	rule.SensorID = existing.SensorID
+	rule.MeasurementTypeId = existing.MeasurementTypeId
 
 	if err := rule.Validate(); err != nil {
 		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid alert rule", "error": err.Error()})

--- a/sensor_hub/api/alert_api_test.go
+++ b/sensor_hub/api/alert_api_test.go
@@ -431,6 +431,8 @@ func TestUpdateAlertRule(t *testing.T) {
 		Enabled:           false,
 	}
 
+	existing := &alerting.AlertRule{ID: 1, SensorID: 1, MeasurementTypeId: 1, AlertType: alerting.AlertTypeNumericRange, HighThreshold: 30, LowThreshold: 10}
+	mockService.On("ServiceGetAlertRuleByID", mock.Anything, 1).Return(existing, nil)
 	mockService.On("ServiceUpdateAlertRule", mock.Anything, mock.AnythingOfType("*alerting.AlertRule")).Return(nil)
 
 	router := setupUpdateAlertRoute(s)
@@ -473,7 +475,12 @@ func TestUpdateAlertRule_InvalidJSON(t *testing.T) {
 }
 
 func TestUpdateAlertRule_ValidationError(t *testing.T) {
-	s := new(Server)
+	mockService := new(mockAlertManagementService)
+	s := &Server{alertService: mockService}
+
+	existing := &alerting.AlertRule{ID: 1, SensorID: 1, MeasurementTypeId: 1, AlertType: alerting.AlertTypeNumericRange, HighThreshold: 30, LowThreshold: 10}
+	mockService.On("ServiceGetAlertRuleByID", mock.Anything, 1).Return(existing, nil)
+
 	router := setupUpdateAlertRoute(s)
 
 	invalidRule := gen.AlertRule{
@@ -508,6 +515,8 @@ func TestUpdateAlertRule_ServiceError(t *testing.T) {
 		Enabled:           true,
 	}
 
+	existing := &alerting.AlertRule{ID: 1, SensorID: 1, MeasurementTypeId: 1, AlertType: alerting.AlertTypeNumericRange, HighThreshold: 30, LowThreshold: 10}
+	mockService.On("ServiceGetAlertRuleByID", mock.Anything, 1).Return(existing, nil)
 	mockService.On("ServiceUpdateAlertRule", mock.Anything, mock.AnythingOfType("*alerting.AlertRule")).Return(fmt.Errorf("db error"))
 
 	router := setupUpdateAlertRoute(s)
@@ -519,6 +528,76 @@ func TestUpdateAlertRule_ServiceError(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	mockService.AssertExpectations(t)
+}
+
+func TestUpdateAlertRule_PreservesImmutableIDsFromExistingRule(t *testing.T) {
+	// Regression for #51: clients editing an alert rule send only the mutable
+	// fields (thresholds, rate limit, enabled, etc.). The server must look up
+	// the existing rule and preserve SensorID and MeasurementTypeID, which are
+	// immutable for the lifetime of an Alert Rule.
+	mockService := new(mockAlertManagementService)
+	s := &Server{alertService: mockService}
+
+	existingRule := &alerting.AlertRule{
+		ID:                1,
+		SensorID:          42,
+		MeasurementTypeId: 7,
+		AlertType:         alerting.AlertTypeNumericRange,
+		HighThreshold:     30.0,
+		LowThreshold:      10.0,
+		Enabled:           true,
+	}
+	mockService.On("ServiceGetAlertRuleByID", mock.Anything, 1).Return(existingRule, nil)
+
+	// Body omits SensorID and MeasurementTypeID — exactly what EditAlertDialog sends.
+	bodyOnlyMutable := map[string]any{
+		"AlertType":        "numeric_range",
+		"HighThreshold":    35.0,
+		"LowThreshold":     12.0,
+		"RateLimitSeconds": 60,
+		"Enabled":          false,
+	}
+
+	var captured *alerting.AlertRule
+	mockService.On("ServiceUpdateAlertRule", mock.Anything, mock.AnythingOfType("*alerting.AlertRule")).
+		Run(func(args mock.Arguments) { captured = args.Get(1).(*alerting.AlertRule) }).
+		Return(nil)
+
+	router := setupUpdateAlertRoute(s)
+	body, _ := json.Marshal(bodyOnlyMutable)
+	req := httptest.NewRequest("PUT", "/api/alerts/1", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	if assert.NotNil(t, captured) {
+		assert.Equal(t, 1, captured.ID)
+		assert.Equal(t, 42, captured.SensorID, "SensorID must be preserved from existing rule")
+		assert.Equal(t, 7, captured.MeasurementTypeId, "MeasurementTypeId must be preserved from existing rule")
+		assert.Equal(t, 35.0, captured.HighThreshold)
+		assert.Equal(t, 12.0, captured.LowThreshold)
+		assert.Equal(t, 60, captured.RateLimitSeconds)
+		assert.False(t, captured.Enabled)
+	}
+	mockService.AssertExpectations(t)
+}
+
+func TestUpdateAlertRule_NotFound(t *testing.T) {
+	mockService := new(mockAlertManagementService)
+	s := &Server{alertService: mockService}
+
+	mockService.On("ServiceGetAlertRuleByID", mock.Anything, 999).Return(nil, nil)
+
+	router := setupUpdateAlertRoute(s)
+	body, _ := json.Marshal(map[string]any{"AlertType": "numeric_range", "HighThreshold": 30.0, "LowThreshold": 10.0})
+	req := httptest.NewRequest("PUT", "/api/alerts/999", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
 	mockService.AssertExpectations(t)
 }
 

--- a/sensor_hub/integration/alerts_test.go
+++ b/sensor_hub/integration/alerts_test.go
@@ -3,6 +3,7 @@
 package integration
 
 import (
+	"encoding/json"
 	"net/http"
 	"testing"
 
@@ -34,6 +35,75 @@ func TestAlerts_CreateAndGetRule(t *testing.T) {
 	resp, status := client.GetAlertRulesBySensorID(sensor.Id)
 	require.Equal(t, http.StatusOK, status)
 	assert.Contains(t, string(resp), "numeric_range")
+}
+
+// TestAlerts_EditRuleWithMutableFieldsOnly is the regression test for #51:
+// the UI's edit dialog only sends mutable fields (alert type, thresholds,
+// trigger status, rate limit, enabled). The server must look up the existing
+// rule and preserve the immutable SensorID and MeasurementTypeID so the PUT
+// succeeds instead of failing validation with 400 Bad Request.
+func TestAlerts_EditRuleWithMutableFieldsOnly(t *testing.T) {
+	ensureSensorsRegistered(t)
+
+	sensor, _ := client.GetSensorByName("Mock Sensor 1")
+	require.True(t, sensor.Id > 0)
+
+	// Find an existing rule for this sensor (created by an earlier test) or
+	// create one. The (sensor_id, measurement_type_id, alert_type) tuple is
+	// unique, so we don't unconditionally re-create.
+	rulesRaw, status := client.GetAlertRulesBySensorID(sensor.Id)
+	require.Equal(t, http.StatusOK, status)
+	var rules []gen.AlertRule
+	require.NoError(t, json.Unmarshal(rulesRaw, &rules))
+
+	if len(rules) == 0 {
+		_, status := client.CreateAlertRule(gen.AlertRule{
+			SensorID:          sensor.Id,
+			MeasurementTypeID: 1,
+			AlertType:         "numeric_range",
+			HighThreshold:     30.0,
+			LowThreshold:      10.0,
+			RateLimitSeconds:  6,
+			Enabled:           true,
+		})
+		require.Equal(t, http.StatusCreated, status)
+		rulesRaw, status = client.GetAlertRulesBySensorID(sensor.Id)
+		require.Equal(t, http.StatusOK, status)
+		require.NoError(t, json.Unmarshal(rulesRaw, &rules))
+	}
+	require.NotEmpty(t, rules)
+	ruleID := rules[0].ID
+
+	// Body matches what EditAlertDialog.tsx sends: only mutable fields, no
+	// SensorID or MeasurementTypeID. Pre-fix this returned 400.
+	body := map[string]any{
+		"AlertType":        "numeric_range",
+		"HighThreshold":    35.0,
+		"LowThreshold":     12.0,
+		"RateLimitSeconds": 60,
+		"Enabled":          false,
+	}
+	_, status = client.UpdateAlertRuleWithBody(ruleID, body)
+	assert.Equal(t, http.StatusOK, status)
+
+	// Verify the update actually applied and immutable fields are intact.
+	rulesRaw, status = client.GetAlertRulesBySensorID(sensor.Id)
+	require.Equal(t, http.StatusOK, status)
+	require.NoError(t, json.Unmarshal(rulesRaw, &rules))
+	var updated *gen.AlertRule
+	for i := range rules {
+		if rules[i].ID == ruleID {
+			updated = &rules[i]
+			break
+		}
+	}
+	require.NotNil(t, updated)
+	assert.Equal(t, sensor.Id, updated.SensorID)
+	assert.Equal(t, 1, updated.MeasurementTypeID)
+	assert.Equal(t, 35.0, updated.HighThreshold)
+	assert.Equal(t, 12.0, updated.LowThreshold)
+	assert.Equal(t, 60, updated.RateLimitSeconds)
+	assert.False(t, updated.Enabled)
 }
 
 func TestAlerts_CollectionTriggersAlertCheck(t *testing.T) {

--- a/sensor_hub/testharness/client.go
+++ b/sensor_hub/testharness/client.go
@@ -250,6 +250,13 @@ func (c *Client) CreateAlertRule(rule gen.AlertRule) (json.RawMessage, int) {
 	return c.consume(c.gen.CreateAlertRule(c.ctx(), rule))
 }
 
+// UpdateAlertRuleWithBody allows sending an arbitrary JSON body to PUT /alerts/{id},
+// e.g. to test that the server accepts a body containing only mutable fields.
+func (c *Client) UpdateAlertRuleWithBody(id int, body any) (json.RawMessage, int) {
+	r := strings.NewReader(mustMarshal(body))
+	return c.consume(c.gen.UpdateAlertRuleWithBody(c.ctx(), id, "application/json", r))
+}
+
 func (c *Client) GetAlertRulesBySensorID(sensorID int) (json.RawMessage, int) {
 	return c.consume(c.gen.GetAlertRulesBySensorId(c.ctx(), sensorID))
 }


### PR DESCRIPTION
Fixes #51.

## Problem

Editing an existing alert rule via the UI always returned `400 Bad Request` from `PUT /api/alerts/{id}` with `sensor ID must be a positive integer`.

`EditAlertDialog.tsx` only sends mutable fields (`AlertType`, `HighThreshold`, `LowThreshold`, `TriggerStatus`, `RateLimitSeconds`, `Enabled`) — it never includes `SensorID` or `MeasurementTypeID`. Both arrived as `0`, so `AlertRule.Validate()` rejected the request before the update reached the database.

## Fix

Per UBIQUITOUS_LANGUAGE.md, an Alert Rule is configured against exactly one Sensor and one Measurement Type — those IDs are part of the rule's identity and are immutable for its lifetime. So the cleaner of the two options suggested in the issue was the server-side merge.

`UpdateAlertRule` now:

1. Parses the request body.
2. Looks up the existing rule by `id`.
   - Returns **404** if not found (previously could return 400 due to validation against an empty body).
3. Copies `SensorID` and `MeasurementTypeId` from the existing rule onto the parsed body.
4. Validates and persists.

Clients no longer need to round-trip immutable IDs. The UI required no changes.

## Tests (TDD)

- **Unit** (`sensor_hub/api/alert_api_test.go`):
  - `TestUpdateAlertRule_PreservesImmutableIDsFromExistingRule` — body without `SensorID`/`MeasurementTypeID` succeeds; captured rule passed to the service has the IDs from the lookup.
  - `TestUpdateAlertRule_NotFound` — non-existent rule returns 404.
  - Existing update tests now mock `ServiceGetAlertRuleByID`.
- **Integration** (`sensor_hub/integration/alerts_test.go`):
  - `TestAlerts_EditRuleWithMutableFieldsOnly` reproduces the bug end-to-end through the real HTTP stack.

`go test ./...` and `go test -tags integration -timeout 300s ./integration/` both pass.