### PR TITLE
Add Zigbee2MQTT metadata foundation

### DIFF
--- a/sensor_hub/api/openapi.yaml
+++ b/sensor_hub/api/openapi.yaml
@@ -3506,6 +3506,13 @@ components:
             Driver-specific configuration key-value pairs. Each driver declares
             which keys it expects via the GET /drivers endpoint. Sensitive
             values are masked as "****" in GET responses.
+        metadata:
+          type: object
+          additionalProperties: true
+          readOnly: true
+          description: >-
+            System-populated device metadata. Contents are driver-specific and
+            ignored on create/update requests.
         health_status:
           $ref: '#/components/schemas/SensorHealthStatus'
           description: Health status ("good", "bad", or "unknown").
@@ -3554,6 +3561,7 @@ components:
         sensor_driver: "sensor-hub-http-temperature"
         config:
           url: "http://sensor.local/28-0000065f2ff3"
+        metadata: {}
         health_status: "good"
         health_reason: "ok"
         enabled: true

--- a/sensor_hub/api/sensor_api_test.go
+++ b/sensor_hub/api/sensor_api_test.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"fmt"
 	appProps "example/sensorHub/application_properties"
 	gen "example/sensorHub/gen"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
+
 func init() {
 	appProps.AppConfig = &appProps.ApplicationConfiguration{
 		HealthHistoryDefaultResponseNumber: 10,
@@ -97,6 +98,41 @@ func TestUpdateSensorHandler(t *testing.T) {
 
 	mockService.On("ServiceGetSensorById", mock.Anything, 1).Return(&existing, nil)
 	mockService.On("ServiceUpdateSensorById", mock.Anything, expected, mock.AnythingOfType("bool")).Return(nil)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("PUT", "/api/sensors/1", bytes.NewBuffer(jsonBody))
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestUpdateSensorHandler_IgnoresMetadataFromRequest(t *testing.T) {
+	router, api, s, mockService := setupSensorRouter()
+	api.PUT("/sensors/:id", func(c *gin.Context) {
+		var id int
+		if _, err := fmt.Sscan(c.Param("id"), &id); err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid sensor ID"})
+			return
+		}
+		s.UpdateSensorById(c, id)
+	})
+
+	metadata := map[string]interface{}{"manufacturer": "Aqara"}
+	existing := gen.Sensor{
+		Id:           1,
+		Name:         "s1",
+		SensorDriver: "mqtt-zigbee2mqtt",
+		Config:       map[string]string{},
+		Enabled:      true,
+		Metadata:     &metadata,
+	}
+	update := map[string]interface{}{
+		"metadata": map[string]interface{}{"manufacturer": "Injected"},
+	}
+	jsonBody, _ := json.Marshal(update)
+
+	mockService.On("ServiceGetSensorById", mock.Anything, 1).Return(&existing, nil)
+	mockService.On("ServiceUpdateSensorById", mock.Anything, existing, false).Return(nil)
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("PUT", "/api/sensors/1", bytes.NewBuffer(jsonBody))
@@ -733,57 +769,57 @@ func TestDismissSensorHandler_Error(t *testing.T) {
 }
 
 func TestGetAllMeasurementTypes(t *testing.T) {
-router, _, s, mockService := setupSensorRouter()
-router.GET("/api/measurement-types", func(c *gin.Context) {
-var params gen.GetAllMeasurementTypesParams
-s.GetAllMeasurementTypes(c, params)
-})
+	router, _, s, mockService := setupSensorRouter()
+	router.GET("/api/measurement-types", func(c *gin.Context) {
+		var params gen.GetAllMeasurementTypesParams
+		s.GetAllMeasurementTypes(c, params)
+	})
 
-mts := []gen.MeasurementType{{Name: "temperature"}}
-mockService.On("ServiceGetAllMeasurementTypes", mock.Anything).Return(mts, nil)
+	mts := []gen.MeasurementType{{Name: "temperature"}}
+	mockService.On("ServiceGetAllMeasurementTypes", mock.Anything).Return(mts, nil)
 
-w := httptest.NewRecorder()
-req := httptest.NewRequest("GET", "/api/measurement-types", nil)
-router.ServeHTTP(w, req)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/measurement-types", nil)
+	router.ServeHTTP(w, req)
 
-assert.Equal(t, http.StatusOK, w.Code)
-assert.Contains(t, w.Body.String(), "temperature")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "temperature")
 }
 
 func TestGetAllMeasurementTypes_HasReadings(t *testing.T) {
-router, _, s, mockService := setupSensorRouter()
-router.GET("/api/measurement-types", func(c *gin.Context) {
-hasReadings := c.Query("has_readings") == "true"
-params := gen.GetAllMeasurementTypesParams{HasReadings: &hasReadings}
-s.GetAllMeasurementTypes(c, params)
-})
+	router, _, s, mockService := setupSensorRouter()
+	router.GET("/api/measurement-types", func(c *gin.Context) {
+		hasReadings := c.Query("has_readings") == "true"
+		params := gen.GetAllMeasurementTypesParams{HasReadings: &hasReadings}
+		s.GetAllMeasurementTypes(c, params)
+	})
 
-mts := []gen.MeasurementType{{Name: "humidity"}}
-mockService.On("ServiceGetAllMeasurementTypesWithReadings", mock.Anything).Return(mts, nil)
+	mts := []gen.MeasurementType{{Name: "humidity"}}
+	mockService.On("ServiceGetAllMeasurementTypesWithReadings", mock.Anything).Return(mts, nil)
 
-w := httptest.NewRecorder()
-req := httptest.NewRequest("GET", "/api/measurement-types?has_readings=true", nil)
-router.ServeHTTP(w, req)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/measurement-types?has_readings=true", nil)
+	router.ServeHTTP(w, req)
 
-assert.Equal(t, http.StatusOK, w.Code)
-assert.Contains(t, w.Body.String(), "humidity")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "humidity")
 }
 
 func TestGetSensorMeasurementTypes(t *testing.T) {
-router, _, s, mockService := setupSensorRouter()
-router.GET("/api/sensors/:id/measurement-types", func(c *gin.Context) {
-var id int
-fmt.Sscan(c.Param("id"), &id)
-s.GetSensorMeasurementTypes(c, id)
-})
+	router, _, s, mockService := setupSensorRouter()
+	router.GET("/api/sensors/:id/measurement-types", func(c *gin.Context) {
+		var id int
+		fmt.Sscan(c.Param("id"), &id)
+		s.GetSensorMeasurementTypes(c, id)
+	})
 
-mts := []gen.MeasurementType{{Name: "temperature"}}
-mockService.On("ServiceGetMeasurementTypesForSensor", mock.Anything, 1).Return(mts, nil)
+	mts := []gen.MeasurementType{{Name: "temperature"}}
+	mockService.On("ServiceGetMeasurementTypesForSensor", mock.Anything, 1).Return(mts, nil)
 
-w := httptest.NewRecorder()
-req := httptest.NewRequest("GET", "/api/sensors/1/measurement-types", nil)
-router.ServeHTTP(w, req)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/sensors/1/measurement-types", nil)
+	router.ServeHTTP(w, req)
 
-assert.Equal(t, http.StatusOK, w.Code)
-assert.Contains(t, w.Body.String(), "temperature")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "temperature")
 }

--- a/sensor_hub/db/migrations/000017_device_metadata.down.sql
+++ b/sensor_hub/db/migrations/000017_device_metadata.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sensors DROP COLUMN metadata;

--- a/sensor_hub/db/migrations/000017_device_metadata.up.sql
+++ b/sensor_hub/db/migrations/000017_device_metadata.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sensors ADD COLUMN metadata TEXT NOT NULL DEFAULT '{}';

