### PR TITLE
Handle IEEE Zigbee sensor resolution

### DIFF
--- a/sensor_hub/db/sensor_repository.go
+++ b/sensor_hub/db/sensor_repository.go
@@ -234,13 +234,17 @@ func (s *SensorRepository) AddSensor(ctx context.Context, sensor gen.Sensor) err
 	if err != nil {
 		return fmt.Errorf("error marshalling sensor config: %w", err)
 	}
+	metadataJSON, err := json.Marshal(sensorMetadataValue(sensor.Metadata))
+	if err != nil {
+		return fmt.Errorf("error marshalling sensor metadata: %w", err)
+	}
 
-	query := "INSERT INTO sensors (name, external_id, sensor_driver, config, health_reason, enabled, status) VALUES (?, ?, ?, ?, 'unknown', ?, ?)"
+	query := "INSERT INTO sensors (name, external_id, sensor_driver, config, metadata, health_reason, enabled, status) VALUES (?, ?, ?, ?, ?, 'unknown', ?, ?)"
 	status := sensor.Status
 	if status == "" {
 		status = gen.SensorStatusActive
 	}
-	_, err = s.db.ExecContext(ctx, query, sensor.Name, sensor.ExternalId, sensor.SensorDriver, string(configJSON), true, status)
+	_, err = s.db.ExecContext(ctx, query, sensor.Name, sensor.ExternalId, sensor.SensorDriver, string(configJSON), string(metadataJSON), true, status)
 	if err != nil {
 		return fmt.Errorf("error adding new sensor: %w", err)
 	}

--- a/sensor_hub/db/sensor_repository_test.go
+++ b/sensor_hub/db/sensor_repository_test.go
@@ -324,7 +324,7 @@ func TestSensorRepository_AddSensor_Success(t *testing.T) {
 	}
 
 	mock.ExpectExec("INSERT INTO sensors").
