### PR TITLE
chore: harden GitHub Actions supply-chain security

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "gomod"
+    directory: "/sensor_hub"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/sensor_hub/ui/sensor_hub_ui"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/docs"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directory: "/temperature_sensor"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directory: "/sensor_hub/docker_tests"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,16 +7,21 @@ on:
     branches: [main]
     tags: ["v*"]
 
+permissions:
+  contents: read
+
 jobs:
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "25"
           cache: "npm"
@@ -54,13 +59,13 @@ jobs:
           cp -r docs/build/* sensor_hub/web/docs/
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: sensor_hub/go.mod
           cache-dependency-path: sensor_hub/go.sum
 
       - name: Install oapi-codegen
-        run: go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@latest
+        run: go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@v2.6.0
 
       - name: Verify generated Go code is up-to-date
         working-directory: sensor_hub
@@ -78,10 +83,12 @@ jobs:
     needs: unit-tests
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "25"
           cache: "npm"
@@ -113,7 +120,7 @@ jobs:
           cp -r docs/build/* sensor_hub/web/docs/
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: sensor_hub/go.mod
           cache-dependency-path: sensor_hub/go.sum

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "25"
           cache: "npm"
@@ -50,7 +51,7 @@ jobs:
           cp -r docs/build/* sensor_hub/web/docs/
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: sensor_hub/go.mod
           cache-dependency-path: sensor_hub/go.sum
@@ -61,13 +62,13 @@ jobs:
 
       - name: Import GPG key
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v7
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1
         with:
           version: "~> v2"
           args: release --clean


### PR DESCRIPTION
Hardens both workflows against the class of supply-chain attacks demonstrated by the **tj-actions/changed-files** compromise (March 2025), where an attacker who gains push to a third-party action repo retags a malicious commit as a popular tag (e.g. \`v1\`) and exfiltrates secrets from every workflow that pulls it by tag.

## Changes

### \`.github/dependabot.yml\` (new)
Weekly version updates for:
- \`github-actions\` — keeps SHA pins moving forward
- \`gomod\` (sensor_hub)
- \`npm\` (UI, docs)
- \`pip\` (temperature_sensor, docker_tests)

Without this, SHA-pinning becomes a permanent freeze. Dependabot opens PRs that bump the SHA + tag-comment together.

### \`.github/workflows/ci.yml\`
- **SHA-pin every action.** \`actions/checkout@v6\` → \`@de0fac2…\` etc. The trailing \`# v6.0.2\` comment is what Dependabot updates.
- **Top-level \`permissions: { contents: read }\`.** Makes \`GITHUB_TOKEN\` provably read-only for this workflow regardless of repo default.
- **\`persist-credentials: false\` on checkouts.** This workflow never pushes; the token shouldn't sit in \`.git/config\` where any subsequent step could read it.
- **Pin \`oapi-codegen@latest\` → \`@v2.6.0\`.** \`@latest\` is the Go equivalent of an unpinned action.

### \`.github/workflows/release.yml\`
- SHA-pin every action (most important here — \`crazy-max/ghaction-import-gpg\` and \`goreleaser/goreleaser-action\` both run with the GPG private key and \`contents: write\` token in scope).
- \`persist-credentials: false\` on checkout. GoReleaser authenticates via \`GITHUB_TOKEN\` env, not git creds.
- \`fetch-depth: 0\` retained for changelog generation.
- Top-level \`permissions: { contents: write }\` already in place; unchanged.

## What is **not** in this PR (settings work for @tom-molotnikoff)

These can't be done from a workflow file — they're repo settings:

1. **Settings → Actions → General → "Require actions to be pinned to a full-length commit SHA"** — turn this on. Belt-and-braces enforcement of what this PR establishes.
2. **Settings → Rules → Rulesets → New branch ruleset on \`main\`:** block force-push, block deletion, require status checks (CI / unit-tests, integration-tests). **Do not** enable "require pull request" — that would block your \`git push origin main\` workflow. Add yourself to the bypass list.
3. **Settings → Rules → Rulesets → New tag ruleset on \`v*\`:** restrict updates and deletions. Add yourself to bypass. Stops a leaked token from retagging a release at a malicious commit.
4. **Settings → Secrets and variables → Actions → Manage environments:** consider moving \`GPG_PRIVATE_KEY\`/\`GPG_PASSPHRASE\` into a \`release\` environment with required reviewer = self, and \`environment: release\` on the release job. Optional, but makes the GPG key unreachable from any workflow that doesn't pass that gate.

## Release workflow impact

None. \`git tag vX.Y.Z && git push origin vX.Y.Z\` continues to trigger \`release.yml\`. SHA pins resolve to the same code that the previous tag pins resolved to at the time of writing.

## Verification

YAML structure unchanged apart from \`uses:\` lines, top-level \`permissions\`, and \`with:\` additions. CI on this PR will execute both pinned versions.