### PR TITLE
Add sensor capability discovery

### DIFF
--- a/sensor_hub/api/mocks_test.go
+++ b/sensor_hub/api/mocks_test.go
@@ -183,6 +183,14 @@ func (m *MockSensorService) ServiceGetSensorById(ctx context.Context, id int) (*
 	return args.Get(0).(*gen.Sensor), args.Error(1)
 }
 
+func (m *MockSensorService) ServiceGetSensorCapabilities(ctx context.Context, id int) ([]gen.Capability, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]gen.Capability), args.Error(1)
+}
+
 func (m *MockSensorService) ServiceGetAllSensors(ctx context.Context) ([]gen.Sensor, error) {
 	args := m.Called(ctx)
 	return args.Get(0).([]gen.Sensor), args.Error(1)

--- a/sensor_hub/api/openapi.yaml
+++ b/sensor_hub/api/openapi.yaml
@@ -464,6 +464,45 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /sensors/by-id/{id}/capabilities:
+    get:
+      tags:
+        - sensors
+      summary: Get sensor capabilities by id
+      description: >-
+        Returns the controllable capabilities derived from the sensor's driver
+        metadata. Sensors without writable features return an empty array.
+      operationId: getSensorCapabilities
+      x-required-permission: view_sensors
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+          description: Numeric database id of the sensor
+      responses:
+        '200':
+          description: Capabilities for the sensor
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Capability'
+        '404':
+          description: Sensor not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /sensors/{name}:
     get:
       tags:
@@ -3477,6 +3516,45 @@ components:
             unit: "°C"
             time: "2026-01-10T12:00:10Z"
 
+    Capability:
+      type: object
+      description: >-
+        A controllable property exposed by a driver. This is derived from
+        driver metadata and is never user-configurable.
+      properties:
+        property:
+          type: string
+          description: Driver-level property name used when sending commands.
+        type:
+          type: string
+          enum: [binary, numeric, enum]
+          description: Capability kind.
+        value_on:
+          type: string
+          description: Canonical "on" value for binary capabilities.
+        value_off:
+          type: string
+          description: Canonical "off" value for binary capabilities.
+        min:
+          type: number
+          format: double
+          description: Minimum allowed value for numeric capabilities.
+        max:
+          type: number
+          format: double
+          description: Maximum allowed value for numeric capabilities.
+        unit:
+          type: string
+          description: Optional engineering unit for numeric capabilities.
+        values:
+          type: array
+          description: Allowed values for enum capabilities.
+          items:
+            type: string
+      required:
+        - property
+        - type
+
     Sensor:
       type: object
       description: |
@@ -3513,6 +3591,15 @@ components:
           description: >-
             System-populated device metadata. Contents are driver-specific and
             ignored on create/update requests.
+        capabilities:
+          type: array
+          readOnly: true
+          description: >-
+            Controllable properties for this sensor. Empty if the sensor is not
+            controllable. Derived from driver metadata and ignored on
+            create/update requests.
+          items:
+            $ref: '#/components/schemas/Capability'
         health_status:
           $ref: '#/components/schemas/SensorHealthStatus'
           description: Health status ("good", "bad", or "unknown").
@@ -3562,6 +3649,7 @@ components:
         config:
           url: "http://sensor.local/28-0000065f2ff3"
         metadata: {}
+        capabilities: []
         health_status: "good"
         health_reason: "ok"
         enabled: true

--- a/sensor_hub/api/route_permissions.go
+++ b/sensor_hub/api/route_permissions.go
@@ -12,13 +12,13 @@ import (
 // or are fully public (no CookieAuthScopes set by the generated wrapper).
 var routePermissions = map[string]string{
 	// Alerts
-	"GET /api/alerts":                        "view_alerts",
-	"POST /api/alerts":                       "manage_alerts",
-	"GET /api/alerts/sensor/:sensorId":       "view_alerts",
+	"GET /api/alerts":                          "view_alerts",
+	"POST /api/alerts":                         "manage_alerts",
+	"GET /api/alerts/sensor/:sensorId":         "view_alerts",
 	"GET /api/alerts/sensor/:sensorId/history": "view_alerts",
-	"GET /api/alerts/:id":                    "view_alerts",
-	"PUT /api/alerts/:id":                    "manage_alerts",
-	"DELETE /api/alerts/:id":                 "manage_alerts",
+	"GET /api/alerts/:id":                      "view_alerts",
+	"PUT /api/alerts/:id":                      "manage_alerts",
+	"DELETE /api/alerts/:id":                   "manage_alerts",
 
 	// API Keys
 	"GET /api/api-keys":              "manage_api_keys",
@@ -28,41 +28,41 @@ var routePermissions = map[string]string{
 	"DELETE /api/api-keys/:id":       "manage_api_keys",
 
 	// Dashboards
-	"GET /api/dashboards":              "view_dashboards",
-	"POST /api/dashboards":             "manage_dashboards",
-	"GET /api/dashboards/:id":          "view_dashboards",
-	"PUT /api/dashboards/:id":          "manage_dashboards",
-	"DELETE /api/dashboards/:id":       "manage_dashboards",
-	"POST /api/dashboards/:id/share":   "manage_dashboards",
-	"PUT /api/dashboards/:id/default":  "manage_dashboards",
+	"GET /api/dashboards":             "view_dashboards",
+	"POST /api/dashboards":            "manage_dashboards",
+	"GET /api/dashboards/:id":         "view_dashboards",
+	"PUT /api/dashboards/:id":         "manage_dashboards",
+	"DELETE /api/dashboards/:id":      "manage_dashboards",
+	"POST /api/dashboards/:id/share":  "manage_dashboards",
+	"PUT /api/dashboards/:id/default": "manage_dashboards",
 
 	// MQTT Brokers
-	"GET /api/mqtt/brokers":      "view_mqtt",
-	"POST /api/mqtt/brokers":     "manage_mqtt",
-	"GET /api/mqtt/brokers/:id":  "view_mqtt",
-	"PUT /api/mqtt/brokers/:id":  "manage_mqtt",
+	"GET /api/mqtt/brokers":        "view_mqtt",
+	"POST /api/mqtt/brokers":       "manage_mqtt",
+	"GET /api/mqtt/brokers/:id":    "view_mqtt",
+	"PUT /api/mqtt/brokers/:id":    "manage_mqtt",
 	"DELETE /api/mqtt/brokers/:id": "manage_mqtt",
 
 	// MQTT Subscriptions
-	"GET /api/mqtt/subscriptions":      "view_mqtt",
-	"POST /api/mqtt/subscriptions":     "manage_mqtt",
-	"GET /api/mqtt/subscriptions/:id":  "view_mqtt",
-	"PUT /api/mqtt/subscriptions/:id":  "manage_mqtt",
+	"GET /api/mqtt/subscriptions":        "view_mqtt",
+	"POST /api/mqtt/subscriptions":       "manage_mqtt",
+	"GET /api/mqtt/subscriptions/:id":    "view_mqtt",
+	"PUT /api/mqtt/subscriptions/:id":    "manage_mqtt",
 	"DELETE /api/mqtt/subscriptions/:id": "manage_mqtt",
 
 	// MQTT Stats
 	"GET /api/mqtt/stats": "view_mqtt",
 
 	// Notifications
-	"GET /api/notifications":                   "view_notifications",
-	"GET /api/notifications/unread-count":       "view_notifications",
-	"POST /api/notifications/:id/read":          "view_notifications",
-	"POST /api/notifications/:id/dismiss":       "manage_notifications",
-	"POST /api/notifications/bulk/read":         "view_notifications",
-	"POST /api/notifications/bulk/dismiss":      "manage_notifications",
-	"GET /api/notifications/preferences":        "view_notifications",
-	"POST /api/notifications/preferences":       "manage_notifications",
-	"GET /api/notifications/ws":                 "view_notifications",
+	"GET /api/notifications":               "view_notifications",
+	"GET /api/notifications/unread-count":  "view_notifications",
+	"POST /api/notifications/:id/read":     "view_notifications",
+	"POST /api/notifications/:id/dismiss":  "manage_notifications",
+	"POST /api/notifications/bulk/read":    "view_notifications",
+	"POST /api/notifications/bulk/dismiss": "manage_notifications",
+	"GET /api/notifications/preferences":   "view_notifications",
+	"POST /api/notifications/preferences":  "manage_notifications",
+	"GET /api/notifications/ws":            "view_notifications",
 
 	// OAuth
 	"GET /api/oauth/status":       "manage_oauth",
@@ -71,49 +71,50 @@ var routePermissions = map[string]string{
 	"POST /api/oauth/reload":      "manage_oauth",
 
 	// Properties
-	"PATCH /api/properties":    "manage_properties",
-	"GET /api/properties":      "view_properties",
-	"GET /api/properties/ws":   "view_properties",
+	"PATCH /api/properties":  "manage_properties",
+	"GET /api/properties":    "view_properties",
+	"GET /api/properties/ws": "view_properties",
 
 	// Readings
-	"GET /api/readings/between":     "view_readings",
-	"GET /api/readings/ws/current":  "view_readings",
+	"GET /api/readings/between":    "view_readings",
+	"GET /api/readings/ws/current": "view_readings",
 
 	// Roles
-	"GET /api/roles":                          "view_roles",
-	"GET /api/roles/permissions":              "view_roles",
-	"GET /api/roles/:id/permissions":          "view_roles",
-	"POST /api/roles/:id/permissions":         "manage_roles",
-	"DELETE /api/roles/:id/permissions/:pid":  "manage_roles",
+	"GET /api/roles":                         "view_roles",
+	"GET /api/roles/permissions":             "view_roles",
+	"GET /api/roles/:id/permissions":         "view_roles",
+	"POST /api/roles/:id/permissions":        "manage_roles",
+	"DELETE /api/roles/:id/permissions/:pid": "manage_roles",
 
 	// Sensors
-	"GET /api/sensors":                                "view_sensors",
-	"POST /api/sensors":                               "manage_sensors",
-	"PUT /api/sensors/:id":                            "manage_sensors",
-	"DELETE /api/sensors/:name":                       "delete_sensors",
-	"GET /api/sensors/:name":                          "view_sensors",
-	"HEAD /api/sensors/:name":                         "view_sensors",
-	"GET /api/sensors/driver/:driver":                 "view_sensors",
-	"POST /api/sensors/collect":                       "trigger_readings",
-	"POST /api/sensors/collect/:sensorName":           "trigger_readings",
-	"POST /api/sensors/disable/:sensorName":           "manage_sensors",
-	"POST /api/sensors/enable/:sensorName":            "manage_sensors",
-	"GET /api/sensors/health/:name":                   "view_sensors",
-	"GET /api/sensors/stats/total-readings":           "view_sensors",
-	"GET /api/sensors/status/:status":                 "view_sensors",
-	"POST /api/sensors/approve/:id":                   "manage_sensors",
-	"POST /api/sensors/dismiss/:id":                   "manage_sensors",
-	"GET /api/sensors/by-id/:id/measurement-types":   "view_sensors",
+	"GET /api/sensors":                             "view_sensors",
+	"POST /api/sensors":                            "manage_sensors",
+	"PUT /api/sensors/:id":                         "manage_sensors",
+	"DELETE /api/sensors/:name":                    "delete_sensors",
+	"GET /api/sensors/:name":                       "view_sensors",
+	"HEAD /api/sensors/:name":                      "view_sensors",
+	"GET /api/sensors/driver/:driver":              "view_sensors",
+	"POST /api/sensors/collect":                    "trigger_readings",
+	"POST /api/sensors/collect/:sensorName":        "trigger_readings",
+	"POST /api/sensors/disable/:sensorName":        "manage_sensors",
+	"POST /api/sensors/enable/:sensorName":         "manage_sensors",
+	"GET /api/sensors/health/:name":                "view_sensors",
+	"GET /api/sensors/by-id/:id/capabilities":      "view_sensors",
+	"GET /api/sensors/stats/total-readings":        "view_sensors",
+	"GET /api/sensors/status/:status":              "view_sensors",
+	"POST /api/sensors/approve/:id":                "manage_sensors",
+	"POST /api/sensors/dismiss/:id":                "manage_sensors",
+	"GET /api/sensors/by-id/:id/measurement-types": "view_sensors",
 
 	// Measurement types
 	"GET /api/measurement-types": "view_sensors",
 
 	// Users
-	"GET /api/users":               "view_users",
-	"POST /api/users":              "manage_users",
-	"DELETE /api/users/:id":        "manage_users",
+	"GET /api/users":                   "view_users",
+	"POST /api/users":                  "manage_users",
+	"DELETE /api/users/:id":            "manage_users",
 	"PATCH /api/users/:id/must_change": "manage_users",
-	"POST /api/users/:id/roles":    "manage_users",
+	"POST /api/users/:id/roles":        "manage_users",
 }
 
 // RouteAuthAndPermissionMiddleware returns a gen.MiddlewareFunc that:

--- a/sensor_hub/api/sensor_api.go
+++ b/sensor_hub/api/sensor_api.go
@@ -7,11 +7,10 @@ import (
 	"example/sensorHub/ws"
 	"log/slog"
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 )
-
-
 
 // computeEffectiveRetentionHours returns the sensor's custom retention if set, otherwise
 // the global default (sensor.data.retention.days × 24 hours).
@@ -146,6 +145,23 @@ func (s *Server) GetSensorByName(c *gin.Context, name string) {
 	effectiveHours := computeEffectiveRetentionHours(masked)
 	masked.EffectiveRetentionHours = &effectiveHours
 	c.IndentedJSON(http.StatusOK, masked)
+}
+
+func (s *Server) GetSensorCapabilities(c *gin.Context, id int) {
+	ctx := c.Request.Context()
+	capabilities, err := s.sensorService.ServiceGetSensorCapabilities(ctx, id)
+	if err != nil {
+		if strings.Contains(err.Error(), "no sensor found") || strings.Contains(err.Error(), "not found") {
+			c.IndentedJSON(http.StatusNotFound, gin.H{"message": "Sensor not found", "error": err.Error()})
+			return
+		}
+		c.IndentedJSON(http.StatusInternalServerError, gin.H{"message": "Error retrieving sensor capabilities", "error": err.Error()})
+		return
+	}
+	if capabilities == nil {
+		capabilities = []gen.Capability{}
+	}
+	c.IndentedJSON(http.StatusOK, capabilities)
 }
 
 func (s *Server) GetAllSensors(c *gin.Context) {

--- a/sensor_hub/api/sensor_api_test.go
+++ b/sensor_hub/api/sensor_api_test.go
@@ -244,6 +244,49 @@ func TestGetSensorsByDriverHandler(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "s1")
 }
 
+func TestGetSensorCapabilitiesHandler(t *testing.T) {
+	router, api, s, mockService := setupSensorRouter()
+	api.GET("/sensors/by-id/:id/capabilities", func(c *gin.Context) {
+		var id int
+		if _, err := fmt.Sscan(c.Param("id"), &id); err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid sensor ID"})
+			return
+		}
+		s.GetSensorCapabilities(c, id)
+	})
+
+	mockService.On("ServiceGetSensorCapabilities", mock.Anything, 7).Return([]gen.Capability{
+		{Property: "state", Type: gen.CapabilityTypeBinary},
+	}, nil)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/sensors/by-id/7/capabilities", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "state")
+}
+
+func TestGetSensorCapabilitiesHandler_NotFound(t *testing.T) {
+	router, api, s, mockService := setupSensorRouter()
+	api.GET("/sensors/by-id/:id/capabilities", func(c *gin.Context) {
+		var id int
+		if _, err := fmt.Sscan(c.Param("id"), &id); err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid sensor ID"})
+			return
+		}
+		s.GetSensorCapabilities(c, id)
+	})
+
+	mockService.On("ServiceGetSensorCapabilities", mock.Anything, 7).Return([]gen.Capability(nil), errors.New("sensor not found"))
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/sensors/by-id/7/capabilities", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
 func TestSensorExistsHandler(t *testing.T) {
 	router, api, s, mockService := setupSensorRouter()
 	api.HEAD("/sensors/:name", func(c *gin.Context) {

--- a/sensor_hub/drivers/driver.go
+++ b/sensor_hub/drivers/driver.go
@@ -55,6 +55,14 @@ type PushDriver interface {
 	IdentifyDevice(topic string, payload []byte) (string, error)
 }
 
+// CommandDriver is an optional interface for drivers that can expose writable
+// capabilities and later build outbound control commands.
+type CommandDriver interface {
+	SensorDriver
+	ParseCapabilities(metadata json.RawMessage) []gen.Capability
+	BuildCommand(sensor gen.Sensor, property string, value string) (topic string, payload []byte, err error)
+}
+
 // DeviceMetadata is metadata extracted from a driver-specific system message.
 type DeviceMetadata struct {
 	FriendlyName string
@@ -91,6 +99,17 @@ func Get(driverType string) (SensorDriver, bool) {
 	defer mu.RUnlock()
 	d, ok := registry[driverType]
 	return d, ok
+}
+
+// GetCommandDriver returns a registered command-capable driver by type.
+func GetCommandDriver(driverType string) (CommandDriver, bool) {
+	driver, ok := Get(driverType)
+	if !ok {
+		return nil, false
+	}
+
+	commandDriver, ok := driver.(CommandDriver)
+	return commandDriver, ok
 }
 
 // All returns a slice of all registered drivers.

--- a/sensor_hub/drivers/driver_test.go
+++ b/sensor_hub/drivers/driver_test.go
@@ -2,6 +2,7 @@ package drivers
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	gen "example/sensorHub/gen"
@@ -13,12 +14,24 @@ type stubDriver struct {
 	driverType string
 }
 
-func (s *stubDriver) Type() string                        { return s.driverType }
-func (s *stubDriver) DisplayName() string                 { return "Stub" }
-func (s *stubDriver) Description() string                 { return "A stub driver for testing" }
-func (s *stubDriver) ConfigFields() []ConfigFieldSpec     { return nil }
-func (s *stubDriver) SupportedMeasurementTypes() []gen.MeasurementType { return nil }
+func (s *stubDriver) Type() string                                         { return s.driverType }
+func (s *stubDriver) DisplayName() string                                  { return "Stub" }
+func (s *stubDriver) Description() string                                  { return "A stub driver for testing" }
+func (s *stubDriver) ConfigFields() []ConfigFieldSpec                      { return nil }
+func (s *stubDriver) SupportedMeasurementTypes() []gen.MeasurementType     { return nil }
 func (s *stubDriver) ValidateSensor(_ context.Context, _ gen.Sensor) error { return nil }
+
+type stubCommandDriver struct {
+	stubDriver
+}
+
+func (s *stubCommandDriver) ParseCapabilities(_ json.RawMessage) []gen.Capability {
+	return []gen.Capability{{Property: "state", Type: gen.CapabilityTypeBinary}}
+}
+
+func (s *stubCommandDriver) BuildCommand(_ gen.Sensor, _ string, _ string) (string, []byte, error) {
+	return "topic", []byte(`{"state":"ON"}`), nil
+}
 
 func TestRegister_And_Get(t *testing.T) {
 	Reset()
@@ -56,4 +69,22 @@ func TestAll(t *testing.T) {
 
 	all := All()
 	assert.Len(t, all, 2)
+}
+
+func TestGetCommandDriver(t *testing.T) {
+	Reset()
+	defer Reset()
+
+	Register(&stubDriver{driverType: "plain-driver"})
+	Register(&stubCommandDriver{stubDriver: stubDriver{driverType: "command-driver"}})
+
+	commandDriver, ok := GetCommandDriver("command-driver")
+	assert.True(t, ok)
+	assert.Equal(t, "command-driver", commandDriver.Type())
+
+	_, ok = GetCommandDriver("plain-driver")
+	assert.False(t, ok)
+
+	_, ok = GetCommandDriver("missing-driver")
+	assert.False(t, ok)
 }

--- a/sensor_hub/drivers/sensor_hub_http_temperature_test.go
+++ b/sensor_hub/drivers/sensor_hub_http_temperature_test.go
@@ -23,7 +23,7 @@ func TestSensorHubHTTPTemperature_Metadata(t *testing.T) {
 	mt := d.SupportedMeasurementTypes()
 	require.Len(t, mt, 1)
 	assert.Equal(t, "temperature", mt[0].Name)
-	assert.Equal(t, gen.Numeric, mt[0].Category)
+	assert.Equal(t, gen.MeasurementTypeCategoryNumeric, mt[0].Category)
 
 	cf := d.ConfigFields()
 	require.Len(t, cf, 1)

--- a/sensor_hub/drivers/zigbee2mqtt.go
+++ b/sensor_hub/drivers/zigbee2mqtt.go
@@ -63,6 +63,7 @@ var knownFields = map[string]fieldMapping{
 type Zigbee2MQTTDriver struct{}
 
 var _ PushDriver = (*Zigbee2MQTTDriver)(nil)
+var _ CommandDriver = (*Zigbee2MQTTDriver)(nil)
 var _ SystemMessageHandler = (*Zigbee2MQTTDriver)(nil)
 
 func (d *Zigbee2MQTTDriver) Type() string        { return "mqtt-zigbee2mqtt" }
@@ -171,6 +172,86 @@ func (d *Zigbee2MQTTDriver) ParseSystemMessage(topic string, payload []byte) []D
 	return metadata
 }
 
+type zigbeeCapabilityExpose struct {
+	Type     string                   `json:"type"`
+	Property string                   `json:"property"`
+	Access   *int                     `json:"access"`
+	ValueOn  *string                  `json:"value_on"`
+	ValueOff *string                  `json:"value_off"`
+	ValueMin *float64                 `json:"value_min"`
+	ValueMax *float64                 `json:"value_max"`
+	Unit     *string                  `json:"unit"`
+	Values   []string                 `json:"values"`
+	Features []zigbeeCapabilityExpose `json:"features"`
+}
+
+func (d *Zigbee2MQTTDriver) ParseCapabilities(metadata json.RawMessage) []gen.Capability {
+	var exposes []zigbeeCapabilityExpose
+	if err := json.Unmarshal(metadata, &exposes); err != nil {
+		return nil
+	}
+
+	capabilities := make([]gen.Capability, 0)
+	for _, expose := range exposes {
+		capabilities = append(capabilities, parseCapabilityExpose(expose)...)
+	}
+
+	return capabilities
+}
+
+func (d *Zigbee2MQTTDriver) BuildCommand(_ gen.Sensor, _ string, _ string) (string, []byte, error) {
+	return "", nil, fmt.Errorf("build command not implemented")
+}
+
+func parseCapabilityExpose(expose zigbeeCapabilityExpose) []gen.Capability {
+	capabilities := make([]gen.Capability, 0)
+	for _, feature := range expose.Features {
+		capabilities = append(capabilities, parseCapabilityExpose(feature)...)
+	}
+
+	if expose.Access == nil || *expose.Access&2 == 0 || expose.Property == "" {
+		return capabilities
+	}
+
+	switch expose.Type {
+	case "binary":
+		valueOn := expose.ValueOn
+		valueOff := expose.ValueOff
+		if valueOn == nil {
+			valueOn = capabilityStringPtr("ON")
+		}
+		if valueOff == nil {
+			valueOff = capabilityStringPtr("OFF")
+		}
+		capabilities = append(capabilities, gen.Capability{
+			Property: expose.Property,
+			Type:     gen.CapabilityTypeBinary,
+			ValueOn:  valueOn,
+			ValueOff: valueOff,
+		})
+	case "numeric":
+		capabilities = append(capabilities, gen.Capability{
+			Property: expose.Property,
+			Type:     gen.CapabilityTypeNumeric,
+			Min:      expose.ValueMin,
+			Max:      expose.ValueMax,
+			Unit:     expose.Unit,
+		})
+	case "enum":
+		capability := gen.Capability{
+			Property: expose.Property,
+			Type:     gen.CapabilityTypeEnum,
+		}
+		if len(expose.Values) > 0 {
+			values := append([]string(nil), expose.Values...)
+			capability.Values = &values
+		}
+		capabilities = append(capabilities, capability)
+	}
+
+	return capabilities
+}
+
 // ParseMessage extracts readings from a Zigbee2MQTT JSON payload.
 // It maps known JSON fields to typed readings and ignores unknown fields.
 func (d *Zigbee2MQTTDriver) ParseMessage(topic string, payload []byte) ([]gen.Reading, error) {
@@ -248,4 +329,8 @@ func toBoolString(v interface{}) string {
 	default:
 		return fmt.Sprintf("%v", v)
 	}
+}
+
+func capabilityStringPtr(value string) *string {
+	return &value
 }

--- a/sensor_hub/drivers/zigbee2mqtt_test.go
+++ b/sensor_hub/drivers/zigbee2mqtt_test.go
@@ -2,6 +2,7 @@ package drivers
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	gen "example/sensorHub/gen"
@@ -306,6 +307,80 @@ func TestZigbee2MQTT_ParseSystemMessage_MalformedPayload(t *testing.T) {
 	assert.Nil(t, entries)
 }
 
+func TestParseCapabilities_BinarySwitch(t *testing.T) {
+	d := &Zigbee2MQTTDriver{}
+
+	capabilities := d.ParseCapabilities(json.RawMessage(`[
+		{"type":"binary","property":"state","name":"state","access":7,"value_on":"ON","value_off":"OFF"}
+	]`))
+
+	require.Len(t, capabilities, 1)
+	assert.Equal(t, gen.Capability{
+		Property: "state",
+		Type:     gen.CapabilityTypeBinary,
+		ValueOn:  strPtr("ON"),
+		ValueOff: strPtr("OFF"),
+	}, capabilities[0])
+}
+
+func TestParseCapabilities_NoWritableFeatures(t *testing.T) {
+	d := &Zigbee2MQTTDriver{}
+
+	capabilities := d.ParseCapabilities(json.RawMessage(`[
+		{"type":"binary","property":"contact","name":"contact","access":1},
+		{"type":"numeric","property":"temperature","name":"temperature","access":1,"unit":"°C","value_min":-40,"value_max":80}
+	]`))
+
+	assert.Empty(t, capabilities)
+}
+
+func TestParseCapabilities_MixedFeatures(t *testing.T) {
+	d := &Zigbee2MQTTDriver{}
+
+	capabilities := d.ParseCapabilities(json.RawMessage(`[
+		{"type":"binary","property":"state","name":"state","access":7,"value_on":"ON","value_off":"OFF"},
+		{"type":"numeric","property":"brightness","name":"brightness","access":7,"unit":"%","value_min":0,"value_max":100},
+		{"type":"enum","property":"mode","name":"mode","access":7,"values":["heat","cool","off"]},
+		{"type":"numeric","property":"power","name":"power","access":1,"unit":"W","value_min":0,"value_max":2500}
+	]`))
+
+	require.Len(t, capabilities, 3)
+
+	byProperty := make(map[string]gen.Capability, len(capabilities))
+	for _, capability := range capabilities {
+		byProperty[capability.Property] = capability
+	}
+
+	assert.Equal(t, gen.Capability{
+		Property: "state",
+		Type:     gen.CapabilityTypeBinary,
+		ValueOn:  strPtr("ON"),
+		ValueOff: strPtr("OFF"),
+	}, byProperty["state"])
+
+	assert.Equal(t, gen.Capability{
+		Property: "brightness",
+		Type:     gen.CapabilityTypeNumeric,
+		Min:      floatPtr(0),
+		Max:      floatPtr(100),
+		Unit:     strPtr("%"),
+	}, byProperty["brightness"])
+
+	assert.Equal(t, gen.Capability{
+		Property: "mode",
+		Type:     gen.CapabilityTypeEnum,
+		Values:   stringSlicePtr("heat", "cool", "off"),
+	}, byProperty["mode"])
+}
+
+func TestParseCapabilities_MalformedExposes(t *testing.T) {
+	d := &Zigbee2MQTTDriver{}
+
+	capabilities := d.ParseCapabilities(json.RawMessage(`{not-json`))
+
+	assert.Nil(t, capabilities)
+}
+
 func TestZigbee2MQTT_SupportedMeasurementTypes(t *testing.T) {
 	d := &Zigbee2MQTTDriver{}
 	mts := d.SupportedMeasurementTypes()
@@ -324,4 +399,16 @@ func TestZigbee2MQTT_ImplementsPushDriver(t *testing.T) {
 	var drv SensorDriver = &Zigbee2MQTTDriver{}
 	_, ok := drv.(PushDriver)
 	assert.True(t, ok, "Zigbee2MQTTDriver should implement PushDriver")
+}
+
+func strPtr(value string) *string {
+	return &value
+}
+
+func floatPtr(value float64) *float64 {
+	return &value
+}
+
+func stringSlicePtr(values ...string) *[]string {
+	return &values
 }

--- a/sensor_hub/gen/client.gen.go
+++ b/sensor_hub/gen/client.gen.go
@@ -320,6 +320,9 @@ type ClientInterface interface {
 	// ApproveSensor request
 	ApproveSensor(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// GetSensorCapabilities request
+	GetSensorCapabilities(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// GetSensorMeasurementTypes request
 	GetSensorMeasurementTypes(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -1371,6 +1374,18 @@ func (c *Client) AddSensor(ctx context.Context, body AddSensorJSONRequestBody, r
 
 func (c *Client) ApproveSensor(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewApproveSensorRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetSensorCapabilities(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetSensorCapabilitiesRequest(c.Server, id)
 	if err != nil {
 		return nil, err
 	}
@@ -4106,6 +4121,40 @@ func NewApproveSensorRequest(server string, id int) (*http.Request, error) {
 	return req, nil
 }
 
+// NewGetSensorCapabilitiesRequest generates requests for GetSensorCapabilities
+func NewGetSensorCapabilitiesRequest(server string, id int) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "integer", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/sensors/by-id/%s/capabilities", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewGetSensorMeasurementTypesRequest generates requests for GetSensorMeasurementTypes
 func NewGetSensorMeasurementTypesRequest(server string, id int) (*http.Request, error) {
 	var err error
@@ -5170,6 +5219,9 @@ type ClientWithResponsesInterface interface {
 
 	// ApproveSensorWithResponse request
 	ApproveSensorWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*ApproveSensorResp, error)
+
+	// GetSensorCapabilitiesWithResponse request
+	GetSensorCapabilitiesWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*GetSensorCapabilitiesResp, error)
 
 	// GetSensorMeasurementTypesWithResponse request
 	GetSensorMeasurementTypesWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*GetSensorMeasurementTypesResp, error)
@@ -6748,6 +6800,30 @@ func (r ApproveSensorResp) StatusCode() int {
 	return 0
 }
 
+type GetSensorCapabilitiesResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *[]Capability
+	JSON404      *ErrorResponse
+	JSON500      *ErrorResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r GetSensorCapabilitiesResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetSensorCapabilitiesResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type GetSensorMeasurementTypesResp struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -7977,6 +8053,15 @@ func (c *ClientWithResponses) ApproveSensorWithResponse(ctx context.Context, id 
 		return nil, err
 	}
 	return ParseApproveSensorResp(rsp)
+}
+
+// GetSensorCapabilitiesWithResponse request returning *GetSensorCapabilitiesResp
+func (c *ClientWithResponses) GetSensorCapabilitiesWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*GetSensorCapabilitiesResp, error) {
+	rsp, err := c.GetSensorCapabilities(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetSensorCapabilitiesResp(rsp)
 }
 
 // GetSensorMeasurementTypesWithResponse request returning *GetSensorMeasurementTypesResp
@@ -10295,6 +10380,46 @@ func ParseApproveSensorResp(rsp *http.Response) (*ApproveSensorResp, error) {
 			return nil, err
 		}
 		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetSensorCapabilitiesResp parses an HTTP response from a GetSensorCapabilitiesWithResponse call
+func ParseGetSensorCapabilitiesResp(rsp *http.Response) (*GetSensorCapabilitiesResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetSensorCapabilitiesResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest []Capability
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
 
 	}
 

--- a/sensor_hub/gen/server.gen.go
+++ b/sensor_hub/gen/server.gen.go
@@ -208,6 +208,9 @@ type ServerInterface interface {
 	// Approve a pending sensor
 	// (POST /sensors/approve/{id})
 	ApproveSensor(c *gin.Context, id int)
+	// Get sensor capabilities by id
+	// (GET /sensors/by-id/{id}/capabilities)
+	GetSensorCapabilities(c *gin.Context, id int)
 	// Get measurement types for a sensor
 	// (GET /sensors/by-id/{id}/measurement-types)
 	GetSensorMeasurementTypes(c *gin.Context, id int)
@@ -1937,6 +1940,36 @@ func (siw *ServerInterfaceWrapper) ApproveSensor(c *gin.Context) {
 	siw.Handler.ApproveSensor(c, id)
 }
 
+// GetSensorCapabilities operation middleware
+func (siw *ServerInterfaceWrapper) GetSensorCapabilities(c *gin.Context) {
+
+	var err error
+
+	// ------------- Path parameter "id" -------------
+	var id int
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", c.Param("id"), &id, runtime.BindStyledParameterOptions{Explode: false, Required: true, Type: "integer", Format: ""})
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter id: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	c.Set(CookieAuthScopes, []string{})
+
+	c.Set(CsrfTokenScopes, []string{})
+
+	c.Set(ApiKeyAuthScopes, []string{})
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		middleware(c)
+		if c.IsAborted() {
+			return
+		}
+	}
+
+	siw.Handler.GetSensorCapabilities(c, id)
+}
+
 // GetSensorMeasurementTypes operation middleware
 func (siw *ServerInterfaceWrapper) GetSensorMeasurementTypes(c *gin.Context) {
 
@@ -2634,6 +2667,7 @@ func RegisterHandlersWithOptions(router gin.IRouter, si ServerInterface, options
 	router.GET(options.BaseURL+"/sensors", wrapper.GetAllSensors)
 	router.POST(options.BaseURL+"/sensors", wrapper.AddSensor)
 	router.POST(options.BaseURL+"/sensors/approve/:id", wrapper.ApproveSensor)
+	router.GET(options.BaseURL+"/sensors/by-id/:id/capabilities", wrapper.GetSensorCapabilities)
 	router.GET(options.BaseURL+"/sensors/by-id/:id/measurement-types", wrapper.GetSensorMeasurementTypes)
 	router.POST(options.BaseURL+"/sensors/collect", wrapper.CollectAllSensorReadings)
 	router.POST(options.BaseURL+"/sensors/collect/:sensorName", wrapper.CollectFromSensor)

--- a/sensor_hub/gen/types.gen.go
+++ b/sensor_hub/gen/types.gen.go
@@ -88,6 +88,27 @@ func (e AlertRuleAlertType) Valid() bool {
 	}
 }
 
+// Defines values for CapabilityType.
+const (
+	CapabilityTypeBinary  CapabilityType = "binary"
+	CapabilityTypeEnum    CapabilityType = "enum"
+	CapabilityTypeNumeric CapabilityType = "numeric"
+)
+
+// Valid indicates whether the value is a known member of the CapabilityType enum.
+func (e CapabilityType) Valid() bool {
+	switch e {
+	case CapabilityTypeBinary:
+		return true
+	case CapabilityTypeEnum:
+		return true
+	case CapabilityTypeNumeric:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for ChannelPreferenceCategory.
 const (
 	ChannelPreferenceCategoryConfigChange   ChannelPreferenceCategory = "config_change"
@@ -111,16 +132,16 @@ func (e ChannelPreferenceCategory) Valid() bool {
 
 // Defines values for MeasurementTypeCategory.
 const (
-	Binary  MeasurementTypeCategory = "binary"
-	Numeric MeasurementTypeCategory = "numeric"
+	MeasurementTypeCategoryBinary  MeasurementTypeCategory = "binary"
+	MeasurementTypeCategoryNumeric MeasurementTypeCategory = "numeric"
 )
 
 // Valid indicates whether the value is a known member of the MeasurementTypeCategory enum.
 func (e MeasurementTypeCategory) Valid() bool {
 	switch e {
-	case Binary:
+	case MeasurementTypeCategoryBinary:
 		return true
-	case Numeric:
+	case MeasurementTypeCategoryNumeric:
 		return true
 	default:
 		return false
@@ -397,6 +418,36 @@ type ApiKey struct {
 	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 	UserId    *int       `json:"user_id,omitempty"`
 }
+
+// Capability A controllable property exposed by a driver. This is derived from driver metadata and is never user-configurable.
+type Capability struct {
+	// Max Maximum allowed value for numeric capabilities.
+	Max *float64 `json:"max,omitempty"`
+
+	// Min Minimum allowed value for numeric capabilities.
+	Min *float64 `json:"min,omitempty"`
+
+	// Property Driver-level property name used when sending commands.
+	Property string `json:"property"`
+
+	// Type Capability kind.
+	Type CapabilityType `json:"type"`
+
+	// Unit Optional engineering unit for numeric capabilities.
+	Unit *string `json:"unit,omitempty"`
+
+	// ValueOff Canonical "off" value for binary capabilities.
+	ValueOff *string `json:"value_off,omitempty"`
+
+	// ValueOn Canonical "on" value for binary capabilities.
+	ValueOn *string `json:"value_on,omitempty"`
+
+	// Values Allowed values for enum capabilities.
+	Values *[]string `json:"values,omitempty"`
+}
+
+// CapabilityType Capability kind.
+type CapabilityType string
 
 // ChangePasswordRequest Change password request body
 type ChangePasswordRequest struct {
@@ -753,6 +804,9 @@ type RoleInfo struct {
 
 // Sensor Metadata for a sensor as returned by sensors endpoints and WebSocket snapshots.
 type Sensor struct {
+	// Capabilities Controllable properties for this sensor. Empty if the sensor is not controllable. Derived from driver metadata and ignored on create/update requests.
+	Capabilities *[]Capability `json:"capabilities,omitempty"`
+
 	// Config Driver-specific configuration key-value pairs. Each driver declares which keys it expects via the GET /drivers endpoint. Sensitive values are masked as "****" in GET responses.
 	Config map[string]string `json:"config"`
 

--- a/sensor_hub/integration/mqtt_metadata_test.go
+++ b/sensor_hub/integration/mqtt_metadata_test.go
@@ -130,6 +130,225 @@ func TestZigbee2MQTTBridgeDevices_BackfillsSensorMetadata(t *testing.T) {
 	assert.JSONEq(t, `[{"type":"binary","property":"contact","name":"contact","access":1}]`, string(exposesJSON))
 }
 
+func TestZigbee2MQTTBridgeDevices_ReportsWritableCapabilitiesViaAPI(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.Default()
+	port := reserveTCPPort(t)
+	sensorName := fmt.Sprintf("office-plug-%d", port)
+
+	embeddedBroker := mqttpkg.NewEmbeddedBroker(mqttpkg.BrokerConfig{
+		TCPAddress: fmt.Sprintf(":%d", port),
+	}, logger)
+	require.NoError(t, embeddedBroker.Start())
+	defer func() {
+		require.NoError(t, embeddedBroker.Stop())
+	}()
+
+	sensorRepo := database.NewSensorRepository(env.DB, logger)
+	readingsRepo := database.NewReadingsRepository(env.DB, logger)
+	mtRepo := database.NewMeasurementTypeRepository(env.DB, logger)
+	alertRepo := database.NewAlertRepository(env.DB, logger)
+	brokerRepo := database.NewMQTTBrokerRepository(env.DB, logger)
+	subRepo := database.NewMQTTSubscriptionRepository(env.DB, logger)
+
+	sensorService := service.NewSensorService(sensorRepo, readingsRepo, mtRepo, alertRepo, nil, logger)
+	connManager := mqttpkg.NewConnectionManager(sensorService, subRepo, brokerRepo, logger)
+
+	brokerID, err := brokerRepo.Add(ctx, gen.MQTTBroker{
+		Name:    fmt.Sprintf("integration-z2m-capabilities-%d", port),
+		Host:    "127.0.0.1",
+		Port:    port,
+		Type:    "external",
+		Enabled: true,
+	})
+	require.NoError(t, err)
+
+	subID, err := subRepo.Add(ctx, gen.MQTTSubscription{
+		BrokerId:     brokerID,
+		TopicPattern: "zigbee2mqtt/#",
+		DriverType:   "mqtt-zigbee2mqtt",
+		Enabled:      true,
+	})
+	require.NoError(t, err)
+
+	defer func() {
+		connManager.Stop()
+		_ = subRepo.Delete(ctx, subID)
+		_ = brokerRepo.Delete(ctx, brokerID)
+		_ = client.DeleteSensor(sensorName)
+	}()
+
+	require.NoError(t, connManager.Start(ctx))
+	require.Eventually(t, func() bool {
+		return connManager.IsConnected(brokerID)
+	}, 5*time.Second, 100*time.Millisecond)
+
+	_, status := client.AddSensor(gen.Sensor{
+		Name:         sensorName,
+		SensorDriver: "mqtt-zigbee2mqtt",
+		Config:       map[string]string{},
+	})
+	require.Equal(t, http.StatusCreated, status)
+
+	mqttClient := pahomqtt.NewClient(
+		pahomqtt.NewClientOptions().
+			AddBroker(fmt.Sprintf("tcp://127.0.0.1:%d", port)).
+			SetClientID(fmt.Sprintf("integration-z2m-capabilities-publisher-%d", port)),
+	)
+	token := mqttClient.Connect()
+	require.True(t, token.WaitTimeout(5*time.Second))
+	require.NoError(t, token.Error())
+	defer mqttClient.Disconnect(250)
+
+	payload := fmt.Sprintf(`[
+		{
+			"ieee_address": "0x00158d0001826601",
+			"friendly_name": %q,
+			"definition": {
+				"model": "TS011F",
+				"vendor": "Tuya",
+				"description": "Smart plug",
+				"exposes": [
+					{"type":"binary","property":"state","name":"state","access":7,"value_on":"ON","value_off":"OFF"},
+					{"type":"numeric","property":"power","name":"power","access":1,"unit":"W","value_min":0,"value_max":2500}
+				]
+			}
+		}
+	]`, sensorName)
+
+	pub := mqttClient.Publish("zigbee2mqtt/bridge/devices", 0, false, payload)
+	require.True(t, pub.WaitTimeout(5*time.Second))
+	require.NoError(t, pub.Error())
+
+	var sensor gen.Sensor
+	require.Eventually(t, func() bool {
+		var currentStatus int
+		sensor, currentStatus = client.GetSensorByName(sensorName)
+		if currentStatus != http.StatusOK || sensor.Metadata == nil || sensor.Capabilities == nil {
+			return false
+		}
+		metadata := *sensor.Metadata
+		return metadata["model"] == "TS011F" &&
+			len(*sensor.Capabilities) == 1 &&
+			(*sensor.Capabilities)[0].Property == "state"
+	}, 5*time.Second, 100*time.Millisecond)
+
+	capabilities, status := client.GetSensorCapabilities(sensor.Id)
+	require.Equal(t, http.StatusOK, status)
+	require.Len(t, capabilities, 1)
+	assert.Equal(t, *sensor.Capabilities, capabilities)
+	require.NotNil(t, capabilities[0].ValueOn)
+	require.NotNil(t, capabilities[0].ValueOff)
+	assert.Equal(t, "ON", *capabilities[0].ValueOn)
+	assert.Equal(t, "OFF", *capabilities[0].ValueOff)
+}
+
+func TestZigbee2MQTTBridgeDevices_ReadOnlySensorsReturnEmptyCapabilities(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.Default()
+	port := reserveTCPPort(t)
+	sensorName := fmt.Sprintf("temperature-probe-%d", port)
+
+	embeddedBroker := mqttpkg.NewEmbeddedBroker(mqttpkg.BrokerConfig{
+		TCPAddress: fmt.Sprintf(":%d", port),
+	}, logger)
+	require.NoError(t, embeddedBroker.Start())
+	defer func() {
+		require.NoError(t, embeddedBroker.Stop())
+	}()
+
+	sensorRepo := database.NewSensorRepository(env.DB, logger)
+	readingsRepo := database.NewReadingsRepository(env.DB, logger)
+	mtRepo := database.NewMeasurementTypeRepository(env.DB, logger)
+	alertRepo := database.NewAlertRepository(env.DB, logger)
+	brokerRepo := database.NewMQTTBrokerRepository(env.DB, logger)
+	subRepo := database.NewMQTTSubscriptionRepository(env.DB, logger)
+
+	sensorService := service.NewSensorService(sensorRepo, readingsRepo, mtRepo, alertRepo, nil, logger)
+	connManager := mqttpkg.NewConnectionManager(sensorService, subRepo, brokerRepo, logger)
+
+	brokerID, err := brokerRepo.Add(ctx, gen.MQTTBroker{
+		Name:    fmt.Sprintf("integration-z2m-read-only-%d", port),
+		Host:    "127.0.0.1",
+		Port:    port,
+		Type:    "external",
+		Enabled: true,
+	})
+	require.NoError(t, err)
+
+	subID, err := subRepo.Add(ctx, gen.MQTTSubscription{
+		BrokerId:     brokerID,
+		TopicPattern: "zigbee2mqtt/#",
+		DriverType:   "mqtt-zigbee2mqtt",
+		Enabled:      true,
+	})
+	require.NoError(t, err)
+
+	defer func() {
+		connManager.Stop()
+		_ = subRepo.Delete(ctx, subID)
+		_ = brokerRepo.Delete(ctx, brokerID)
+		_ = client.DeleteSensor(sensorName)
+	}()
+
+	require.NoError(t, connManager.Start(ctx))
+	require.Eventually(t, func() bool {
+		return connManager.IsConnected(brokerID)
+	}, 5*time.Second, 100*time.Millisecond)
+
+	_, status := client.AddSensor(gen.Sensor{
+		Name:         sensorName,
+		SensorDriver: "mqtt-zigbee2mqtt",
+		Config:       map[string]string{},
+	})
+	require.Equal(t, http.StatusCreated, status)
+
+	mqttClient := pahomqtt.NewClient(
+		pahomqtt.NewClientOptions().
+			AddBroker(fmt.Sprintf("tcp://127.0.0.1:%d", port)).
+			SetClientID(fmt.Sprintf("integration-z2m-read-only-publisher-%d", port)),
+	)
+	token := mqttClient.Connect()
+	require.True(t, token.WaitTimeout(5*time.Second))
+	require.NoError(t, token.Error())
+	defer mqttClient.Disconnect(250)
+
+	payload := fmt.Sprintf(`[
+		{
+			"ieee_address": "0x00158d0001826602",
+			"friendly_name": %q,
+			"definition": {
+				"model": "WSDCGQ11LM",
+				"vendor": "Aqara",
+				"description": "Temperature sensor",
+				"exposes": [
+					{"type":"numeric","property":"temperature","name":"temperature","access":1,"unit":"°C","value_min":-40,"value_max":80}
+				]
+			}
+		}
+	]`, sensorName)
+
+	pub := mqttClient.Publish("zigbee2mqtt/bridge/devices", 0, false, payload)
+	require.True(t, pub.WaitTimeout(5*time.Second))
+	require.NoError(t, pub.Error())
+
+	var sensor gen.Sensor
+	require.Eventually(t, func() bool {
+		var currentStatus int
+		sensor, currentStatus = client.GetSensorByName(sensorName)
+		if currentStatus != http.StatusOK || sensor.Metadata == nil || sensor.Capabilities == nil {
+			return false
+		}
+		metadata := *sensor.Metadata
+		return metadata["model"] == "WSDCGQ11LM" && len(*sensor.Capabilities) == 0
+	}, 5*time.Second, 100*time.Millisecond)
+
+	capabilities, status := client.GetSensorCapabilities(sensor.Id)
+	require.Equal(t, http.StatusOK, status)
+	assert.Empty(t, capabilities)
+	assert.Empty(t, *sensor.Capabilities)
+}
+
 func TestZigbee2MQTTBridgeDevices_RenamesPhantomIEEESensorInPlace(t *testing.T) {
 	ctx := context.Background()
 	logger := slog.Default()

--- a/sensor_hub/mqtt/connection_manager_test.go
+++ b/sensor_hub/mqtt/connection_manager_test.go
@@ -126,6 +126,13 @@ func (m *MockSensorService) ServiceGetSensorById(ctx context.Context, id int) (*
 	}
 	return args.Get(0).(*gen.Sensor), args.Error(1)
 }
+func (m *MockSensorService) ServiceGetSensorCapabilities(ctx context.Context, id int) ([]gen.Capability, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]gen.Capability), args.Error(1)
+}
 func (m *MockSensorService) ServiceSensorExistsByExternalId(ctx context.Context, externalId string) (bool, error) {
 	args := m.Called(ctx, externalId)
 	return args.Bool(0), args.Error(1)

--- a/sensor_hub/service/sensor_service.go
+++ b/sensor_hub/service/sensor_service.go
@@ -2,15 +2,16 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
-	appProps "example/sensorHub/application_properties"
 	"example/sensorHub/alerting"
+	appProps "example/sensorHub/application_properties"
 	database "example/sensorHub/db"
 	"example/sensorHub/drivers"
+	gen "example/sensorHub/gen"
 	"example/sensorHub/notifications"
 	"example/sensorHub/periodic"
 	"example/sensorHub/telemetry"
-	gen "example/sensorHub/gen"
 	"example/sensorHub/ws"
 	"fmt"
 	"log/slog"
@@ -147,11 +148,32 @@ func (s *SensorService) ServiceGetSensorByName(ctx context.Context, name string)
 	if err != nil {
 		return nil, err
 	}
-	return sensor, nil
+	if sensor == nil {
+		return nil, nil
+	}
+	return s.enrichSensor(sensor), nil
 }
 
 func (s *SensorService) ServiceGetSensorById(ctx context.Context, id int) (*gen.Sensor, error) {
-	return s.sensorRepo.GetSensorById(ctx, id)
+	sensor, err := s.sensorRepo.GetSensorById(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if sensor == nil {
+		return nil, nil
+	}
+	return s.enrichSensor(sensor), nil
+}
+
+func (s *SensorService) ServiceGetSensorCapabilities(ctx context.Context, id int) ([]gen.Capability, error) {
+	sensor, err := s.ServiceGetSensorById(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if sensor == nil || sensor.Capabilities == nil {
+		return []gen.Capability{}, nil
+	}
+	return append([]gen.Capability(nil), (*sensor.Capabilities)...), nil
 }
 
 func (s *SensorService) ServiceGetAllSensors(ctx context.Context) ([]gen.Sensor, error) {
@@ -159,7 +181,7 @@ func (s *SensorService) ServiceGetAllSensors(ctx context.Context) ([]gen.Sensor,
 	if err != nil {
 		return nil, err
 	}
-	return sensors, nil
+	return s.enrichSensors(sensors), nil
 }
 
 func (s *SensorService) ServiceGetSensorsByDriver(ctx context.Context, sensorDriver string) ([]gen.Sensor, error) {
@@ -167,7 +189,7 @@ func (s *SensorService) ServiceGetSensorsByDriver(ctx context.Context, sensorDri
 	if err != nil {
 		return nil, err
 	}
-	return sensors, nil
+	return s.enrichSensors(sensors), nil
 }
 
 func (s *SensorService) ServiceGetSensorIdByName(ctx context.Context, name string) (int, error) {
@@ -182,7 +204,14 @@ func (s *SensorService) ServiceGetSensorByExternalId(ctx context.Context, extern
 	if externalId == "" {
 		return nil, fmt.Errorf("external_id cannot be empty")
 	}
-	return s.sensorRepo.GetSensorByExternalId(ctx, externalId)
+	sensor, err := s.sensorRepo.GetSensorByExternalId(ctx, externalId)
+	if err != nil {
+		return nil, err
+	}
+	if sensor == nil {
+		return nil, nil
+	}
+	return s.enrichSensor(sensor), nil
 }
 
 func (s *SensorService) ServiceSensorExistsByExternalId(ctx context.Context, externalId string) (bool, error) {
@@ -518,6 +547,7 @@ func (s *SensorService) broadcastSensors(ctx context.Context) {
 		s.logger.Error("failed to fetch sensors for broadcast", "error", err)
 		return
 	}
+	sensors = s.enrichSensors(sensors)
 
 	// Per-driver broadcast (existing WebSocket subscribers)
 	byType := make(map[string][]gen.Sensor)
@@ -540,7 +570,11 @@ func (s *SensorService) broadcastSensors(ctx context.Context) {
 }
 
 func (s *SensorService) ServiceGetSensorsByStatus(ctx context.Context, status string) ([]gen.Sensor, error) {
-	return s.sensorRepo.GetSensorsByStatus(ctx, status)
+	sensors, err := s.sensorRepo.GetSensorsByStatus(ctx, status)
+	if err != nil {
+		return nil, err
+	}
+	return s.enrichSensors(sensors), nil
 }
 
 func (s *SensorService) ServiceApproveSensor(ctx context.Context, sensorId int) error {
@@ -602,4 +636,46 @@ func (s *SensorService) ServiceGetAllMeasurementTypes(ctx context.Context) ([]ge
 
 func (s *SensorService) ServiceGetAllMeasurementTypesWithReadings(ctx context.Context) ([]gen.MeasurementType, error) {
 	return s.mtRepo.GetAllWithReadings(ctx)
+}
+
+func (s *SensorService) enrichSensor(sensor *gen.Sensor) *gen.Sensor {
+	enriched := *sensor
+	capabilities := s.resolveSensorCapabilities(enriched)
+	enriched.Capabilities = &capabilities
+	return &enriched
+}
+
+func (s *SensorService) enrichSensors(sensors []gen.Sensor) []gen.Sensor {
+	enriched := make([]gen.Sensor, len(sensors))
+	for i := range sensors {
+		capabilities := s.resolveSensorCapabilities(sensors[i])
+		enriched[i] = sensors[i]
+		enriched[i].Capabilities = &capabilities
+	}
+	return enriched
+}
+
+func (s *SensorService) resolveSensorCapabilities(sensor gen.Sensor) []gen.Capability {
+	commandDriver, ok := drivers.GetCommandDriver(sensor.SensorDriver)
+	if !ok || sensor.Metadata == nil {
+		return []gen.Capability{}
+	}
+
+	exposesValue, ok := (*sensor.Metadata)["exposes"]
+	if !ok || exposesValue == nil {
+		return []gen.Capability{}
+	}
+
+	exposesJSON, err := json.Marshal(exposesValue)
+	if err != nil {
+		s.logger.Warn("failed to marshal sensor exposes metadata", "sensor", sensor.Name, "error", err)
+		return []gen.Capability{}
+	}
+
+	capabilities := commandDriver.ParseCapabilities(exposesJSON)
+	if capabilities == nil {
+		return []gen.Capability{}
+	}
+
+	return capabilities
 }

--- a/sensor_hub/service/sensor_service_interface.go
+++ b/sensor_hub/service/sensor_service_interface.go
@@ -12,6 +12,7 @@ type SensorServiceInterface interface {
 	ServiceGetSensorByName(ctx context.Context, name string) (*gen.Sensor, error)
 	ServiceGetSensorByExternalId(ctx context.Context, externalId string) (*gen.Sensor, error)
 	ServiceGetSensorById(ctx context.Context, id int) (*gen.Sensor, error)
+	ServiceGetSensorCapabilities(ctx context.Context, id int) ([]gen.Capability, error)
 	ServiceGetAllSensors(ctx context.Context) ([]gen.Sensor, error)
 	ServiceGetSensorsByDriver(ctx context.Context, sensorDriver string) ([]gen.Sensor, error)
 	ServiceGetSensorIdByName(ctx context.Context, name string) (int, error)

--- a/sensor_hub/service/sensor_service_test.go
+++ b/sensor_hub/service/sensor_service_test.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	"example/sensorHub/alerting"
-	_ "example/sensorHub/drivers" // trigger init() to register drivers
 	database "example/sensorHub/db"
+	_ "example/sensorHub/drivers" // trigger init() to register drivers
 	gen "example/sensorHub/gen"
 
 	"github.com/stretchr/testify/assert"
@@ -202,7 +202,7 @@ func TestSensorService_ServiceAddSensor_Success(t *testing.T) {
 	sensor.Config = map[string]string{"url": server.URL}
 
 	sensorRepo.On("SensorExists", mock.Anything, "TestSensor").Return(false, nil)
-	sensorRepo.On("AddSensor", mock.Anything,  mock.Anything).Return(nil)
+	sensorRepo.On("AddSensor", mock.Anything, mock.Anything).Return(nil)
 	sensorRepo.On("UpdateSensorHealthById", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 	sensorRepo.On("GetAllSensors", mock.Anything).Return([]gen.Sensor{sensor}, nil).Maybe()
 
@@ -360,6 +360,31 @@ func TestSensorService_ServiceGetSensorByName_Success(t *testing.T) {
 	assert.Equal(t, "TestSensor", result.Name)
 }
 
+func TestSensorService_ServiceGetSensorByName_IncludesCapabilities(t *testing.T) {
+	service, sensorRepo, _, _, _ := setupSensorService()
+
+	metadata := map[string]interface{}{
+		"exposes": json.RawMessage(`[
+			{"type":"binary","property":"state","name":"state","access":7,"value_on":"ON","value_off":"OFF"}
+		]`),
+	}
+	sensor := &gen.Sensor{
+		Id:           1,
+		Name:         "Office Plug",
+		SensorDriver: "mqtt-zigbee2mqtt",
+		Metadata:     &metadata,
+	}
+	sensorRepo.On("GetSensorByName", mock.Anything, "Office Plug").Return(sensor, nil)
+
+	result, err := service.ServiceGetSensorByName(context.Background(), "Office Plug")
+
+	assert.NoError(t, err)
+	if assert.NotNil(t, result) && assert.NotNil(t, result.Capabilities) {
+		assert.Len(t, *result.Capabilities, 1)
+		assert.Equal(t, "state", (*result.Capabilities)[0].Property)
+	}
+}
+
 func TestSensorService_ServiceGetSensorByName_EmptyName(t *testing.T) {
 	service, _, _, _, _ := setupSensorService()
 
@@ -411,6 +436,22 @@ func TestSensorService_ServiceGetAllSensors_Empty(t *testing.T) {
 	assert.Len(t, result, 0)
 }
 
+func TestSensorService_ServiceGetAllSensors_NonCommandDriversHaveEmptyCapabilities(t *testing.T) {
+	service, sensorRepo, _, _, _ := setupSensorService()
+
+	sensors := []gen.Sensor{
+		{Id: 1, Name: "Sensor1", SensorDriver: "sensor-hub-http-temperature"},
+	}
+	sensorRepo.On("GetAllSensors", mock.Anything).Return(sensors, nil)
+
+	result, err := service.ServiceGetAllSensors(context.Background())
+
+	assert.NoError(t, err)
+	if assert.Len(t, result, 1) && assert.NotNil(t, result[0].Capabilities) {
+		assert.Empty(t, *result[0].Capabilities)
+	}
+}
+
 func TestSensorService_ServiceGetAllSensors_Error(t *testing.T) {
 	service, sensorRepo, _, _, _ := setupSensorService()
 
@@ -438,6 +479,29 @@ func TestSensorService_ServiceGetSensorsByDriver_Success(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Len(t, result, 2)
+}
+
+func TestSensorService_ServiceGetSensorCapabilities_Success(t *testing.T) {
+	service, sensorRepo, _, _, _ := setupSensorService()
+
+	metadata := map[string]interface{}{
+		"exposes": json.RawMessage(`[
+			{"type":"binary","property":"state","name":"state","access":7,"value_on":"ON","value_off":"OFF"}
+		]`),
+	}
+	sensor := &gen.Sensor{
+		Id:           7,
+		Name:         "office-plug",
+		SensorDriver: "mqtt-zigbee2mqtt",
+		Metadata:     &metadata,
+	}
+	sensorRepo.On("GetSensorById", mock.Anything, 7).Return(sensor, nil)
+
+	capabilities, err := service.ServiceGetSensorCapabilities(context.Background(), 7)
+
+	assert.NoError(t, err)
+	assert.Len(t, capabilities, 1)
+	assert.Equal(t, "state", capabilities[0].Property)
 }
 
 // ============================================================================
@@ -511,7 +575,7 @@ func TestSensorService_ServiceSetEnabledSensorByName_Enable(t *testing.T) {
 	sensorRepo.On("GetAllSensors", mock.Anything).Return([]gen.Sensor{*sensor}, nil).Maybe()
 	sensorRepo.On("GetSensorByName", mock.Anything, "TestSensor").Return(sensor, nil).Maybe()
 	sensorRepo.On("UpdateSensorHealthById", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
-	readingsRepo.On("Add", mock.Anything,  mock.Anything).Return(nil).Maybe()
+	readingsRepo.On("Add", mock.Anything, mock.Anything).Return(nil).Maybe()
 	// The async collection triggers alert processing
 	alertRepo.On("GetAlertRuleForReading", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil).Maybe()
 

--- a/sensor_hub/testharness/client.go
+++ b/sensor_hub/testharness/client.go
@@ -244,6 +244,13 @@ func (c *Client) GetMeasurementTypesForSensor(sensorID int) (json.RawMessage, in
 	return c.consume(c.gen.GetSensorMeasurementTypes(c.ctx(), sensorID))
 }
 
+func (c *Client) GetSensorCapabilities(sensorID int) ([]gen.Capability, int) {
+	var result []gen.Capability
+	resp, err := c.gen.GetSensorCapabilities(c.ctx(), sensorID)
+	status := c.decodeInto(resp, err, &result)
+	return result, status
+}
+
 // --- Alerts ---
 
 func (c *Client) CreateAlertRule(rule gen.AlertRule) (json.RawMessage, int) {

--- a/sensor_hub/ui/sensor_hub_ui/src/gen/schema.d.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/gen/schema.d.ts
@@ -190,6 +190,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/sensors/by-id/{id}/capabilities": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get sensor capabilities by id
+         * @description Returns the controllable capabilities derived from the sensor's driver metadata. Sensors without writable features return an empty array.
+         */
+        get: operations["getSensorCapabilities"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/sensors/{name}": {
         parameters: {
             query?: never;
@@ -1731,6 +1751,34 @@ export interface components {
             timestamp: string;
             readings: components["schemas"]["Reading"][];
         };
+        /** @description A controllable property exposed by a driver. This is derived from driver metadata and is never user-configurable. */
+        Capability: {
+            /** @description Driver-level property name used when sending commands. */
+            property: string;
+            /**
+             * @description Capability kind.
+             * @enum {string}
+             */
+            type: "binary" | "numeric" | "enum";
+            /** @description Canonical "on" value for binary capabilities. */
+            value_on?: string;
+            /** @description Canonical "off" value for binary capabilities. */
+            value_off?: string;
+            /**
+             * Format: double
+             * @description Minimum allowed value for numeric capabilities.
+             */
+            min?: number;
+            /**
+             * Format: double
+             * @description Maximum allowed value for numeric capabilities.
+             */
+            max?: number;
+            /** @description Optional engineering unit for numeric capabilities. */
+            unit?: string;
+            /** @description Allowed values for enum capabilities. */
+            values?: string[];
+        };
         /**
          * @description Metadata for a sensor as returned by sensors endpoints and WebSocket snapshots.
          * @example {
@@ -1742,6 +1790,7 @@ export interface components {
          *         "url": "http://sensor.local/28-0000065f2ff3"
          *       },
          *       "metadata": {},
+         *       "capabilities": [],
          *       "health_status": "good",
          *       "health_reason": "ok",
          *       "enabled": true,
@@ -1767,6 +1816,8 @@ export interface components {
             readonly metadata?: {
                 [key: string]: unknown;
             };
+            /** @description Controllable properties for this sensor. Empty if the sensor is not controllable. Derived from driver metadata and ignored on create/update requests. */
+            readonly capabilities?: components["schemas"]["Capability"][];
             /** @description Health status ("good", "bad", or "unknown"). */
             health_status: components["schemas"]["SensorHealthStatus"];
             /** @description Optional short reason or message describing health state. */
@@ -2416,6 +2467,47 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Sensor not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    getSensorCapabilities: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Numeric database id of the sensor */
+                id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Capabilities for the sensor */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Capability"][];
                 };
             };
             /** @description Sensor not found */

--- a/sensor_hub/ui/sensor_hub_ui/vite.config.ts
+++ b/sensor_hub/ui/sensor_hub_ui/vite.config.ts
@@ -1,4 +1,6 @@
-import { defineConfig } from 'vitest/config';
+/// <reference types="vitest/config" />
+
+import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import fs from 'fs';
 import path from 'path';


### PR DESCRIPTION
## Summary
- add the command-capable driver interface and registry and parse Zigbee2MQTT writable capabilities from bridge/devices metadata
- expose derived capabilities on sensor responses and add a dedicated by-id capabilities endpoint
- cover the new behavior with driver, service, API, and integration tests

## Notes
- this uses GET /sensors/by-id/{id}/capabilities instead of /sensors/{id}/capabilities because the existing GET /sensors/{name} route makes the original path shape conflict in Gin

Closes #72