--- a/sensor_hub/db/sensor_repository.go
+++ b/sensor_hub/db/sensor_repository.go
@@ -169,7 +169,7 @@ func (s *SensorRepository) DeleteSensorByName(ctx context.Context, name string) 
 }
 
 func (s *SensorRepository) GetSensorsByDriver(ctx context.Context, sensorDriver string) ([]gen.Sensor, error) {
-	query := "SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status, retention_hours FROM sensors WHERE LOWER(sensor_driver) = LOWER(?)"
+	query := "SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status, retention_hours, metadata FROM sensors WHERE LOWER(sensor_driver) = LOWER(?)"
 	rows, err := s.db.QueryContext(ctx, query, sensorDriver)
 	if err != nil {
 		return nil, fmt.Errorf("error querying sensors by driver: %w", err)
@@ -195,15 +195,19 @@ func (s *SensorRepository) UpdateSensorById(ctx context.Context, sensor gen.Sens
 	if err != nil {
 		return fmt.Errorf("error marshalling sensor config: %w", err)
 	}
+	metadataJSON, err := json.Marshal(sensorMetadataValue(sensor.Metadata))
+	if err != nil {
+		return fmt.Errorf("error marshalling sensor metadata: %w", err)
+	}
 
 	var result sql.Result
 	if retentionHoursPresent {
 		// retention_hours was explicitly provided (even if null — meaning "clear it").
-		query := "UPDATE sensors SET name = ?, sensor_driver = ?, config = ?, retention_hours = ? WHERE id = ?"
-		result, err = s.db.ExecContext(ctx, query, sensor.Name, sensor.SensorDriver, string(configJSON), sensor.RetentionHours, sensor.Id)
+		query := "UPDATE sensors SET name = ?, sensor_driver = ?, config = ?, metadata = ?, retention_hours = ? WHERE id = ?"
+		result, err = s.db.ExecContext(ctx, query, sensor.Name, sensor.SensorDriver, string(configJSON), string(metadataJSON), sensor.RetentionHours, sensor.Id)
 	} else {
-		query := "UPDATE sensors SET name = ?, sensor_driver = ?, config = ? WHERE id = ?"
-		result, err = s.db.ExecContext(ctx, query, sensor.Name, sensor.SensorDriver, string(configJSON), sensor.Id)
+		query := "UPDATE sensors SET name = ?, sensor_driver = ?, config = ?, metadata = ? WHERE id = ?"
+		result, err = s.db.ExecContext(ctx, query, sensor.Name, sensor.SensorDriver, string(configJSON), string(metadataJSON), sensor.Id)
 	}
 	if err != nil {
 		return fmt.Errorf("error updating sensor: %w", err)
@@ -244,7 +248,7 @@ func (s *SensorRepository) AddSensor(ctx context.Context, sensor gen.Sensor) err
 }
 
 func (s *SensorRepository) GetSensorById(ctx context.Context, id int) (*gen.Sensor, error) {
-	query := "SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status, retention_hours FROM sensors WHERE id = ?"
+	query := "SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status, retention_hours, metadata FROM sensors WHERE id = ?"
 	sensor, err := scanSensorRow(s.db.QueryRowContext(ctx, query, id))
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -256,7 +260,7 @@ func (s *SensorRepository) GetSensorById(ctx context.Context, id int) (*gen.Sens
 }
 
 func (s *SensorRepository) GetSensorByName(ctx context.Context, name string) (*gen.Sensor, error) {
-	query := "SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status, retention_hours FROM sensors WHERE LOWER(name) = LOWER(?)"
+	query := "SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status, retention_hours, metadata FROM sensors WHERE LOWER(name) = LOWER(?)"
 	sensor, err := scanSensorRow(s.db.QueryRowContext(ctx, query, name))
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -268,7 +272,7 @@ func (s *SensorRepository) GetSensorByName(ctx context.Context, name string) (*g
 }
 
 func (s *SensorRepository) GetSensorByExternalId(ctx context.Context, externalId string) (*gen.Sensor, error) {
-	query := "SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status, retention_hours FROM sensors WHERE LOWER(external_id) = LOWER(?)"
+	query := "SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status, retention_hours, metadata FROM sensors WHERE LOWER(external_id) = LOWER(?)"
 	sensor, err := scanSensorRow(s.db.QueryRowContext(ctx, query, externalId))
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -290,7 +294,7 @@ func (s *SensorRepository) SensorExistsByExternalId(ctx context.Context, externa
 }
 
 func (s *SensorRepository) GetAllSensors(ctx context.Context) ([]gen.Sensor, error) {
-	query := "SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status, retention_hours FROM sensors"
+	query := "SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status, retention_hours, metadata FROM sensors"
 	rows, err := s.db.QueryContext(ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf("error querying all sensors: %w", err)
@@ -340,14 +344,15 @@ type scannable interface {
 }
 
 // scanSensorRow scans a sensor row (columns: id, name, external_id, sensor_driver, config,
-// health_status, health_reason, enabled, status, retention_hours) and unmarshals the JSON
-// config column into the Config map.
+// health_status, health_reason, enabled, status, retention_hours, metadata) and unmarshals
+// the JSON config/metadata columns into the Sensor maps.
 func scanSensorRow(row scannable) (gen.Sensor, error) {
 	var s gen.Sensor
 	var configJSON string
+	var metadataJSON string
 	var externalId sql.NullString
 	var retentionHours sql.NullInt64
-	err := row.Scan(&s.Id, &s.Name, &externalId, &s.SensorDriver, &configJSON, &s.HealthStatus, &s.HealthReason, &s.Enabled, &s.Status, &retentionHours)
+	err := row.Scan(&s.Id, &s.Name, &externalId, &s.SensorDriver, &configJSON, &s.HealthStatus, &s.HealthReason, &s.Enabled, &s.Status, &retentionHours, &metadataJSON)
 	if err != nil {
 		return s, err
 	}
@@ -366,11 +371,25 @@ func scanSensorRow(row scannable) (gen.Sensor, error) {
 	if s.Config == nil {
 		s.Config = make(map[string]string)
 	}
+	metadata := make(map[string]interface{})
+	if metadataJSON != "" {
+		if err := json.Unmarshal([]byte(metadataJSON), &metadata); err != nil {
+			return s, fmt.Errorf("failed to unmarshal sensor metadata: %w", err)
+		}
+	}
+	s.Metadata = &metadata
 	return s, nil
 }
 
+func sensorMetadataValue(metadata *map[string]interface{}) map[string]interface{} {
+	if metadata == nil {
+		return map[string]interface{}{}
+	}
+	return *metadata
+}
+
 func (sr *SensorRepository) GetSensorsByStatus(ctx context.Context, status string) ([]gen.Sensor, error) {
-	query := "SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status, retention_hours FROM sensors WHERE LOWER(status) = LOWER(?)"
+	query := "SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status, retention_hours, metadata FROM sensors WHERE LOWER(status) = LOWER(?)"
 	rows, err := sr.db.QueryContext(ctx, query, status)
 	if err != nil {
 		return nil, fmt.Errorf("error querying sensors by status: %w", err)
@@ -393,7 +412,7 @@ func (sr *SensorRepository) GetSensorsByStatus(ctx context.Context, status strin
 
 // GetSensorsWithRetention returns all sensors that have a custom retention_hours set.
 func (sr *SensorRepository) GetSensorsWithRetention(ctx context.Context) ([]gen.Sensor, error) {
-	query := "SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status, retention_hours FROM sensors WHERE retention_hours IS NOT NULL"
+	query := "SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status, retention_hours, metadata FROM sensors WHERE retention_hours IS NOT NULL"
 	rows, err := sr.db.QueryContext(ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf("error querying sensors with custom retention: %w", err)

--- a/sensor_hub/db/sensor_repository_test.go
+++ b/sensor_hub/db/sensor_repository_test.go
@@ -138,10 +138,10 @@ func TestSensorRepository_GetSensorByName_Success(t *testing.T) {
 	db, mock := newMockDB(t)
 	repo := NewSensorRepository(db, slog.Default())
 
-	mock.ExpectQuery("SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status, retention_hours FROM sensors WHERE LOWER\\(name\\) = LOWER\\(\\?\\)").
+	mock.ExpectQuery("SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status, retention_hours, metadata FROM sensors WHERE LOWER\\(name\\) = LOWER\\(\\?\\)").
 		WithArgs("test-sensor").
 		WillReturnRows(sqlmock.NewRows(sensorColumns).
-			AddRow(1, "test-sensor", nil, "temperature", `{"url":"http://localhost:8080"}`, "good", "ok", true, "active", nil))
+			AddRow(1, "test-sensor", nil, "temperature", `{"url":"http://localhost:8080"}`, "good", "ok", true, "active", nil, `{}`))
 
 	sensor, err := repo.GetSensorByName(context.Background(), "test-sensor")
 
@@ -156,11 +156,30 @@ func TestSensorRepository_GetSensorByName_Success(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestSensorRepository_GetSensorByName_IncludesMetadata(t *testing.T) {
+	db, mock := newMockDB(t)
+	repo := NewSensorRepository(db, slog.Default())
+
+	mock.ExpectQuery("SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status, retention_hours, metadata FROM sensors WHERE LOWER\\(name\\) = LOWER\\(\\?\\)").
+		WithArgs("test-sensor").
+		WillReturnRows(sqlmock.NewRows(sensorColumns).
+			AddRow(1, "test-sensor", nil, "mqtt-zigbee2mqtt", `{"base_topic":"zigbee2mqtt"}`, "good", "ok", true, "active", nil, `{"manufacturer":"Aqara","model":"MCCGQ11LM"}`))
+
+	sensor, err := repo.GetSensorByName(context.Background(), "test-sensor")
+
+	assert.NoError(t, err)
+	require.NotNil(t, sensor)
+	require.NotNil(t, sensor.Metadata)
+	assert.Equal(t, "Aqara", (*sensor.Metadata)["manufacturer"])
+	assert.Equal(t, "MCCGQ11LM", (*sensor.Metadata)["model"])
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestSensorRepository_GetSensorByName_NotFound(t *testing.T) {
 	db, mock := newMockDB(t)
 	repo := NewSensorRepository(db, slog.Default())
 
-	mock.ExpectQuery("SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status, retention_hours FROM sensors WHERE LOWER\\(name\\) = LOWER\\(\\?\\)").
+	mock.ExpectQuery("SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status, retention_hours, metadata FROM sensors WHERE LOWER\\(name\\) = LOWER\\(\\?\\)").
 		WithArgs("nonexistent").
 		WillReturnError(sql.ErrNoRows)
 
@@ -176,7 +195,7 @@ func TestSensorRepository_GetSensorByName_DBError(t *testing.T) {
 	db, mock := newMockDB(t)
 	repo := NewSensorRepository(db, slog.Default())
 
-	mock.ExpectQuery("SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status, retention_hours FROM sensors WHERE LOWER\\(name\\) = LOWER\\(\\?\\)").
+	mock.ExpectQuery("SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status, retention_hours, metadata FROM sensors WHERE LOWER\\(name\\) = LOWER\\(\\?\\)").
 		WithArgs("test-sensor").
 		WillReturnError(errors.New("connection error"))
 
@@ -196,10 +215,10 @@ func TestSensorRepository_GetAllSensors_Success(t *testing.T) {
 	db, mock := newMockDB(t)
 	repo := NewSensorRepository(db, slog.Default())
 
-	mock.ExpectQuery("SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status, retention_hours FROM sensors").
+	mock.ExpectQuery("SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status, retention_hours, metadata FROM sensors").
 		WillReturnRows(sqlmock.NewRows(sensorColumns).
-			AddRow(1, "sensor-1", nil, "temperature", `{"url":"http://localhost:8081"}`, "good", "ok", true, "active", nil).
-			AddRow(2, "sensor-2", nil, "temperature", `{"url":"http://localhost:8082"}`, "bad", "timeout", false, "active", nil))
+			AddRow(1, "sensor-1", nil, "temperature", `{"url":"http://localhost:8081"}`, "good", "ok", true, "active", nil, `{}`).
+			AddRow(2, "sensor-2", nil, "temperature", `{"url":"http://localhost:8082"}`, "bad", "timeout", false, "active", nil, `{}`))
 
 	sensors, err := repo.GetAllSensors(context.Background())
 
@@ -214,7 +233,7 @@ func TestSensorRepository_GetAllSensors_EmptyTable(t *testing.T) {
 	db, mock := newMockDB(t)
 	repo := NewSensorRepository(db, slog.Default())
 
-	mock.ExpectQuery("SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status, retention_hours FROM sensors").
+	mock.ExpectQuery("SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status, retention_hours, metadata FROM sensors").
 		WillReturnRows(sqlmock.NewRows(sensorColumns))
 
 	sensors, err := repo.GetAllSensors(context.Background())
@@ -228,7 +247,7 @@ func TestSensorRepository_GetAllSensors_DBError(t *testing.T) {
 	db, mock := newMockDB(t)
 	repo := NewSensorRepository(db, slog.Default())
 
-	mock.ExpectQuery("SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status, retention_hours FROM sensors").
+	mock.ExpectQuery("SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status, retention_hours, metadata FROM sensors").
 		WillReturnError(errors.New("database error"))
 
 	sensors, err := repo.GetAllSensors(context.Background())
@@ -247,11 +266,11 @@ func TestSensorRepository_GetSensorsByDriver_Success(t *testing.T) {
 	db, mock := newMockDB(t)
 	repo := NewSensorRepository(db, slog.Default())
 
-	mock.ExpectQuery("SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status, retention_hours FROM sensors WHERE LOWER\\(sensor_driver\\) = LOWER\\(\\?\\)").
+	mock.ExpectQuery("SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status, retention_hours, metadata FROM sensors WHERE LOWER\\(sensor_driver\\) = LOWER\\(\\?\\)").
 		WithArgs("sensor-hub-http-temperature").
 		WillReturnRows(sqlmock.NewRows(sensorColumns).
-			AddRow(1, "temp-sensor-1", nil, "sensor-hub-http-temperature", `{"url":"http://localhost:8081"}`, "good", "ok", true, "active", nil).
-			AddRow(2, "temp-sensor-2", nil, "sensor-hub-http-temperature", `{"url":"http://localhost:8082"}`, "good", "ok", true, "active", nil))
+			AddRow(1, "temp-sensor-1", nil, "sensor-hub-http-temperature", `{"url":"http://localhost:8081"}`, "good", "ok", true, "active", nil, `{}`).
+			AddRow(2, "temp-sensor-2", nil, "sensor-hub-http-temperature", `{"url":"http://localhost:8082"}`, "good", "ok", true, "active", nil, `{}`))
 
 	sensors, err := repo.GetSensorsByDriver(context.Background(), "sensor-hub-http-temperature")
 
@@ -264,7 +283,7 @@ func TestSensorRepository_GetSensorsByDriver_NoMatches(t *testing.T) {
 	db, mock := newMockDB(t)
 	repo := NewSensorRepository(db, slog.Default())
 
-	mock.ExpectQuery("SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status, retention_hours FROM sensors WHERE LOWER\\(sensor_driver\\) = LOWER\\(\\?\\)").
+	mock.ExpectQuery("SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status, retention_hours, metadata FROM sensors WHERE LOWER\\(sensor_driver\\) = LOWER\\(\\?\\)").
 		WithArgs("humidity").
 		WillReturnRows(sqlmock.NewRows(sensorColumns))
 
@@ -279,7 +298,7 @@ func TestSensorRepository_GetSensorsByDriver_DBError(t *testing.T) {
 	db, mock := newMockDB(t)
 	repo := NewSensorRepository(db, slog.Default())
 
-	mock.ExpectQuery("SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status, retention_hours FROM sensors WHERE LOWER\\(sensor_driver\\) = LOWER\\(\\?\\)").
+	mock.ExpectQuery("SELECT id, name, external_id, sensor_driver, config, health_status, health_reason, enabled, status, retention_hours, metadata FROM sensors WHERE LOWER\\(sensor_driver\\) = LOWER\\(\\?\\)").
 		WithArgs("sensor-hub-http-temperature").
 		WillReturnError(errors.New("database error"))
 
@@ -302,6 +321,28 @@ func TestSensorRepository_AddSensor_Success(t *testing.T) {
 		Name:         "new-sensor",
 		SensorDriver: "sensor-hub-http-temperature",
 		Config:       map[string]string{"url": "http://localhost:8080"},
+	}
+
+	mock.ExpectExec("INSERT INTO sensors").
+		WithArgs("new-sensor", nil, "sensor-hub-http-temperature", `{"url":"http://localhost:8080"}`, true, gen.SensorStatusActive).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err := repo.AddSensor(context.Background(), sensor)
+
+	assert.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSensorRepository_AddSensor_IgnoresMetadata(t *testing.T) {
+	db, mock := newMockDB(t)
+	repo := NewSensorRepository(db, slog.Default())
+
+	metadata := map[string]interface{}{"manufacturer": "Aqara"}
+	sensor := gen.Sensor{
+		Name:         "new-sensor",
+		SensorDriver: "sensor-hub-http-temperature",
+		Config:       map[string]string{"url": "http://localhost:8080"},
+		Metadata:     &metadata,
 	}
 
 	mock.ExpectExec("INSERT INTO sensors").
@@ -382,8 +423,8 @@ func TestSensorRepository_UpdateSensorById_Success(t *testing.T) {
 		Config:       map[string]string{"url": "http://localhost:9090"},
 	}
 
-	mock.ExpectExec("UPDATE sensors SET name = \\?, sensor_driver = \\?, config = \\? WHERE id = \\?").
-		WithArgs("updated-sensor", "sensor-hub-http-temperature", `{"url":"http://localhost:9090"}`, 1).
+	mock.ExpectExec("UPDATE sensors SET name = \\?, sensor_driver = \\?, config = \\?, metadata = \\? WHERE id = \\?").
+		WithArgs("updated-sensor", "sensor-hub-http-temperature", `{"url":"http://localhost:9090"}`, `{}`, 1).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	err := repo.UpdateSensorById(context.Background(), sensor, false)
@@ -403,8 +444,8 @@ func TestSensorRepository_UpdateSensorById_NotFound(t *testing.T) {
 		Config:       map[string]string{"url": "http://localhost:9090"},
 	}
 
-	mock.ExpectExec("UPDATE sensors SET name = \\?, sensor_driver = \\?, config = \\? WHERE id = \\?").
-		WithArgs("nonexistent", "sensor-hub-http-temperature", `{"url":"http://localhost:9090"}`, 999).
+	mock.ExpectExec("UPDATE sensors SET name = \\?, sensor_driver = \\?, config = \\?, metadata = \\? WHERE id = \\?").
+		WithArgs("nonexistent", "sensor-hub-http-temperature", `{"url":"http://localhost:9090"}`, `{}`, 999).
 		WillReturnResult(sqlmock.NewResult(0, 0))
 
 	err := repo.UpdateSensorById(context.Background(), sensor, false)
@@ -425,8 +466,8 @@ func TestSensorRepository_UpdateSensorById_DBError(t *testing.T) {
 		Config:       map[string]string{"url": "http://localhost:9090"},
 	}
 
-	mock.ExpectExec("UPDATE sensors SET name = \\?, sensor_driver = \\?, config = \\? WHERE id = \\?").
-		WithArgs("updated-sensor", "sensor-hub-http-temperature", `{"url":"http://localhost:9090"}`, 1).
+	mock.ExpectExec("UPDATE sensors SET name = \\?, sensor_driver = \\?, config = \\?, metadata = \\? WHERE id = \\?").
+		WithArgs("updated-sensor", "sensor-hub-http-temperature", `{"url":"http://localhost:9090"}`, `{}`, 1).
 		WillReturnError(errors.New("database error"))
 
 	err := repo.UpdateSensorById(context.Background(), sensor, false)
@@ -770,8 +811,8 @@ func TestSensorRepository_GetSensorsByStatus_Success(t *testing.T) {
 	mock.ExpectQuery("SELECT .* FROM sensors WHERE LOWER\\(status\\) = LOWER\\(\\?\\)").
 		WithArgs("pending").
 		WillReturnRows(sqlmock.NewRows(sensorColumns).
-			AddRow(1, "mqtt-sensor-1", "mqtt-sensor-1", "mqtt-zigbee2mqtt", "{}", "healthy", "", true, "pending", nil).
-			AddRow(2, "mqtt-sensor-2", "mqtt-sensor-2", "mqtt-zigbee2mqtt", "{}", "unknown", "", true, "pending", nil))
+			AddRow(1, "mqtt-sensor-1", "mqtt-sensor-1", "mqtt-zigbee2mqtt", "{}", "healthy", "", true, "pending", nil, `{}`).
+			AddRow(2, "mqtt-sensor-2", "mqtt-sensor-2", "mqtt-zigbee2mqtt", "{}", "unknown", "", true, "pending", nil, `{}`))
 
 	sensors, err := repo.GetSensorsByStatus(context.Background(), "pending")
 

--- a/sensor_hub/db/test_helpers_test.go
+++ b/sensor_hub/db/test_helpers_test.go
@@ -90,7 +90,7 @@ func testAlertRule() alerting.AlertRule {
 		LowThreshold:      10.0,
 		TriggerStatus:     "",
 		Enabled:           true,
-		RateLimitSeconds:    1,
+		RateLimitSeconds:  1,
 	}
 }
 
@@ -130,7 +130,7 @@ func testSensorHealthHistory() gen.SensorHealthHistory {
 
 // Column definitions for sqlmock rows
 
-var sensorColumns = []string{"id", "name", "external_id", "sensor_driver", "config", "health_status", "health_reason", "enabled", "status", "retention_hours"}
+var sensorColumns = []string{"id", "name", "external_id", "sensor_driver", "config", "health_status", "health_reason", "enabled", "status", "retention_hours", "metadata"}
 
 var userColumns = []string{"id", "username", "email", "must_change_password", "disabled", "created_at", "updated_at"}
 

--- a/sensor_hub/drivers/driver.go
+++ b/sensor_hub/drivers/driver.go
@@ -2,6 +2,7 @@ package drivers
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sync"
 
@@ -52,6 +53,20 @@ type PushDriver interface {
 	// IdentifyDevice returns a suggested sensor name from an MQTT message,
 	// used during auto-discovery of new devices.
 	IdentifyDevice(topic string, payload []byte) (string, error)
+}
+
+// DeviceMetadata is metadata extracted from a driver-specific system message.
+type DeviceMetadata struct {
+	FriendlyName string
+	IEEEAddress  string
+	Metadata     map[string]string
+	Exposes      json.RawMessage
+}
+
+// SystemMessageHandler is an optional interface for push drivers that emit
+// non-reading system messages such as device inventories.
+type SystemMessageHandler interface {
+	ParseSystemMessage(topic string, payload []byte) []DeviceMetadata
 }
 
 var (

--- a/sensor_hub/drivers/zigbee2mqtt.go
+++ b/sensor_hub/drivers/zigbee2mqtt.go
@@ -26,34 +26,34 @@ type fieldMapping struct {
 // definitions. Zigbee2MQTT normalises field names across hardware vendors,
 // so "temperature" is always "temperature" regardless of the device model.
 var knownFields = map[string]fieldMapping{
-	"temperature":       {MeasurementType: "temperature", DisplayName: "Temperature", Unit: "°C", Category: "numeric"},
-	"humidity":          {MeasurementType: "humidity", DisplayName: "Humidity", Unit: "%", Category: "numeric"},
-	"pressure":          {MeasurementType: "pressure", DisplayName: "Pressure", Unit: "hPa", Category: "numeric"},
-	"battery":           {MeasurementType: "battery", DisplayName: "Battery", Unit: "%", Category: "numeric"},
-	"voltage":           {MeasurementType: "voltage", DisplayName: "Voltage", Unit: "V", Category: "numeric"},
-	"linkquality":       {MeasurementType: "link_quality", DisplayName: "Link Quality", Unit: "lqi", Category: "numeric"},
-	"illuminance":       {MeasurementType: "illuminance", DisplayName: "Illuminance", Unit: "lx", Category: "numeric"},
-	"illuminance_lux":   {MeasurementType: "illuminance", DisplayName: "Illuminance", Unit: "lx", Category: "numeric"},
-	"power":             {MeasurementType: "power", DisplayName: "Power", Unit: "W", Category: "numeric"},
-	"energy":            {MeasurementType: "energy", DisplayName: "Energy", Unit: "kWh", Category: "numeric"},
-	"energy_today":      {MeasurementType: "energy_today", DisplayName: "Energy Today", Unit: "kWh", Category: "numeric"},
-	"energy_month":      {MeasurementType: "energy_month", DisplayName: "Energy Month", Unit: "kWh", Category: "numeric"},
-	"energy_yesterday":  {MeasurementType: "energy_yesterday", DisplayName: "Energy Yesterday", Unit: "kWh", Category: "numeric"},
-	"current":           {MeasurementType: "current", DisplayName: "Current", Unit: "A", Category: "numeric"},
-	"co2":               {MeasurementType: "co2", DisplayName: "CO₂", Unit: "ppm", Category: "numeric"},
-	"voc":               {MeasurementType: "voc", DisplayName: "VOC", Unit: "ppb", Category: "numeric"},
-	"formaldehyde":      {MeasurementType: "formaldehyde", DisplayName: "Formaldehyde", Unit: "mg/m³", Category: "numeric"},
-	"pm25":              {MeasurementType: "pm25", DisplayName: "PM2.5", Unit: "µg/m³", Category: "numeric"},
-	"soil_moisture":     {MeasurementType: "soil_moisture", DisplayName: "Soil Moisture", Unit: "%", Category: "numeric"},
-	"occupancy":         {MeasurementType: "occupancy", DisplayName: "Occupancy", Unit: "", Category: "binary"},
-	"contact":           {MeasurementType: "contact", DisplayName: "Contact", Unit: "", Category: "binary"},
-	"water_leak":        {MeasurementType: "water_leak", DisplayName: "Water Leak", Unit: "", Category: "binary"},
-	"smoke":             {MeasurementType: "smoke", DisplayName: "Smoke", Unit: "", Category: "binary"},
-	"carbon_monoxide":   {MeasurementType: "carbon_monoxide", DisplayName: "Carbon Monoxide", Unit: "", Category: "binary"},
-	"tamper":            {MeasurementType: "tamper", DisplayName: "Tamper", Unit: "", Category: "binary"},
-	"battery_low":       {MeasurementType: "battery_low", DisplayName: "Battery Low", Unit: "", Category: "binary"},
-	"vibration":         {MeasurementType: "vibration", DisplayName: "Vibration", Unit: "", Category: "binary"},
-	"state":             {MeasurementType: "state", DisplayName: "State", Unit: "", Category: "binary"},
+	"temperature":      {MeasurementType: "temperature", DisplayName: "Temperature", Unit: "°C", Category: "numeric"},
+	"humidity":         {MeasurementType: "humidity", DisplayName: "Humidity", Unit: "%", Category: "numeric"},
+	"pressure":         {MeasurementType: "pressure", DisplayName: "Pressure", Unit: "hPa", Category: "numeric"},
+	"battery":          {MeasurementType: "battery", DisplayName: "Battery", Unit: "%", Category: "numeric"},
+	"voltage":          {MeasurementType: "voltage", DisplayName: "Voltage", Unit: "V", Category: "numeric"},
+	"linkquality":      {MeasurementType: "link_quality", DisplayName: "Link Quality", Unit: "lqi", Category: "numeric"},
+	"illuminance":      {MeasurementType: "illuminance", DisplayName: "Illuminance", Unit: "lx", Category: "numeric"},
+	"illuminance_lux":  {MeasurementType: "illuminance", DisplayName: "Illuminance", Unit: "lx", Category: "numeric"},
+	"power":            {MeasurementType: "power", DisplayName: "Power", Unit: "W", Category: "numeric"},
+	"energy":           {MeasurementType: "energy", DisplayName: "Energy", Unit: "kWh", Category: "numeric"},
+	"energy_today":     {MeasurementType: "energy_today", DisplayName: "Energy Today", Unit: "kWh", Category: "numeric"},
+	"energy_month":     {MeasurementType: "energy_month", DisplayName: "Energy Month", Unit: "kWh", Category: "numeric"},
+	"energy_yesterday": {MeasurementType: "energy_yesterday", DisplayName: "Energy Yesterday", Unit: "kWh", Category: "numeric"},
+	"current":          {MeasurementType: "current", DisplayName: "Current", Unit: "A", Category: "numeric"},
+	"co2":              {MeasurementType: "co2", DisplayName: "CO₂", Unit: "ppm", Category: "numeric"},
+	"voc":              {MeasurementType: "voc", DisplayName: "VOC", Unit: "ppb", Category: "numeric"},
+	"formaldehyde":     {MeasurementType: "formaldehyde", DisplayName: "Formaldehyde", Unit: "mg/m³", Category: "numeric"},
+	"pm25":             {MeasurementType: "pm25", DisplayName: "PM2.5", Unit: "µg/m³", Category: "numeric"},
+	"soil_moisture":    {MeasurementType: "soil_moisture", DisplayName: "Soil Moisture", Unit: "%", Category: "numeric"},
+	"occupancy":        {MeasurementType: "occupancy", DisplayName: "Occupancy", Unit: "", Category: "binary"},
+	"contact":          {MeasurementType: "contact", DisplayName: "Contact", Unit: "", Category: "binary"},
+	"water_leak":       {MeasurementType: "water_leak", DisplayName: "Water Leak", Unit: "", Category: "binary"},
+	"smoke":            {MeasurementType: "smoke", DisplayName: "Smoke", Unit: "", Category: "binary"},
+	"carbon_monoxide":  {MeasurementType: "carbon_monoxide", DisplayName: "Carbon Monoxide", Unit: "", Category: "binary"},
+	"tamper":           {MeasurementType: "tamper", DisplayName: "Tamper", Unit: "", Category: "binary"},
+	"battery_low":      {MeasurementType: "battery_low", DisplayName: "Battery Low", Unit: "", Category: "binary"},
+	"vibration":        {MeasurementType: "vibration", DisplayName: "Vibration", Unit: "", Category: "binary"},
+	"state":            {MeasurementType: "state", DisplayName: "State", Unit: "", Category: "binary"},
 }
 
 // Zigbee2MQTTDriver parses MQTT messages from a Zigbee2MQTT bridge.
@@ -63,9 +63,10 @@ var knownFields = map[string]fieldMapping{
 type Zigbee2MQTTDriver struct{}
 
 var _ PushDriver = (*Zigbee2MQTTDriver)(nil)
+var _ SystemMessageHandler = (*Zigbee2MQTTDriver)(nil)
 
 func (d *Zigbee2MQTTDriver) Type() string        { return "mqtt-zigbee2mqtt" }
-func (d *Zigbee2MQTTDriver) DisplayName() string  { return "Zigbee2MQTT" }
+func (d *Zigbee2MQTTDriver) DisplayName() string { return "Zigbee2MQTT" }
 func (d *Zigbee2MQTTDriver) Description() string {
 	return "Zigbee devices via the Zigbee2MQTT bridge — temperature, humidity, contact sensors, smart plugs, and more"
 }
@@ -130,6 +131,44 @@ func (d *Zigbee2MQTTDriver) IdentifyDevice(topic string, _ []byte) (string, erro
 	}
 
 	return deviceName, nil
+}
+
+type zigbeeBridgeDevice struct {
+	IEEEAddress  string `json:"ieee_address"`
+	FriendlyName string `json:"friendly_name"`
+	Definition   struct {
+		Model       string          `json:"model"`
+		Vendor      string          `json:"vendor"`
+		Description string          `json:"description"`
+		Exposes     json.RawMessage `json:"exposes"`
+	} `json:"definition"`
+}
+
+func (d *Zigbee2MQTTDriver) ParseSystemMessage(topic string, payload []byte) []DeviceMetadata {
+	if topic != "zigbee2mqtt/bridge/devices" {
+		return nil
+	}
+
+	var devices []zigbeeBridgeDevice
+	if err := json.Unmarshal(payload, &devices); err != nil {
+		return nil
+	}
+
+	metadata := make([]DeviceMetadata, 0, len(devices))
+	for _, device := range devices {
+		metadata = append(metadata, DeviceMetadata{
+			FriendlyName: device.FriendlyName,
+			IEEEAddress:  device.IEEEAddress,
+			Metadata: map[string]string{
+				"manufacturer": device.Definition.Vendor,
+				"model":        device.Definition.Model,
+				"description":  device.Definition.Description,
+			},
+			Exposes: device.Definition.Exposes,
+		})
+	}
+
+	return metadata
 }
 
 // ParseMessage extracts readings from a Zigbee2MQTT JSON payload.

--- a/sensor_hub/drivers/zigbee2mqtt_test.go
+++ b/sensor_hub/drivers/zigbee2mqtt_test.go
@@ -259,6 +259,53 @@ func TestZigbee2MQTT_ValidateSensor(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestZigbee2MQTT_ParseSystemMessage_BridgeDevices(t *testing.T) {
+	d := &Zigbee2MQTTDriver{}
+
+	payload := `[
+		{
+			"ieee_address": "0x00158d00018255df",
+			"friendly_name": "front-door",
+			"definition": {
+				"model": "MCCGQ11LM",
+				"vendor": "Aqara",
+				"description": "Door and window sensor",
+				"exposes": [
+					{"type": "binary", "property": "contact", "name": "contact", "access": 1}
+				]
+			}
+		}
+	]`
+
+	entries := d.ParseSystemMessage("zigbee2mqtt/bridge/devices", []byte(payload))
+
+	require.Len(t, entries, 1)
+	assert.Equal(t, "front-door", entries[0].FriendlyName)
+	assert.Equal(t, "0x00158d00018255df", entries[0].IEEEAddress)
+	assert.Equal(t, map[string]string{
+		"manufacturer": "Aqara",
+		"model":        "MCCGQ11LM",
+		"description":  "Door and window sensor",
+	}, entries[0].Metadata)
+	assert.JSONEq(t, `[{"type":"binary","property":"contact","name":"contact","access":1}]`, string(entries[0].Exposes))
+}
+
+func TestZigbee2MQTT_ParseSystemMessage_NonSystemTopic(t *testing.T) {
+	d := &Zigbee2MQTTDriver{}
+
+	entries := d.ParseSystemMessage("zigbee2mqtt/front-door", []byte(`{"contact":true}`))
+
+	assert.Nil(t, entries)
+}
+
+func TestZigbee2MQTT_ParseSystemMessage_MalformedPayload(t *testing.T) {
+	d := &Zigbee2MQTTDriver{}
+
+	entries := d.ParseSystemMessage("zigbee2mqtt/bridge/devices", []byte(`{not-json`))
+
+	assert.Nil(t, entries)
+}
+
 func TestZigbee2MQTT_SupportedMeasurementTypes(t *testing.T) {
 	d := &Zigbee2MQTTDriver{}
 	mts := d.SupportedMeasurementTypes()

--- a/sensor_hub/gen/types.gen.go
+++ b/sensor_hub/gen/types.gen.go
@@ -774,6 +774,9 @@ type Sensor struct {
 	// Id Internal numeric id for the sensor (database primary key).
 	Id int `json:"id"`
 
+	// Metadata System-populated device metadata. Contents are driver-specific and ignored on create/update requests.
+	Metadata *map[string]interface{} `json:"metadata,omitempty"`
+
 	// Name Human-friendly sensor name (used as `sensor_name` in readings).
 	Name string `json:"name"`
 

--- a/sensor_hub/integration/mqtt_metadata_test.go
+++ b/sensor_hub/integration/mqtt_metadata_test.go
@@ -1,0 +1,141 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	database "example/sensorHub/db"
+	gen "example/sensorHub/gen"
+	mqttpkg "example/sensorHub/mqtt"
+	"example/sensorHub/service"
+
+	pahomqtt "github.com/eclipse/paho.mqtt.golang"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestZigbee2MQTTBridgeDevices_BackfillsSensorMetadata(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.Default()
+	port := reserveTCPPort(t)
+	sensorName := fmt.Sprintf("front-door-%d", port)
+
+	embeddedBroker := mqttpkg.NewEmbeddedBroker(mqttpkg.BrokerConfig{
+		TCPAddress: fmt.Sprintf(":%d", port),
+	}, logger)
+	require.NoError(t, embeddedBroker.Start())
+	defer func() {
+		require.NoError(t, embeddedBroker.Stop())
+	}()
+
+	sensorRepo := database.NewSensorRepository(env.DB, logger)
+	readingsRepo := database.NewReadingsRepository(env.DB, logger)
+	mtRepo := database.NewMeasurementTypeRepository(env.DB, logger)
+	alertRepo := database.NewAlertRepository(env.DB, logger)
+	brokerRepo := database.NewMQTTBrokerRepository(env.DB, logger)
+	subRepo := database.NewMQTTSubscriptionRepository(env.DB, logger)
+
+	sensorService := service.NewSensorService(sensorRepo, readingsRepo, mtRepo, alertRepo, nil, logger)
+	connManager := mqttpkg.NewConnectionManager(sensorService, subRepo, brokerRepo, logger)
+
+	brokerID, err := brokerRepo.Add(ctx, gen.MQTTBroker{
+		Name:    fmt.Sprintf("integration-z2m-%d", port),
+		Host:    "127.0.0.1",
+		Port:    port,
+		Type:    "external",
+		Enabled: true,
+	})
+	require.NoError(t, err)
+
+	subID, err := subRepo.Add(ctx, gen.MQTTSubscription{
+		BrokerId:     brokerID,
+		TopicPattern: "zigbee2mqtt/#",
+		DriverType:   "mqtt-zigbee2mqtt",
+		Enabled:      true,
+	})
+	require.NoError(t, err)
+
+	defer func() {
+		connManager.Stop()
+		_ = subRepo.Delete(ctx, subID)
+		_ = brokerRepo.Delete(ctx, brokerID)
+		_ = client.DeleteSensor(sensorName)
+	}()
+
+	require.NoError(t, connManager.Start(ctx))
+	require.Eventually(t, func() bool {
+		return connManager.IsConnected(brokerID)
+	}, 5*time.Second, 100*time.Millisecond)
+
+	_, status := client.AddSensor(gen.Sensor{
+		Name:         sensorName,
+		SensorDriver: "mqtt-zigbee2mqtt",
+		Config:       map[string]string{},
+	})
+	require.Equal(t, http.StatusCreated, status)
+
+	mqttClient := pahomqtt.NewClient(
+		pahomqtt.NewClientOptions().
+			AddBroker(fmt.Sprintf("tcp://127.0.0.1:%d", port)).
+			SetClientID(fmt.Sprintf("integration-z2m-publisher-%d", port)),
+	)
+	token := mqttClient.Connect()
+	require.True(t, token.WaitTimeout(5*time.Second))
+	require.NoError(t, token.Error())
+	defer mqttClient.Disconnect(250)
+
+	payload := fmt.Sprintf(`[
+		{
+			"ieee_address": "0x00158d00018255df",
+			"friendly_name": %q,
+			"definition": {
+				"model": "MCCGQ11LM",
+				"vendor": "Aqara",
+				"description": "Door and window sensor",
+				"exposes": [
+					{"type": "binary", "property": "contact", "name": "contact", "access": 1}
+				]
+			}
+		}
+	]`, sensorName)
+
+	pub := mqttClient.Publish("zigbee2mqtt/bridge/devices", 0, false, payload)
+	require.True(t, pub.WaitTimeout(5*time.Second))
+	require.NoError(t, pub.Error())
+
+	var sensor gen.Sensor
+	require.Eventually(t, func() bool {
+		var currentStatus int
+		sensor, currentStatus = client.GetSensorByName(sensorName)
+		if currentStatus != http.StatusOK || sensor.Metadata == nil {
+			return false
+		}
+		metadata := *sensor.Metadata
+		return metadata["manufacturer"] == "Aqara" &&
+			metadata["model"] == "MCCGQ11LM" &&
+			metadata["description"] == "Door and window sensor" &&
+			metadata["ieee_address"] == "0x00158d00018255df"
+	}, 5*time.Second, 100*time.Millisecond)
+
+	exposesJSON, err := json.Marshal((*sensor.Metadata)["exposes"])
+	require.NoError(t, err)
+	assert.JSONEq(t, `[{"type":"binary","property":"contact","name":"contact","access":1}]`, string(exposesJSON))
+}
+
+func reserveTCPPort(t *testing.T) int {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer listener.Close()
+
+	return listener.Addr().(*net.TCPAddr).Port
+}

--- a/sensor_hub/mqtt/connection_manager.go
+++ b/sensor_hub/mqtt/connection_manager.go
@@ -13,6 +13,7 @@ package mqtt
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -40,6 +41,17 @@ type BrokerConnection struct {
 	Client pahomqtt.Client
 }
 
+type bridgeCacheKey struct {
+	brokerID int
+	key      string
+}
+
+type bridgeDevicesCache struct {
+	mu             sync.RWMutex
+	ieeeToFriendly map[bridgeCacheKey]string
+	deviceMetadata map[bridgeCacheKey]drivers.DeviceMetadata
+}
+
 // ConnectionManager manages MQTT client connections for all configured brokers.
 type ConnectionManager struct {
 	sensorService service.SensorServiceInterface
@@ -53,6 +65,8 @@ type ConnectionManager struct {
 	instruments *mqttInstruments
 	tracer      trace.Tracer
 	stats       *StatsTracker
+
+	bridgeDevices *bridgeDevicesCache
 }
 
 // NewConnectionManager creates a new connection manager.
@@ -71,6 +85,10 @@ func NewConnectionManager(
 		instruments:   newMQTTInstruments(),
 		tracer:        telemetry.Tracer("mqtt"),
 		stats:         NewStatsTracker(),
+		bridgeDevices: &bridgeDevicesCache{
+			ieeeToFriendly: make(map[bridgeCacheKey]string),
+			deviceMetadata: make(map[bridgeCacheKey]drivers.DeviceMetadata),
+		},
 	}
 }
 
@@ -235,7 +253,7 @@ func (cm *ConnectionManager) subscribeTopic(client pahomqtt.Client, brokerID int
 	}
 
 	token := client.Subscribe(sub.TopicPattern, 0, handler)
-	if token.WaitTimeout(5 * time.Second) && token.Error() != nil {
+	if token.WaitTimeout(5*time.Second) && token.Error() != nil {
 		cm.logger.Error("failed to subscribe", "topic", sub.TopicPattern, "error", token.Error())
 		return
 	}
@@ -278,6 +296,14 @@ func (cm *ConnectionManager) handleMessage(ctx context.Context, brokerID int, dr
 		cm.instruments.messageErrors.Add(ctx, 1, metric.WithAttributeSet(attrs))
 		cm.stats.RecordParseError(brokerID)
 		return
+	}
+
+	if systemHandler, ok := pushDriver.(drivers.SystemMessageHandler); ok {
+		if metadata := systemHandler.ParseSystemMessage(topic, payload); metadata != nil {
+			cm.updateBridgeDevicesCache(brokerID, metadata)
+			cm.backfillSensorMetadata(ctx, brokerID, driverType, metadata)
+			return
+		}
 	}
 
 	// Identify the device from the message
@@ -332,6 +358,65 @@ func (cm *ConnectionManager) handleMessage(ctx context.Context, brokerID int, dr
 	cm.instruments.processingTime.Record(ctx, elapsed, metric.WithAttributeSet(attrs))
 
 	cm.logger.Debug("processed MQTT message", "sensor", deviceName, "readings", len(readings))
+}
+
+func (cm *ConnectionManager) updateBridgeDevicesCache(brokerID int, devices []drivers.DeviceMetadata) {
+	cm.bridgeDevices.mu.Lock()
+	defer cm.bridgeDevices.mu.Unlock()
+
+	for _, device := range devices {
+		if device.IEEEAddress != "" {
+			cm.bridgeDevices.ieeeToFriendly[bridgeCacheKey{brokerID: brokerID, key: device.IEEEAddress}] = device.FriendlyName
+		}
+		cm.bridgeDevices.deviceMetadata[bridgeCacheKey{brokerID: brokerID, key: device.FriendlyName}] = device
+	}
+}
+
+func (cm *ConnectionManager) backfillSensorMetadata(ctx context.Context, brokerID int, driverType string, devices []drivers.DeviceMetadata) {
+	sensors, err := cm.sensorService.ServiceGetSensorsByDriver(ctx, driverType)
+	if err != nil {
+		cm.logger.Error("failed to load sensors for metadata backfill", "driver", driverType, "broker_id", brokerID, "error", err)
+		return
+	}
+
+	devicesByName := make(map[string]drivers.DeviceMetadata, len(devices))
+	for _, device := range devices {
+		devicesByName[device.FriendlyName] = device
+	}
+
+	for _, sensor := range sensors {
+		device, ok := devicesByName[sensor.Name]
+		if !ok && sensor.ExternalId != nil {
+			device, ok = devicesByName[*sensor.ExternalId]
+		}
+		if !ok {
+			continue
+		}
+
+		sensor.Metadata = mergedSensorMetadata(sensor.Metadata, device)
+		if err := cm.sensorService.ServiceUpdateSensorById(ctx, sensor, false); err != nil {
+			cm.logger.Error("failed to backfill sensor metadata", "sensor_id", sensor.Id, "sensor", sensor.Name, "broker_id", brokerID, "error", err)
+		}
+	}
+}
+
+func mergedSensorMetadata(existing *map[string]interface{}, device drivers.DeviceMetadata) *map[string]interface{} {
+	metadata := make(map[string]interface{})
+	if existing != nil {
+		for key, value := range *existing {
+			metadata[key] = value
+		}
+	}
+	for key, value := range device.Metadata {
+		metadata[key] = value
+	}
+	if device.IEEEAddress != "" {
+		metadata["ieee_address"] = device.IEEEAddress
+	}
+	if len(device.Exposes) > 0 {
+		metadata["exposes"] = json.RawMessage(device.Exposes)
+	}
+	return &metadata
 }
 
 // autoDiscoverSensor creates a new sensor in pending status for user approval.

--- a/sensor_hub/mqtt/connection_manager_test.go
+++ b/sensor_hub/mqtt/connection_manager_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"testing"
 
 	"example/sensorHub/drivers"
@@ -53,7 +54,7 @@ func (m *MockSensorService) ServiceGetAllSensors(ctx context.Context) ([]gen.Sen
 	return args.Get(0).([]gen.Sensor), args.Error(1)
 }
 func (m *MockSensorService) ServiceGetSensorsByDriver(ctx context.Context, sensorDriver string) ([]gen.Sensor, error) {
-	args := m.Called(ctx)
+	args := m.Called(ctx, sensorDriver)
 	return args.Get(0).([]gen.Sensor), args.Error(1)
 }
 func (m *MockSensorService) ServiceGetSensorIdByName(ctx context.Context, name string) (int, error) {
@@ -210,10 +211,10 @@ func (m *MockBrokerRepo) Delete(ctx context.Context, id int) error {
 
 type stubPushDriver struct{}
 
-func (s *stubPushDriver) Type() string                                                  { return "test-push-driver" }
-func (s *stubPushDriver) DisplayName() string                                           { return "Test Push" }
-func (s *stubPushDriver) Description() string                                           { return "test" }
-func (s *stubPushDriver) ConfigFields() []drivers.ConfigFieldSpec                       { return nil }
+func (s *stubPushDriver) Type() string                                                { return "test-push-driver" }
+func (s *stubPushDriver) DisplayName() string                                         { return "Test Push" }
+func (s *stubPushDriver) Description() string                                         { return "test" }
+func (s *stubPushDriver) ConfigFields() []drivers.ConfigFieldSpec                     { return nil }
 func (s *stubPushDriver) SupportedMeasurementTypes() []gen.MeasurementType            { return nil }
 func (s *stubPushDriver) ValidateSensor(ctx context.Context, sensor gen.Sensor) error { return nil }
 
@@ -226,6 +227,31 @@ func (s *stubPushDriver) ParseMessage(topic string, payload []byte) ([]gen.Readi
 
 func (s *stubPushDriver) IdentifyDevice(topic string, payload []byte) (string, error) {
 	return "mqtt-device-1", nil
+}
+
+func (s *stubPushDriver) ParseSystemMessage(topic string, payload []byte) []drivers.DeviceMetadata {
+	if topic != "zigbee2mqtt/bridge/devices" {
+		return nil
+	}
+	model := "MCCGQ11LM"
+	if strings.Contains(string(payload), "broker-1") {
+		model = "broker-1"
+	}
+	if strings.Contains(string(payload), "broker-2") {
+		model = "broker-2"
+	}
+	return []drivers.DeviceMetadata{
+		{
+			FriendlyName: "front-door",
+			IEEEAddress:  "0x00158d00018255df",
+			Metadata: map[string]string{
+				"manufacturer": "Aqara",
+				"model":        model,
+				"description":  "Door and window sensor",
+			},
+			Exposes: []byte(`[{"type":"binary","property":"contact","name":"contact","access":1}]`),
+		},
+	}
 }
 
 func init() {
@@ -315,6 +341,73 @@ func TestConnectionManager_HandleMessage_DisabledSensor(t *testing.T) {
 
 	// Should NOT process readings for disabled sensors
 	mockSensor.AssertNotCalled(t, "ServiceProcessPushReadings")
+}
+
+func TestConnectionManager_HandleMessage_SystemMessageBackfillsExistingSensors(t *testing.T) {
+	mockSensor := &MockSensorService{}
+	mockSub := &MockSubRepo{}
+	mockBroker := &MockBrokerRepo{}
+
+	cm := NewConnectionManager(mockSensor, mockSub, mockBroker, slog.Default())
+
+	existing := gen.Sensor{
+		Id:           42,
+		Name:         "front-door",
+		SensorDriver: "test-push-driver",
+		Status:       gen.SensorStatusDismissed,
+		Enabled:      false,
+		Config:       map[string]string{},
+	}
+
+	mockSensor.On("ServiceGetSensorsByDriver", mock.Anything, "test-push-driver").Return([]gen.Sensor{existing}, nil)
+	mockSensor.On("ServiceUpdateSensorById", mock.Anything, mock.MatchedBy(func(sensor gen.Sensor) bool {
+		if sensor.Id != existing.Id || sensor.Name != existing.Name {
+			return false
+		}
+		if sensor.Metadata == nil {
+			return false
+		}
+		metadata := *sensor.Metadata
+		return metadata["manufacturer"] == "Aqara" &&
+			metadata["model"] == "MCCGQ11LM" &&
+			metadata["description"] == "Door and window sensor" &&
+			metadata["ieee_address"] == "0x00158d00018255df"
+	}), false).Return(nil)
+
+	cm.handleMessage(context.Background(), 7, "test-push-driver", "zigbee2mqtt/bridge/devices", []byte(`[]`))
+
+	mockSensor.AssertExpectations(t)
+	mockSensor.AssertNotCalled(t, "ServiceGetSensorByExternalId")
+	mockSensor.AssertNotCalled(t, "ServiceProcessPushReadings")
+
+	cachedFriendly, ok := cm.bridgeDevices.ieeeToFriendly[bridgeCacheKey{brokerID: 7, key: "0x00158d00018255df"}]
+	assert.True(t, ok)
+	assert.Equal(t, "front-door", cachedFriendly)
+
+	cachedMetadata, ok := cm.bridgeDevices.deviceMetadata[bridgeCacheKey{brokerID: 7, key: "front-door"}]
+	assert.True(t, ok)
+	assert.Equal(t, "Aqara", cachedMetadata.Metadata["manufacturer"])
+}
+
+func TestConnectionManager_HandleMessage_SystemMessageCacheIsBrokerScoped(t *testing.T) {
+	mockSensor := &MockSensorService{}
+	mockSub := &MockSubRepo{}
+	mockBroker := &MockBrokerRepo{}
+
+	cm := NewConnectionManager(mockSensor, mockSub, mockBroker, slog.Default())
+
+	mockSensor.On("ServiceGetSensorsByDriver", mock.Anything, "test-push-driver").Return([]gen.Sensor{}, nil).Twice()
+
+	cm.handleMessage(context.Background(), 1, "test-push-driver", "zigbee2mqtt/bridge/devices", []byte(`broker-1`))
+	cm.handleMessage(context.Background(), 2, "test-push-driver", "zigbee2mqtt/bridge/devices", []byte(`broker-2`))
+
+	cachedOne, ok := cm.bridgeDevices.deviceMetadata[bridgeCacheKey{brokerID: 1, key: "front-door"}]
+	assert.True(t, ok)
+	assert.Equal(t, "broker-1", cachedOne.Metadata["model"])
+
+	cachedTwo, ok := cm.bridgeDevices.deviceMetadata[bridgeCacheKey{brokerID: 2, key: "front-door"}]
+	assert.True(t, ok)
+	assert.Equal(t, "broker-2", cachedTwo.Metadata["model"])
 }
 
 func TestConnectionManager_IsConnected_NoConnection(t *testing.T) {

--- a/sensor_hub/ui/sensor_hub_ui/src/gen/schema.d.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/gen/schema.d.ts
@@ -1741,6 +1741,7 @@ export interface components {
          *       "config": {
          *         "url": "http://sensor.local/28-0000065f2ff3"
          *       },
+         *       "metadata": {},
          *       "health_status": "good",
          *       "health_reason": "ok",
          *       "enabled": true,
@@ -1761,6 +1762,10 @@ export interface components {
             /** @description Driver-specific configuration key-value pairs. Each driver declares which keys it expects via the GET /drivers endpoint. Sensitive values are masked as "****" in GET responses. */
             config: {
                 [key: string]: string;
+            };
+            /** @description System-populated device metadata. Contents are driver-specific and ignored on create/update requests. */
+            readonly metadata?: {
+                [key: string]: unknown;
             };
             /** @description Health status ("good", "bad", or "unknown"). */
             health_status: components["schemas"]["SensorHealthStatus"];


### PR DESCRIPTION
## Summary
- add `Sensor.metadata` persistence, migration `000017_device_metadata`, and read-only API/schema exposure
- parse Zigbee2MQTT `bridge/devices` system messages and back-fill matching sensors with manufacturer/model/description/IEEE/exposes metadata
- add broker-scoped connection-manager cache plus unit and integration coverage for the metadata ingest flow

## Testing
- `cd sensor_hub && go test ./...`
- `cd sensor_hub/ui/sensor_hub_ui && npm run build`
- `cd sensor_hub && go test -tags integration -v -timeout 300s ./integration/`

Closes #79
Relates to #13