-		WithArgs("new-sensor", nil, "sensor-hub-http-temperature", `{"url":"http://localhost:8080"}`, true, gen.SensorStatusActive).
+		WithArgs("new-sensor", nil, "sensor-hub-http-temperature", `{"url":"http://localhost:8080"}`, `{}`, true, gen.SensorStatusActive).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	err := repo.AddSensor(context.Background(), sensor)
@@ -333,7 +333,7 @@ func TestSensorRepository_AddSensor_Success(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestSensorRepository_AddSensor_IgnoresMetadata(t *testing.T) {
+func TestSensorRepository_AddSensor_StoresMetadata(t *testing.T) {
 	db, mock := newMockDB(t)
 	repo := NewSensorRepository(db, slog.Default())
 
@@ -346,7 +346,7 @@ func TestSensorRepository_AddSensor_IgnoresMetadata(t *testing.T) {
 	}
 
 	mock.ExpectExec("INSERT INTO sensors").
-		WithArgs("new-sensor", nil, "sensor-hub-http-temperature", `{"url":"http://localhost:8080"}`, true, gen.SensorStatusActive).
+		WithArgs("new-sensor", nil, "sensor-hub-http-temperature", `{"url":"http://localhost:8080"}`, `{"manufacturer":"Aqara"}`, true, gen.SensorStatusActive).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	err := repo.AddSensor(context.Background(), sensor)
@@ -398,7 +398,7 @@ func TestSensorRepository_AddSensor_DBError(t *testing.T) {
 	}
 
 	mock.ExpectExec("INSERT INTO sensors").
-		WithArgs("new-sensor", nil, "sensor-hub-http-temperature", `{"url":"http://localhost:8080"}`, true, gen.SensorStatusActive).
+		WithArgs("new-sensor", nil, "sensor-hub-http-temperature", `{"url":"http://localhost:8080"}`, `{}`, true, gen.SensorStatusActive).
 		WillReturnError(errors.New("duplicate entry"))
 
 	err := repo.AddSensor(context.Background(), sensor)

--- a/sensor_hub/integration/mqtt_metadata_test.go
+++ b/sensor_hub/integration/mqtt_metadata_test.go
@@ -130,6 +130,231 @@ func TestZigbee2MQTTBridgeDevices_BackfillsSensorMetadata(t *testing.T) {
 	assert.JSONEq(t, `[{"type":"binary","property":"contact","name":"contact","access":1}]`, string(exposesJSON))
 }
 
+func TestZigbee2MQTTBridgeDevices_RenamesPhantomIEEESensorInPlace(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.Default()
+	port := reserveTCPPort(t)
+	friendlyName := fmt.Sprintf("front-door-renamed-%d", port)
+	ieeeName := "0x00158d00018255df"
+
+	embeddedBroker := mqttpkg.NewEmbeddedBroker(mqttpkg.BrokerConfig{
+		TCPAddress: fmt.Sprintf(":%d", port),
+	}, logger)
+	require.NoError(t, embeddedBroker.Start())
+	defer func() {
+		require.NoError(t, embeddedBroker.Stop())
+	}()
+
+	sensorRepo := database.NewSensorRepository(env.DB, logger)
+	readingsRepo := database.NewReadingsRepository(env.DB, logger)
+	mtRepo := database.NewMeasurementTypeRepository(env.DB, logger)
+	alertRepo := database.NewAlertRepository(env.DB, logger)
+	brokerRepo := database.NewMQTTBrokerRepository(env.DB, logger)
+	subRepo := database.NewMQTTSubscriptionRepository(env.DB, logger)
+
+	sensorService := service.NewSensorService(sensorRepo, readingsRepo, mtRepo, alertRepo, nil, logger)
+	connManager := mqttpkg.NewConnectionManager(sensorService, subRepo, brokerRepo, logger)
+
+	brokerID, err := brokerRepo.Add(ctx, gen.MQTTBroker{
+		Name:    fmt.Sprintf("integration-z2m-rename-%d", port),
+		Host:    "127.0.0.1",
+		Port:    port,
+		Type:    "external",
+		Enabled: true,
+	})
+	require.NoError(t, err)
+
+	subID, err := subRepo.Add(ctx, gen.MQTTSubscription{
+		BrokerId:     brokerID,
+		TopicPattern: "zigbee2mqtt/#",
+		DriverType:   "mqtt-zigbee2mqtt",
+		Enabled:      true,
+	})
+	require.NoError(t, err)
+
+	defer func() {
+		connManager.Stop()
+		_ = subRepo.Delete(ctx, subID)
+		_ = brokerRepo.Delete(ctx, brokerID)
+		_ = client.DeleteSensor(friendlyName)
+		_ = client.DeleteSensor(ieeeName)
+	}()
+
+	require.NoError(t, connManager.Start(ctx))
+	require.Eventually(t, func() bool {
+		return connManager.IsConnected(brokerID)
+	}, 5*time.Second, 100*time.Millisecond)
+
+	require.NoError(t, sensorRepo.AddSensor(ctx, gen.Sensor{
+		Name:         ieeeName,
+		ExternalId:   &ieeeName,
+		SensorDriver: "mqtt-zigbee2mqtt",
+		Config:       map[string]string{},
+		Status:       gen.SensorStatusPending,
+	}))
+
+	phantom, err := sensorRepo.GetSensorByName(ctx, ieeeName)
+	require.NoError(t, err)
+
+	mqttClient := pahomqtt.NewClient(
+		pahomqtt.NewClientOptions().
+			AddBroker(fmt.Sprintf("tcp://127.0.0.1:%d", port)).
+			SetClientID(fmt.Sprintf("integration-z2m-rename-publisher-%d", port)),
+	)
+	token := mqttClient.Connect()
+	require.True(t, token.WaitTimeout(5*time.Second))
+	require.NoError(t, token.Error())
+	defer mqttClient.Disconnect(250)
+
+	payload := fmt.Sprintf(`[
+		{
+			"ieee_address": %q,
+			"friendly_name": %q,
+			"definition": {
+				"model": "MCCGQ11LM",
+				"vendor": "Aqara",
+				"description": "Door and window sensor",
+				"exposes": [
+					{"type": "binary", "property": "contact", "name": "contact", "access": 1}
+				]
+			}
+		}
+	]`, ieeeName, friendlyName)
+
+	pub := mqttClient.Publish("zigbee2mqtt/bridge/devices", 0, false, payload)
+	require.True(t, pub.WaitTimeout(5*time.Second))
+	require.NoError(t, pub.Error())
+
+	pub = mqttClient.Publish(fmt.Sprintf("zigbee2mqtt/%s", ieeeName), 0, false, `{"contact":false,"battery":95}`)
+	require.True(t, pub.WaitTimeout(5*time.Second))
+	require.NoError(t, pub.Error())
+
+	var renamed gen.Sensor
+	require.Eventually(t, func() bool {
+		var currentStatus int
+		renamed, currentStatus = client.GetSensorByName(friendlyName)
+		if currentStatus != http.StatusOK || renamed.Metadata == nil {
+			return false
+		}
+		metadata := *renamed.Metadata
+		return renamed.Id == phantom.Id &&
+			renamed.ExternalId != nil &&
+			*renamed.ExternalId == ieeeName &&
+			renamed.Status == gen.SensorStatusPending &&
+			metadata["manufacturer"] == "Aqara" &&
+			metadata["model"] == "MCCGQ11LM" &&
+			metadata["description"] == "Door and window sensor" &&
+			metadata["ieee_address"] == ieeeName
+	}, 5*time.Second, 100*time.Millisecond)
+
+	_, err = sensorRepo.GetSensorByName(ctx, ieeeName)
+	assert.Error(t, err)
+}
+
+func TestZigbee2MQTTBridgeDevices_AutoDiscoversFriendlySensorFromIEEEWithMetadata(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.Default()
+	port := reserveTCPPort(t)
+	friendlyName := fmt.Sprintf("front-door-new-%d", port)
+	ieeeName := "0x00158d00018255aa"
+
+	embeddedBroker := mqttpkg.NewEmbeddedBroker(mqttpkg.BrokerConfig{
+		TCPAddress: fmt.Sprintf(":%d", port),
+	}, logger)
+	require.NoError(t, embeddedBroker.Start())
+	defer func() {
+		require.NoError(t, embeddedBroker.Stop())
+	}()
+
+	sensorRepo := database.NewSensorRepository(env.DB, logger)
+	readingsRepo := database.NewReadingsRepository(env.DB, logger)
+	mtRepo := database.NewMeasurementTypeRepository(env.DB, logger)
+	alertRepo := database.NewAlertRepository(env.DB, logger)
+	brokerRepo := database.NewMQTTBrokerRepository(env.DB, logger)
+	subRepo := database.NewMQTTSubscriptionRepository(env.DB, logger)
+
+	sensorService := service.NewSensorService(sensorRepo, readingsRepo, mtRepo, alertRepo, nil, logger)
+	connManager := mqttpkg.NewConnectionManager(sensorService, subRepo, brokerRepo, logger)
+
+	brokerID, err := brokerRepo.Add(ctx, gen.MQTTBroker{
+		Name:    fmt.Sprintf("integration-z2m-autodiscover-%d", port),
+		Host:    "127.0.0.1",
+		Port:    port,
+		Type:    "external",
+		Enabled: true,
+	})
+	require.NoError(t, err)
+
+	subID, err := subRepo.Add(ctx, gen.MQTTSubscription{
+		BrokerId:     brokerID,
+		TopicPattern: "zigbee2mqtt/#",
+		DriverType:   "mqtt-zigbee2mqtt",
+		Enabled:      true,
+	})
+	require.NoError(t, err)
+
+	defer func() {
+		connManager.Stop()
+		_ = subRepo.Delete(ctx, subID)
+		_ = brokerRepo.Delete(ctx, brokerID)
+		_ = client.DeleteSensor(friendlyName)
+		_ = client.DeleteSensor(ieeeName)
+	}()
+
+	require.NoError(t, connManager.Start(ctx))
+	require.Eventually(t, func() bool {
+		return connManager.IsConnected(brokerID)
+	}, 5*time.Second, 100*time.Millisecond)
+
+	mqttClient := pahomqtt.NewClient(
+		pahomqtt.NewClientOptions().
+			AddBroker(fmt.Sprintf("tcp://127.0.0.1:%d", port)).
+			SetClientID(fmt.Sprintf("integration-z2m-autodiscover-publisher-%d", port)),
+	)
+	token := mqttClient.Connect()
+	require.True(t, token.WaitTimeout(5*time.Second))
+	require.NoError(t, token.Error())
+	defer mqttClient.Disconnect(250)
+
+	payload := fmt.Sprintf(`[
+		{
+			"ieee_address": %q,
+			"friendly_name": %q,
+			"definition": {
+				"model": "MCCGQ11LM",
+				"vendor": "Aqara",
+				"description": "Door and window sensor",
+				"exposes": [
+					{"type": "binary", "property": "contact", "name": "contact", "access": 1}
+				]
+			}
+		}
+	]`, ieeeName, friendlyName)
+
+	pub := mqttClient.Publish("zigbee2mqtt/bridge/devices", 0, false, payload)
+	require.True(t, pub.WaitTimeout(5*time.Second))
+	require.NoError(t, pub.Error())
+
+	pub = mqttClient.Publish(fmt.Sprintf("zigbee2mqtt/%s", ieeeName), 0, false, `{"contact":true,"battery":100}`)
+	require.True(t, pub.WaitTimeout(5*time.Second))
+	require.NoError(t, pub.Error())
+
+	var sensor gen.Sensor
+	require.Eventually(t, func() bool {
+		var currentStatus int
+		sensor, currentStatus = client.GetSensorByName(friendlyName)
+		if currentStatus != http.StatusOK || sensor.Metadata == nil {
+			return false
+		}
+		metadata := *sensor.Metadata
+		return sensor.Status == gen.SensorStatusPending &&
+			metadata["manufacturer"] == "Aqara" &&
+			metadata["model"] == "MCCGQ11LM" &&
+			metadata["description"] == "Door and window sensor" &&
+			metadata["ieee_address"] == ieeeName
+	}, 5*time.Second, 100*time.Millisecond)
+}
+
 func reserveTCPPort(t *testing.T) int {
 	t.Helper()
 

--- a/sensor_hub/mqtt/connection_manager.go
+++ b/sensor_hub/mqtt/connection_manager.go
@@ -16,6 +16,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -313,12 +314,26 @@ func (cm *ConnectionManager) handleMessage(ctx context.Context, brokerID int, dr
 		return
 	}
 
+	originalDeviceName := deviceName
+	deviceName = cm.resolveDeviceName(brokerID, deviceName)
+
 	span.SetAttributes(attribute.String("sensor", deviceName))
 
-	// Look up the sensor by external_id (stable MQTT identity), fall back to name
-	sensor, err := cm.sensorService.ServiceGetSensorByExternalId(ctx, deviceName)
-	if err != nil {
-		sensor, err = cm.sensorService.ServiceGetSensorByName(ctx, deviceName)
+	sensor, err := cm.lookupSensorByIdentity(ctx, deviceName)
+	if deviceName != originalDeviceName {
+		if err == nil {
+			originalSensor, originalErr := cm.lookupSensorByIdentity(ctx, originalDeviceName)
+			if originalErr == nil {
+				cm.logger.Warn("IEEE resolution collision, keeping original sensor",
+					"broker_id", brokerID,
+					"ieee_name", originalDeviceName,
+					"friendly_name", deviceName)
+				sensor = originalSensor
+				deviceName = originalDeviceName
+			}
+		} else {
+			sensor, err = cm.renameResolvedIEEESensor(ctx, brokerID, deviceName, originalDeviceName)
+		}
 	}
 	if err != nil {
 		// Sensor not found → auto-discovery: create as pending
@@ -358,6 +373,72 @@ func (cm *ConnectionManager) handleMessage(ctx context.Context, brokerID int, dr
 	cm.instruments.processingTime.Record(ctx, elapsed, metric.WithAttributeSet(attrs))
 
 	cm.logger.Debug("processed MQTT message", "sensor", deviceName, "readings", len(readings))
+}
+
+func (cm *ConnectionManager) resolveDeviceName(brokerID int, deviceName string) string {
+	if !isIEEEAddress(deviceName) {
+		return deviceName
+	}
+
+	cm.bridgeDevices.mu.RLock()
+	defer cm.bridgeDevices.mu.RUnlock()
+
+	friendlyName, ok := cm.bridgeDevices.ieeeToFriendly[bridgeCacheKey{brokerID: brokerID, key: deviceName}]
+	if !ok || friendlyName == "" {
+		return deviceName
+	}
+
+	return friendlyName
+}
+
+func (cm *ConnectionManager) lookupSensorByIdentity(ctx context.Context, deviceName string) (*gen.Sensor, error) {
+	sensor, err := cm.sensorService.ServiceGetSensorByExternalId(ctx, deviceName)
+	if err != nil {
+		sensor, err = cm.sensorService.ServiceGetSensorByName(ctx, deviceName)
+	}
+	return sensor, err
+}
+
+func (cm *ConnectionManager) renameResolvedIEEESensor(ctx context.Context, brokerID int, resolvedName string, ieeeName string) (*gen.Sensor, error) {
+	sensor, err := cm.lookupSensorByIdentity(ctx, ieeeName)
+	if err != nil {
+		return nil, err
+	}
+
+	renamed := *sensor
+	renamed.Name = resolvedName
+
+	if device, ok := cm.cachedDeviceMetadata(brokerID, resolvedName); ok {
+		renamed.Metadata = mergedSensorMetadata(renamed.Metadata, device)
+	}
+
+	if err := cm.sensorService.ServiceUpdateSensorById(ctx, renamed, false); err != nil {
+		return nil, err
+	}
+
+	return &renamed, nil
+}
+
+func (cm *ConnectionManager) cachedDeviceMetadata(brokerID int, deviceName string) (drivers.DeviceMetadata, bool) {
+	cm.bridgeDevices.mu.RLock()
+	defer cm.bridgeDevices.mu.RUnlock()
+
+	device, ok := cm.bridgeDevices.deviceMetadata[bridgeCacheKey{brokerID: brokerID, key: deviceName}]
+	return device, ok
+}
+
+func isIEEEAddress(name string) bool {
+	if len(name) != 18 || !strings.HasPrefix(name, "0x") {
+		return false
+	}
+
+	for _, char := range name[2:] {
+		if (char < '0' || char > '9') && (char < 'a' || char > 'f') && (char < 'A' || char > 'F') {
+			return false
+		}
+	}
+
+	return true
 }
 
 func (cm *ConnectionManager) updateBridgeDevicesCache(brokerID int, devices []drivers.DeviceMetadata) {
@@ -439,6 +520,9 @@ func (cm *ConnectionManager) autoDiscoverSensor(ctx context.Context, brokerID in
 		Config:       map[string]string{},
 		Enabled:      false,
 		Status:       gen.SensorStatusPending,
+	}
+	if device, ok := cm.cachedDeviceMetadata(brokerID, deviceName); ok {
+		sensor.Metadata = mergedSensorMetadata(sensor.Metadata, device)
 	}
 
 	if err := cm.sensorService.ServiceAddSensor(ctx, sensor); err != nil {

--- a/sensor_hub/mqtt/connection_manager_test.go
+++ b/sensor_hub/mqtt/connection_manager_test.go
@@ -1,6 +1,7 @@
 package mqtt
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"log/slog"
@@ -226,6 +227,9 @@ func (s *stubPushDriver) ParseMessage(topic string, payload []byte) ([]gen.Readi
 }
 
 func (s *stubPushDriver) IdentifyDevice(topic string, payload []byte) (string, error) {
+	if strings.HasPrefix(topic, "zigbee2mqtt/") && topic != "zigbee2mqtt/bridge/devices" {
+		return strings.TrimPrefix(topic, "zigbee2mqtt/"), nil
+	}
 	return "mqtt-device-1", nil
 }
 
@@ -408,6 +412,145 @@ func TestConnectionManager_HandleMessage_SystemMessageCacheIsBrokerScoped(t *tes
 	cachedTwo, ok := cm.bridgeDevices.deviceMetadata[bridgeCacheKey{brokerID: 2, key: "front-door"}]
 	assert.True(t, ok)
 	assert.Equal(t, "broker-2", cachedTwo.Metadata["model"])
+}
+
+func TestConnectionManager_HandleMessage_IEEECacheHitRoutesToFriendlySensor(t *testing.T) {
+	mockSensor := &MockSensorService{}
+	mockSub := &MockSubRepo{}
+	mockBroker := &MockBrokerRepo{}
+
+	cm := NewConnectionManager(mockSensor, mockSub, mockBroker, slog.Default())
+
+	mockSensor.On("ServiceGetSensorsByDriver", mock.Anything, "test-push-driver").Return([]gen.Sensor{}, nil).Once()
+
+	friendly := &gen.Sensor{
+		Id:           11,
+		Name:         "front-door",
+		SensorDriver: "test-push-driver",
+		Status:       gen.SensorStatusActive,
+		Enabled:      true,
+	}
+	mockSensor.On("ServiceGetSensorByExternalId", mock.Anything, "front-door").Return(friendly, nil)
+	mockSensor.On("ServiceGetSensorByExternalId", mock.Anything, "0x00158d00018255df").Return(nil, fmt.Errorf("not found"))
+	mockSensor.On("ServiceGetSensorByName", mock.Anything, "0x00158d00018255df").Return(nil, fmt.Errorf("not found"))
+	mockSensor.On("ServiceProcessPushReadings", mock.Anything, *friendly, mock.AnythingOfType("[]gen.Reading")).Return(nil)
+
+	cm.handleMessage(context.Background(), 1, "test-push-driver", "zigbee2mqtt/bridge/devices", []byte(`[]`))
+	cm.handleMessage(context.Background(), 1, "test-push-driver", "zigbee2mqtt/0x00158d00018255df", []byte(`{}`))
+
+	mockSensor.AssertExpectations(t)
+}
+
+func TestConnectionManager_HandleMessage_IEEECacheMissFallsThroughUnchanged(t *testing.T) {
+	mockSensor := &MockSensorService{}
+	mockSub := &MockSubRepo{}
+	mockBroker := &MockBrokerRepo{}
+
+	cm := NewConnectionManager(mockSensor, mockSub, mockBroker, slog.Default())
+
+	ieeeName := "0x00158d00018255df"
+	mockSensor.On("ServiceGetSensorByExternalId", mock.Anything, ieeeName).Return(nil, fmt.Errorf("not found"))
+	mockSensor.On("ServiceGetSensorByName", mock.Anything, ieeeName).Return(nil, fmt.Errorf("not found"))
+	mockSensor.On("ServiceSensorExistsByExternalId", mock.Anything, ieeeName).Return(false, nil)
+	mockSensor.On("ServiceSensorExists", mock.Anything, ieeeName).Return(false, nil)
+	mockSensor.On("ServiceAddSensor", mock.Anything, mock.MatchedBy(func(sensor gen.Sensor) bool {
+		return sensor.Name == ieeeName &&
+			sensor.Status == gen.SensorStatusPending &&
+			sensor.ExternalId != nil &&
+			*sensor.ExternalId == ieeeName
+	})).Return(nil)
+
+	cm.handleMessage(context.Background(), 1, "test-push-driver", "zigbee2mqtt/0x00158d00018255df", []byte(`{}`))
+
+	mockSensor.AssertExpectations(t)
+}
+
+func TestConnectionManager_HandleMessage_RenamesPhantomIEEESensorInPlace(t *testing.T) {
+	mockSensor := &MockSensorService{}
+	mockSub := &MockSubRepo{}
+	mockBroker := &MockBrokerRepo{}
+
+	cm := NewConnectionManager(mockSensor, mockSub, mockBroker, slog.Default())
+
+	mockSensor.On("ServiceGetSensorsByDriver", mock.Anything, "test-push-driver").Return([]gen.Sensor{}, nil).Once()
+
+	ieeeName := "0x00158d00018255df"
+	phantom := &gen.Sensor{
+		Id:           77,
+		Name:         ieeeName,
+		ExternalId:   &ieeeName,
+		SensorDriver: "test-push-driver",
+		Status:       gen.SensorStatusPending,
+		Enabled:      false,
+		Config:       map[string]string{},
+	}
+
+	mockSensor.On("ServiceGetSensorByExternalId", mock.Anything, "front-door").Return(nil, fmt.Errorf("not found"))
+	mockSensor.On("ServiceGetSensorByName", mock.Anything, "front-door").Return(nil, fmt.Errorf("not found"))
+	mockSensor.On("ServiceGetSensorByExternalId", mock.Anything, ieeeName).Return(phantom, nil)
+	mockSensor.On("ServiceUpdateSensorById", mock.Anything, mock.MatchedBy(func(sensor gen.Sensor) bool {
+		if sensor.Id != phantom.Id || sensor.Name != "front-door" || sensor.ExternalId == nil || *sensor.ExternalId != ieeeName {
+			return false
+		}
+		if sensor.Metadata == nil {
+			return false
+		}
+		metadata := *sensor.Metadata
+		return metadata["manufacturer"] == "Aqara" &&
+			metadata["model"] == "MCCGQ11LM" &&
+			metadata["description"] == "Door and window sensor" &&
+			metadata["ieee_address"] == ieeeName
+	}), false).Return(nil)
+
+	cm.handleMessage(context.Background(), 1, "test-push-driver", "zigbee2mqtt/bridge/devices", []byte(`[]`))
+	cm.handleMessage(context.Background(), 1, "test-push-driver", "zigbee2mqtt/0x00158d00018255df", []byte(`{}`))
+
+	mockSensor.AssertExpectations(t)
+	mockSensor.AssertNotCalled(t, "ServiceAddSensor")
+	mockSensor.AssertNotCalled(t, "ServiceProcessPushReadings")
+}
+
+func TestConnectionManager_HandleMessage_IEEECollisionLogsAndKeepsOriginalSensor(t *testing.T) {
+	mockSensor := &MockSensorService{}
+	mockSub := &MockSubRepo{}
+	mockBroker := &MockBrokerRepo{}
+
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, nil))
+	cm := NewConnectionManager(mockSensor, mockSub, mockBroker, logger)
+
+	mockSensor.On("ServiceGetSensorsByDriver", mock.Anything, "test-push-driver").Return([]gen.Sensor{}, nil).Once()
+
+	ieeeName := "0x00158d00018255df"
+	friendly := &gen.Sensor{
+		Id:           11,
+		Name:         "front-door",
+		SensorDriver: "test-push-driver",
+		Status:       gen.SensorStatusActive,
+		Enabled:      true,
+		Config:       map[string]string{},
+	}
+	phantom := &gen.Sensor{
+		Id:           77,
+		Name:         ieeeName,
+		ExternalId:   &ieeeName,
+		SensorDriver: "test-push-driver",
+		Status:       gen.SensorStatusActive,
+		Enabled:      true,
+		Config:       map[string]string{},
+	}
+
+	mockSensor.On("ServiceGetSensorByExternalId", mock.Anything, "front-door").Return(friendly, nil)
+	mockSensor.On("ServiceGetSensorByExternalId", mock.Anything, ieeeName).Return(phantom, nil)
+	mockSensor.On("ServiceProcessPushReadings", mock.Anything, *phantom, mock.AnythingOfType("[]gen.Reading")).Return(nil)
+
+	cm.handleMessage(context.Background(), 1, "test-push-driver", "zigbee2mqtt/bridge/devices", []byte(`[]`))
+	cm.handleMessage(context.Background(), 1, "test-push-driver", "zigbee2mqtt/0x00158d00018255df", []byte(`{}`))
+
+	mockSensor.AssertExpectations(t)
+	mockSensor.AssertNotCalled(t, "ServiceUpdateSensorById")
+	assert.Contains(t, logs.String(), "collision")
+	assert.Contains(t, logs.String(), ieeeName)
 }
 
 func TestConnectionManager_IsConnected_NoConnection(t *testing.T) {


### PR DESCRIPTION
## Summary
- resolve IEEE Zigbee topics to friendly names when bridge cache data exists
- rename phantom IEEE sensor rows in place, preserve identity, and skip destructive collisions with a warning
- persist metadata on auto-discovered sensors and cover the flow with unit and integration tests

Closes #80
Related to #13