### PR TITLE
Add end-to-end sensor command sending

### DIFF
--- a/sensor_hub/api/mocks_test.go
+++ b/sensor_hub/api/mocks_test.go
@@ -5,6 +5,7 @@ import (
 	db "example/sensorHub/db"
 	gen "example/sensorHub/gen"
 	"example/sensorHub/notifications"
+	"example/sensorHub/service"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/mock"
 	"time"
@@ -299,6 +300,18 @@ func (m *MockSensorService) ServiceGetSensorByExternalId(ctx context.Context, ex
 func (m *MockSensorService) ServiceSensorExistsByExternalId(ctx context.Context, externalId string) (bool, error) {
 	args := m.Called(ctx, externalId)
 	return args.Bool(0), args.Error(1)
+}
+
+type MockCommandService struct {
+	mock.Mock
+}
+
+func (m *MockCommandService) Send(ctx context.Context, sensorID int, actor *gen.User, property string, value string) (service.SentCommandResult, error) {
+	args := m.Called(ctx, sensorID, actor, property, value)
+	if args.Get(0) == nil {
+		return service.SentCommandResult{}, args.Error(1)
+	}
+	return args.Get(0).(service.SentCommandResult), args.Error(1)
 }
 
 type MockPropertiesService struct {

--- a/sensor_hub/api/openapi.yaml
+++ b/sensor_hub/api/openapi.yaml
@@ -503,6 +503,75 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /sensors/{id}/command:
+    post:
+      tags:
+        - sensors
+      summary: Send a command to a controllable sensor
+      description: >-
+        Sends a single property command to a controllable sensor and returns the
+        persisted command record metadata once the MQTT publish has been issued.
+      operationId: sendSensorCommand
+      x-required-permission: control_sensors
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+          description: Numeric database id of the sensor
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SensorCommandRequest'
+      responses:
+        '202':
+          description: Command accepted and sent
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SensorCommandAccepted'
+        '400':
+          description: Invalid command request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Not authenticated
+        '403':
+          description: Insufficient permissions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Sensor not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: Sensor is not in a controllable state
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          description: A pending command already exists for this property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          description: MQTT broker unavailable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /sensors/{name}:
     get:
       tags:
@@ -3554,6 +3623,51 @@ components:
       required:
         - property
         - type
+
+    SensorCommandRequest:
+      type: object
+      description: Request body for sending a single command to a controllable sensor.
+      properties:
+        property:
+          type: string
+          description: Driver-level capability property to control.
+        value:
+          type: string
+          description: String form of the desired value. The driver converts this to the typed MQTT payload.
+      required:
+        - property
+        - value
+      example:
+        property: "state"
+        value: "ON"
+
+    SensorCommandAccepted:
+      type: object
+      description: Response body returned when a sensor command has been sent.
+      properties:
+        id:
+          type: integer
+          description: Internal identifier of the persisted command history row.
+        status:
+          type: string
+          enum: [sent]
+          description: Current command status.
+        property:
+          type: string
+          description: Driver-level capability property that was commanded.
+        value:
+          type: string
+          description: Original string value supplied in the request.
+      required:
+        - id
+        - status
+        - property
+        - value
+      example:
+        id: 42
+        status: "sent"
+        property: "state"
+        value: "ON"
 
     Sensor:
       type: object

--- a/sensor_hub/api/route_permissions.go
+++ b/sensor_hub/api/route_permissions.go
@@ -89,6 +89,7 @@ var routePermissions = map[string]string{
 	// Sensors
 	"GET /api/sensors":                             "view_sensors",
 	"POST /api/sensors":                            "manage_sensors",
+	"POST /api/sensors/:id/command":                "control_sensors",
 	"PUT /api/sensors/:id":                         "manage_sensors",
 	"DELETE /api/sensors/:name":                    "delete_sensors",
 	"GET /api/sensors/:name":                       "view_sensors",

--- a/sensor_hub/api/route_permissions_test.go
+++ b/sensor_hub/api/route_permissions_test.go
@@ -76,3 +76,25 @@ func TestRouteMiddleware_BlocksInsufficientPermission(t *testing.T) {
 
 	assert.Equal(t, http.StatusForbidden, w.Code)
 }
+
+func TestRouteMiddleware_BlocksInsufficientPermissionForSendSensorCommand(t *testing.T) {
+	mockAuth := &MockAuthService{}
+	middleware.InitAuthMiddleware(mockAuth)
+
+	userWithNoPerms := &gen.User{
+		Id:          1,
+		Username:    "testuser",
+		Roles:       []string{"viewer"},
+		Permissions: []string{},
+	}
+	mockAuth.On("ValidateSession", mock.Anything, "valid-token").Return(userWithNoPerms, nil)
+
+	router := setupGenRouter(&Server{authService: mockAuth})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/sensors/7/command", nil)
+	req.AddCookie(&http.Cookie{Name: "sensor_hub_session", Value: "valid-token"})
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}

--- a/sensor_hub/api/sensor_api.go
+++ b/sensor_hub/api/sensor_api.go
@@ -1,9 +1,11 @@
 package api
 
 import (
+	"errors"
 	appProps "example/sensorHub/application_properties"
 	"example/sensorHub/drivers"
 	gen "example/sensorHub/gen"
+	"example/sensorHub/service"
 	"example/sensorHub/ws"
 	"log/slog"
 	"net/http"
@@ -162,6 +164,51 @@ func (s *Server) GetSensorCapabilities(c *gin.Context, id int) {
 		capabilities = []gen.Capability{}
 	}
 	c.IndentedJSON(http.StatusOK, capabilities)
+}
+
+func (s *Server) SendSensorCommand(c *gin.Context, id int) {
+	if s.commandService == nil {
+		c.IndentedJSON(http.StatusServiceUnavailable, gin.H{"message": "Command service unavailable"})
+		return
+	}
+
+	var body struct {
+		Property string `json:"property"`
+		Value    string `json:"value"`
+	}
+	if err := c.BindJSON(&body); err != nil {
+		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid request body"})
+		return
+	}
+
+	currentUser, exists := c.Get("currentUser")
+	if !exists {
+		c.IndentedJSON(http.StatusUnauthorized, gin.H{"message": "Not authenticated"})
+		return
+	}
+	actor, ok := currentUser.(*gen.User)
+	if !ok || actor == nil {
+		c.IndentedJSON(http.StatusUnauthorized, gin.H{"message": "Not authenticated"})
+		return
+	}
+
+	result, err := s.commandService.Send(c.Request.Context(), id, actor, body.Property, body.Value)
+	if err != nil {
+		var commandErr *service.CommandError
+		if errors.As(err, &commandErr) {
+			c.IndentedJSON(commandErr.StatusCode, gin.H{"message": commandErr.Message})
+			return
+		}
+		c.IndentedJSON(http.StatusInternalServerError, gin.H{"message": "Error sending sensor command", "error": err.Error()})
+		return
+	}
+
+	c.IndentedJSON(http.StatusAccepted, gin.H{
+		"id":       result.ID,
+		"status":   result.Status,
+		"property": result.Property,
+		"value":    result.Value,
+	})
 }
 
 func (s *Server) GetAllSensors(c *gin.Context) {

--- a/sensor_hub/api/sensor_api_test.go
+++ b/sensor_hub/api/sensor_api_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	appProps "example/sensorHub/application_properties"
 	gen "example/sensorHub/gen"
+	servicepkg "example/sensorHub/service"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -285,6 +286,63 @@ func TestGetSensorCapabilitiesHandler_NotFound(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestSendSensorCommandHandler(t *testing.T) {
+	router, api, s, _ := setupSensorRouter()
+	mockCommandService := new(MockCommandService)
+	s.commandService = mockCommandService
+	api.POST("/sensors/:id/command", func(c *gin.Context) {
+		var id int
+		if _, err := fmt.Sscan(c.Param("id"), &id); err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid sensor ID"})
+			return
+		}
+		c.Set("currentUser", &gen.User{Id: 99, Permissions: []string{"control_sensors"}})
+		s.SendSensorCommand(c, id)
+	})
+
+	body := []byte(`{"property":"state","value":"ON"}`)
+	mockCommandService.On("Send", mock.Anything, 7, mock.AnythingOfType("*gen.User"), "state", "ON").Return(servicepkg.SentCommandResult{
+		ID:       42,
+		Status:   "sent",
+		Property: "state",
+		Value:    "ON",
+	}, nil)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/sensors/7/command", bytes.NewBuffer(body))
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusAccepted, w.Code)
+	assert.Contains(t, w.Body.String(), `"id": 42`)
+	assert.Contains(t, w.Body.String(), `"status": "sent"`)
+}
+
+func TestSendSensorCommandHandler_ServiceUnavailable(t *testing.T) {
+	router, api, s, _ := setupSensorRouter()
+	mockCommandService := new(MockCommandService)
+	s.commandService = mockCommandService
+	api.POST("/sensors/:id/command", func(c *gin.Context) {
+		var id int
+		if _, err := fmt.Sscan(c.Param("id"), &id); err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid sensor ID"})
+			return
+		}
+		c.Set("currentUser", &gen.User{Id: 99, Permissions: []string{"control_sensors"}})
+		s.SendSensorCommand(c, id)
+	})
+
+	body := []byte(`{"property":"state","value":"ON"}`)
+	mockCommandService.On("Send", mock.Anything, 7, mock.AnythingOfType("*gen.User"), "state", "ON").
+		Return(servicepkg.SentCommandResult{}, &servicepkg.CommandError{StatusCode: http.StatusServiceUnavailable, Message: "broker 12 is not connected"})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/sensors/7/command", bytes.NewBuffer(body))
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+	assert.Contains(t, w.Body.String(), "broker 12 is not connected")
 }
 
 func TestSensorExistsHandler(t *testing.T) {

--- a/sensor_hub/api/server.go
+++ b/sensor_hub/api/server.go
@@ -12,6 +12,7 @@ var _ gen.ServerInterface = (*Server)(nil)
 // Server holds all service dependencies for the API layer.
 type Server struct {
 	sensorService       service.SensorServiceInterface
+	commandService      service.CommandServiceInterface
 	readingsService     service.ReadingsServiceInterface
 	authService         service.AuthServiceInterface
 	userService         service.UserServiceInterface
@@ -29,6 +30,7 @@ type Server struct {
 // NewServer constructs a Server with all service dependencies.
 func NewServer(
 	sensorService service.SensorServiceInterface,
+	commandService service.CommandServiceInterface,
 	readingsService service.ReadingsServiceInterface,
 	authService service.AuthServiceInterface,
 	userService service.UserServiceInterface,
@@ -44,6 +46,7 @@ func NewServer(
 ) *Server {
 	return &Server{
 		sensorService:       sensorService,
+		commandService:      commandService,
 		readingsService:     readingsService,
 		authService:         authService,
 		userService:         userService,

--- a/sensor_hub/cmd/serve.go
+++ b/sensor_hub/cmd/serve.go
@@ -150,10 +150,12 @@ func runServe(cmd *cobra.Command, args []string) error {
 
 	mqttBrokerRepo := database.NewMQTTBrokerRepository(db, logger)
 	mqttSubRepo := database.NewMQTTSubscriptionRepository(db, logger)
+	commandHistoryRepo := database.NewSensorCommandHistoryRepository(db, logger)
 	mqttService := service.NewMQTTService(mqttBrokerRepo, mqttSubRepo, logger)
 
 	connManager := mqttBrokerPkg.NewConnectionManager(sensorService, mqttSubRepo, mqttBrokerRepo, logger)
 	mqttService.SetSubscriptionNotifier(connManager)
+	commandService := service.NewCommandService(sensorRepo, mqttSubRepo, commandHistoryRepo, connManager, logger)
 
 	middleware.InitAuthMiddleware(authService)
 	middleware.InitPermissionMiddleware(roleRepo)
@@ -198,6 +200,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 
 	server := api.NewServer(
 		sensorService,
+		commandService,
 		readingsService,
 		authService,
 		userService,

--- a/sensor_hub/db/internal_types.go
+++ b/sensor_hub/db/internal_types.go
@@ -9,6 +9,7 @@ import "time"
 const (
 	TableReadings               = "readings"
 	TableSensorHealthHistory    = "sensor_health_history"
+	TableSensorCommandHistory   = "sensor_command_history"
 	TableMeasurementTypes       = "measurement_types"
 	TableSensorMeasurementTypes = "sensor_measurement_types"
 	TableMQTTBrokers            = "mqtt_brokers"

--- a/sensor_hub/db/migrations/000018_sensor_command_history.down.sql
+++ b/sensor_hub/db/migrations/000018_sensor_command_history.down.sql
@@ -1,0 +1,11 @@
+DELETE FROM role_permissions
+WHERE permission_id IN (
+    SELECT id FROM permissions WHERE name = 'control_sensors'
+);
+
+DELETE FROM permissions
+WHERE name = 'control_sensors';
+
+DROP INDEX IF EXISTS idx_sensor_command_history_pending;
+DROP INDEX IF EXISTS idx_sensor_command_history_sensor_id;
+DROP TABLE IF EXISTS sensor_command_history;

--- a/sensor_hub/db/migrations/000018_sensor_command_history.up.sql
+++ b/sensor_hub/db/migrations/000018_sensor_command_history.up.sql
@@ -1,0 +1,31 @@
+CREATE TABLE sensor_command_history (
+    id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+    sensor_id          INTEGER NOT NULL REFERENCES sensors(id),
+    user_id            INTEGER REFERENCES users(id),
+    property           TEXT NOT NULL,
+    value              TEXT NOT NULL,
+    status             TEXT NOT NULL DEFAULT 'sent',
+    mqtt_topic         TEXT NOT NULL,
+    mqtt_payload       TEXT NOT NULL,
+    timeout_seconds    INTEGER NOT NULL DEFAULT 10,
+    sent_at            DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    acknowledged_at    DATETIME,
+    acknowledged_value TEXT NULL,
+    created_at         DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_sensor_command_history_sensor_id
+    ON sensor_command_history(sensor_id, sent_at DESC);
+
+CREATE INDEX idx_sensor_command_history_pending
+    ON sensor_command_history(sensor_id, property, sent_at DESC)
+    WHERE status = 'sent';
+
+INSERT OR IGNORE INTO permissions (name, description)
+VALUES ('control_sensors', 'Send commands to controllable sensors');
+
+INSERT OR IGNORE INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM roles r
+JOIN permissions p ON p.name = 'control_sensors'
+WHERE r.name IN ('admin', 'user');

--- a/sensor_hub/db/mqtt_repository_interfaces.go
+++ b/sensor_hub/db/mqtt_repository_interfaces.go
@@ -21,6 +21,7 @@ type MQTTSubscriptionRepositoryInterface interface {
 	GetAll(ctx context.Context) ([]gen.MQTTSubscription, error)
 	GetByBrokerID(ctx context.Context, brokerID int) ([]gen.MQTTSubscription, error)
 	GetEnabledByBrokerID(ctx context.Context, brokerID int) ([]gen.MQTTSubscription, error)
+	GetEnabledByDriverType(ctx context.Context, driverType string) (*gen.MQTTSubscription, error)
 	Update(ctx context.Context, sub gen.MQTTSubscription) error
 	Delete(ctx context.Context, id int) error
 }

--- a/sensor_hub/db/mqtt_subscription_repository.go
+++ b/sensor_hub/db/mqtt_subscription_repository.go
@@ -124,6 +124,42 @@ func (r *MQTTSubscriptionRepository) GetEnabledByBrokerID(ctx context.Context, b
 	return subs, nil
 }
 
+func (r *MQTTSubscriptionRepository) GetEnabledByDriverType(ctx context.Context, driverType string) (*gen.MQTTSubscription, error) {
+	query := `SELECT id, broker_id, topic_pattern, driver_type, enabled, created_at, updated_at
+		FROM mqtt_subscriptions WHERE driver_type = ? AND enabled = 1 ORDER BY id LIMIT 1`
+	sub, err := scanSubscriptionRow(r.db.QueryRowContext(ctx, query, driverType))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("error querying enabled MQTT subscription by driver type: %w", err)
+	}
+	return &sub, nil
+}
+
+func (r *MQTTSubscriptionRepository) ListEnabledByDriverType(ctx context.Context, driverType string) ([]gen.MQTTSubscription, error) {
+	query := `SELECT id, broker_id, topic_pattern, driver_type, enabled, created_at, updated_at
+		FROM mqtt_subscriptions WHERE driver_type = ? AND enabled = 1 ORDER BY id`
+	rows, err := r.db.QueryContext(ctx, query, driverType)
+	if err != nil {
+		return nil, fmt.Errorf("error querying enabled MQTT subscriptions by driver type: %w", err)
+	}
+	defer rows.Close()
+
+	var subs []gen.MQTTSubscription
+	for rows.Next() {
+		sub, err := scanSubscriptionRow(rows)
+		if err != nil {
+			return nil, fmt.Errorf("error scanning MQTT subscription row: %w", err)
+		}
+		subs = append(subs, sub)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating over MQTT subscription rows: %w", err)
+	}
+	return subs, nil
+}
+
 func (r *MQTTSubscriptionRepository) Update(ctx context.Context, sub gen.MQTTSubscription) error {
 	query := `UPDATE mqtt_subscriptions SET broker_id = ?, topic_pattern = ?, driver_type = ?,
 		enabled = ?, updated_at = datetime('now') WHERE id = ?`

--- a/sensor_hub/db/mqtt_subscription_repository_test.go
+++ b/sensor_hub/db/mqtt_subscription_repository_test.go
@@ -159,6 +159,36 @@ func TestMQTTSubscriptionRepository_GetEnabledByBrokerID_Success(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestMQTTSubscriptionRepository_GetEnabledByDriverType_Success(t *testing.T) {
+	db, mock := newMockDB(t)
+	repo := NewMQTTSubscriptionRepository(db, slog.Default())
+
+	mock.ExpectQuery("SELECT .+ FROM mqtt_subscriptions WHERE driver_type = \\? AND enabled = 1 ORDER BY id LIMIT 1").
+		WithArgs("mqtt-zigbee2mqtt").
+		WillReturnRows(sqlmock.NewRows(subscriptionColumns).
+			AddRow(3, 12, "zigbee2mqtt/+", "mqtt-zigbee2mqtt", true, "2025-01-01 00:00:00", "2025-01-01 00:00:00"))
+
+	sub, err := repo.GetEnabledByDriverType(context.Background(), "mqtt-zigbee2mqtt")
+	assert.NoError(t, err)
+	require.NotNil(t, sub)
+	assert.Equal(t, 12, sub.BrokerId)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestMQTTSubscriptionRepository_GetEnabledByDriverType_NotFound(t *testing.T) {
+	db, mock := newMockDB(t)
+	repo := NewMQTTSubscriptionRepository(db, slog.Default())
+
+	mock.ExpectQuery("SELECT .+ FROM mqtt_subscriptions WHERE driver_type = \\? AND enabled = 1 ORDER BY id LIMIT 1").
+		WithArgs("mqtt-zigbee2mqtt").
+		WillReturnError(sql.ErrNoRows)
+
+	sub, err := repo.GetEnabledByDriverType(context.Background(), "mqtt-zigbee2mqtt")
+	assert.NoError(t, err)
+	assert.Nil(t, sub)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
 // ============================================================================
 // Update tests
 // ============================================================================

--- a/sensor_hub/db/sensor_command_history_repository.go
+++ b/sensor_hub/db/sensor_command_history_repository.go
@@ -1,0 +1,49 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"time"
+)
+
+type SensorCommandHistoryRepository struct {
+	db     *sql.DB
+	logger *slog.Logger
+}
+
+func NewSensorCommandHistoryRepository(db *sql.DB, logger *slog.Logger) *SensorCommandHistoryRepository {
+	return &SensorCommandHistoryRepository{db: db, logger: logger.With("component", "sensor_command_history_repository")}
+}
+
+func (r *SensorCommandHistoryRepository) AddSentCommand(ctx context.Context, sensorID int, userID *int, property string, value string, mqttTopic string, mqttPayload string, timeoutSeconds int, sentAt time.Time) (int, error) {
+	var userIDValue any
+	if userID != nil {
+		userIDValue = *userID
+	}
+
+	query := `INSERT INTO sensor_command_history
+		(sensor_id, user_id, property, value, status, mqtt_topic, mqtt_payload, timeout_seconds, sent_at)
+		VALUES (?, ?, ?, ?, 'sent', ?, ?, ?, ?)`
+	result, err := r.db.ExecContext(ctx, query, sensorID, userIDValue, property, value, mqttTopic, mqttPayload, timeoutSeconds, sentAt)
+	if err != nil {
+		return 0, fmt.Errorf("error inserting sensor command history: %w", err)
+	}
+
+	id, err := result.LastInsertId()
+	if err != nil {
+		return 0, fmt.Errorf("error reading sensor command history insert id: %w", err)
+	}
+
+	return int(id), nil
+}
+
+func (r *SensorCommandHistoryRepository) HasPendingCommand(ctx context.Context, sensorID int, property string) (bool, error) {
+	query := `SELECT COUNT(1) FROM sensor_command_history WHERE sensor_id = ? AND property = ? AND status = 'sent'`
+	var count int
+	if err := r.db.QueryRowContext(ctx, query, sensorID, property).Scan(&count); err != nil {
+		return false, fmt.Errorf("error querying pending sensor commands: %w", err)
+	}
+	return count > 0, nil
+}

--- a/sensor_hub/db/sensor_command_history_repository_test.go
+++ b/sensor_hub/db/sensor_command_history_repository_test.go
@@ -1,0 +1,56 @@
+package database
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSensorCommandHistoryRepository_AddSentCommand_Success(t *testing.T) {
+	db, mock := newMockDB(t)
+	repo := NewSensorCommandHistoryRepository(db, slog.Default())
+	userID := 99
+	sentAt := time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC)
+
+	mock.ExpectExec("INSERT INTO sensor_command_history").
+		WithArgs(7, &userID, "state", "ON", "zigbee2mqtt/office-plug/set", `{"state":"ON"}`, 10, sentAt).
+		WillReturnResult(sqlmock.NewResult(42, 1))
+
+	id, err := repo.AddSentCommand(context.Background(), 7, &userID, "state", "ON", "zigbee2mqtt/office-plug/set", `{"state":"ON"}`, 10, sentAt)
+	assert.NoError(t, err)
+	assert.Equal(t, 42, id)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSensorCommandHistoryRepository_HasPendingCommand_ReturnsTrue(t *testing.T) {
+	db, mock := newMockDB(t)
+	repo := NewSensorCommandHistoryRepository(db, slog.Default())
+
+	mock.ExpectQuery("SELECT COUNT\\(1\\) FROM sensor_command_history WHERE sensor_id = \\? AND property = \\? AND status = 'sent'").
+		WithArgs(7, "state").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+
+	hasPending, err := repo.HasPendingCommand(context.Background(), 7, "state")
+	assert.NoError(t, err)
+	assert.True(t, hasPending)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSensorCommandHistoryRepository_AddSentCommand_DBError(t *testing.T) {
+	db, mock := newMockDB(t)
+	repo := NewSensorCommandHistoryRepository(db, slog.Default())
+
+	mock.ExpectExec("INSERT INTO sensor_command_history").
+		WithArgs(7, nil, "state", "ON", "zigbee2mqtt/office-plug/set", `{"state":"ON"}`, 10, sqlmock.AnyArg()).
+		WillReturnError(errors.New("write failed"))
+
+	_, err := repo.AddSentCommand(context.Background(), 7, nil, "state", "ON", "zigbee2mqtt/office-plug/set", `{"state":"ON"}`, 10, time.Now().UTC())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "error inserting sensor command history")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}

--- a/sensor_hub/db/sensor_repository.go
+++ b/sensor_hub/db/sensor_repository.go
@@ -151,6 +151,11 @@ func (s *SensorRepository) DeleteSensorByName(ctx context.Context, name string) 
 	if err != nil {
 		return fmt.Errorf("error purging sensor health history for sensor ID %d: %w", sensorId, err)
 	}
+	commandHistoryPurgeQuery := fmt.Sprintf("DELETE FROM %s WHERE sensor_id = ?", TableSensorCommandHistory)
+	_, err = txn.Exec(commandHistoryPurgeQuery, sensorId)
+	if err != nil {
+		return fmt.Errorf("error purging sensor command history for sensor ID %d: %w", sensorId, err)
+	}
 
 	query := "DELETE FROM sensors WHERE LOWER(name) = LOWER(?)"
 	result, err := txn.Exec(query, name)

--- a/sensor_hub/db/sensor_repository_test.go
+++ b/sensor_hub/db/sensor_repository_test.go
@@ -711,6 +711,11 @@ func TestSensorRepository_DeleteSensorByName_Success(t *testing.T) {
 		WithArgs(1).
 		WillReturnResult(sqlmock.NewResult(0, 3))
 
+	// Purge command history
+	mock.ExpectExec("DELETE FROM sensor_command_history WHERE sensor_id = \\?").
+		WithArgs(1).
+		WillReturnResult(sqlmock.NewResult(0, 2))
+
 	// Delete sensor
 	mock.ExpectExec("DELETE FROM sensors WHERE LOWER\\(name\\) = LOWER\\(\\?\\)").
 		WithArgs("test-sensor").
@@ -781,6 +786,10 @@ func TestSensorRepository_DeleteSensorByName_NoRowsDeleted(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(0, 0))
 
 	mock.ExpectExec("DELETE FROM sensor_health_history WHERE sensor_id = \\?").
+		WithArgs(1).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	mock.ExpectExec("DELETE FROM sensor_command_history WHERE sensor_id = \\?").
 		WithArgs(1).
 		WillReturnResult(sqlmock.NewResult(0, 0))
 

--- a/sensor_hub/drivers/zigbee2mqtt.go
+++ b/sensor_hub/drivers/zigbee2mqtt.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -199,8 +200,125 @@ func (d *Zigbee2MQTTDriver) ParseCapabilities(metadata json.RawMessage) []gen.Ca
 	return capabilities
 }
 
-func (d *Zigbee2MQTTDriver) BuildCommand(_ gen.Sensor, _ string, _ string) (string, []byte, error) {
-	return "", nil, fmt.Errorf("build command not implemented")
+func (d *Zigbee2MQTTDriver) BuildCommand(sensor gen.Sensor, property string, value string) (string, []byte, error) {
+	capabilities, err := d.capabilitiesForSensor(sensor)
+	if err != nil {
+		return "", nil, err
+	}
+
+	capability, ok := findCapability(capabilities, property)
+	if !ok {
+		return "", nil, fmt.Errorf("unknown command property %q", property)
+	}
+
+	typedValue, err := commandPayloadValue(capability, value)
+	if err != nil {
+		return "", nil, err
+	}
+
+	payload, err := json.Marshal(map[string]any{property: typedValue})
+	if err != nil {
+		return "", nil, fmt.Errorf("marshal command payload: %w", err)
+	}
+
+	return fmt.Sprintf("zigbee2mqtt/%s/set", sensor.Name), payload, nil
+}
+
+func (d *Zigbee2MQTTDriver) capabilitiesForSensor(sensor gen.Sensor) ([]gen.Capability, error) {
+	if sensor.Metadata == nil {
+		return nil, fmt.Errorf("sensor metadata is required for command building")
+	}
+
+	exposesValue, ok := (*sensor.Metadata)["exposes"]
+	if !ok || exposesValue == nil {
+		return nil, fmt.Errorf("sensor exposes metadata is required for command building")
+	}
+
+	exposesJSON, err := json.Marshal(exposesValue)
+	if err != nil {
+		return nil, fmt.Errorf("marshal sensor exposes metadata: %w", err)
+	}
+
+	capabilities := d.ParseCapabilities(exposesJSON)
+	if len(capabilities) == 0 {
+		return nil, fmt.Errorf("sensor has no writable capabilities")
+	}
+
+	return capabilities, nil
+}
+
+func findCapability(capabilities []gen.Capability, property string) (gen.Capability, bool) {
+	for _, capability := range capabilities {
+		if capability.Property == property {
+			return capability, true
+		}
+	}
+	return gen.Capability{}, false
+}
+
+func commandPayloadValue(capability gen.Capability, value string) (any, error) {
+	switch capability.Type {
+	case gen.CapabilityTypeBinary:
+		return binaryCommandPayloadValue(capability, value)
+	case gen.CapabilityTypeNumeric:
+		return numericCommandPayloadValue(value)
+	case gen.CapabilityTypeEnum:
+		if capability.Values != nil {
+			for _, allowed := range *capability.Values {
+				if allowed == value {
+					return value, nil
+				}
+			}
+			return nil, fmt.Errorf("invalid enum value %q for property %q", value, capability.Property)
+		}
+		return value, nil
+	default:
+		return nil, fmt.Errorf("unsupported capability type %q", capability.Type)
+	}
+}
+
+func binaryCommandPayloadValue(capability gen.Capability, value string) (any, error) {
+	valueOn := "ON"
+	valueOff := "OFF"
+	if capability.ValueOn != nil {
+		valueOn = *capability.ValueOn
+	}
+	if capability.ValueOff != nil {
+		valueOff = *capability.ValueOff
+	}
+
+	switch {
+	case strings.EqualFold(value, valueOn):
+		return canonicalBinaryPayloadValue(valueOn, true), nil
+	case strings.EqualFold(value, valueOff):
+		return canonicalBinaryPayloadValue(valueOff, false), nil
+	default:
+		return nil, fmt.Errorf("invalid binary value %q for property %q", value, capability.Property)
+	}
+}
+
+func canonicalBinaryPayloadValue(canonical string, state bool) any {
+	switch strings.ToLower(strings.TrimSpace(canonical)) {
+	case "true", "false":
+		return state
+	default:
+		return canonical
+	}
+}
+
+func numericCommandPayloadValue(value string) (any, error) {
+	if !strings.ContainsAny(value, ".eE") {
+		if integerValue, err := strconv.ParseInt(value, 10, 64); err == nil {
+			return integerValue, nil
+		}
+	}
+
+	floatValue, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid numeric value %q", value)
+	}
+
+	return floatValue, nil
 }
 
 func parseCapabilityExpose(expose zigbeeCapabilityExpose) []gen.Capability {

--- a/sensor_hub/drivers/zigbee2mqtt_test.go
+++ b/sensor_hub/drivers/zigbee2mqtt_test.go
@@ -381,6 +381,100 @@ func TestParseCapabilities_MalformedExposes(t *testing.T) {
 	assert.Nil(t, capabilities)
 }
 
+func TestBuildCommand_State(t *testing.T) {
+	d := &Zigbee2MQTTDriver{}
+	sensor := gen.Sensor{
+		Name: "office-plug",
+		Metadata: &map[string]interface{}{
+			"exposes": []interface{}{
+				map[string]interface{}{
+					"type":      "binary",
+					"property":  "state",
+					"access":    float64(7),
+					"value_on":  "ON",
+					"value_off": "OFF",
+				},
+			},
+		},
+	}
+
+	topic, payload, err := d.BuildCommand(sensor, "state", "ON")
+
+	require.NoError(t, err)
+	assert.Equal(t, "zigbee2mqtt/office-plug/set", topic)
+	assert.JSONEq(t, `{"state":"ON"}`, string(payload))
+}
+
+func TestBuildCommand_UnknownProperty(t *testing.T) {
+	d := &Zigbee2MQTTDriver{}
+	sensor := gen.Sensor{
+		Name: "office-plug",
+		Metadata: &map[string]interface{}{
+			"exposes": []interface{}{
+				map[string]interface{}{
+					"type":      "binary",
+					"property":  "state",
+					"access":    float64(7),
+					"value_on":  "ON",
+					"value_off": "OFF",
+				},
+			},
+		},
+	}
+
+	_, _, err := d.BuildCommand(sensor, "brightness", "100")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `unknown command property "brightness"`)
+}
+
+func TestBuildCommand_NumericCapability(t *testing.T) {
+	d := &Zigbee2MQTTDriver{}
+	sensor := gen.Sensor{
+		Name: "office-light",
+		Metadata: &map[string]interface{}{
+			"exposes": []interface{}{
+				map[string]interface{}{
+					"type":      "numeric",
+					"property":  "brightness",
+					"access":    float64(7),
+					"value_min": float64(0),
+					"value_max": float64(100),
+				},
+			},
+		},
+	}
+
+	topic, payload, err := d.BuildCommand(sensor, "brightness", "42")
+
+	require.NoError(t, err)
+	assert.Equal(t, "zigbee2mqtt/office-light/set", topic)
+	assert.JSONEq(t, `{"brightness":42}`, string(payload))
+}
+
+func TestBuildCommand_BooleanBinaryCapability(t *testing.T) {
+	d := &Zigbee2MQTTDriver{}
+	sensor := gen.Sensor{
+		Name: "hallway-light",
+		Metadata: &map[string]interface{}{
+			"exposes": []interface{}{
+				map[string]interface{}{
+					"type":      "binary",
+					"property":  "state",
+					"access":    float64(7),
+					"value_on":  "true",
+					"value_off": "false",
+				},
+			},
+		},
+	}
+
+	_, payload, err := d.BuildCommand(sensor, "state", "true")
+
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"state":true}`, string(payload))
+}
+
 func TestZigbee2MQTT_SupportedMeasurementTypes(t *testing.T) {
 	d := &Zigbee2MQTTDriver{}
 	mts := d.SupportedMeasurementTypes()

--- a/sensor_hub/gen/client.gen.go
+++ b/sensor_hub/gen/client.gen.go
@@ -364,6 +364,11 @@ type ClientInterface interface {
 
 	UpdateSensorById(ctx context.Context, id int, body UpdateSensorByIdJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// SendSensorCommandWithBody request with any body
+	SendSensorCommandWithBody(ctx context.Context, id int, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	SendSensorCommand(ctx context.Context, id int, body SendSensorCommandJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// DeleteSensorByName request
 	DeleteSensorByName(ctx context.Context, name string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -1554,6 +1559,30 @@ func (c *Client) UpdateSensorByIdWithBody(ctx context.Context, id int, contentTy
 
 func (c *Client) UpdateSensorById(ctx context.Context, id int, body UpdateSensorByIdJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewUpdateSensorByIdRequest(c.Server, id, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) SendSensorCommandWithBody(ctx context.Context, id int, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSendSensorCommandRequestWithBody(c.Server, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) SendSensorCommand(ctx context.Context, id int, body SendSensorCommandJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSendSensorCommandRequest(c.Server, id, body)
 	if err != nil {
 		return nil, err
 	}
@@ -4611,6 +4640,53 @@ func NewUpdateSensorByIdRequestWithBody(server string, id int, contentType strin
 	return req, nil
 }
 
+// NewSendSensorCommandRequest calls the generic SendSensorCommand builder with application/json body
+func NewSendSensorCommandRequest(server string, id int, body SendSensorCommandJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewSendSensorCommandRequestWithBody(server, id, "application/json", bodyReader)
+}
+
+// NewSendSensorCommandRequestWithBody generates requests for SendSensorCommand with any type of body
+func NewSendSensorCommandRequestWithBody(server string, id int, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "integer", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/sensors/%s/command", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewDeleteSensorByNameRequest generates requests for DeleteSensorByName
 func NewDeleteSensorByNameRequest(server string, name string) (*http.Request, error) {
 	var err error
@@ -5263,6 +5339,11 @@ type ClientWithResponsesInterface interface {
 	UpdateSensorByIdWithBodyWithResponse(ctx context.Context, id int, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateSensorByIdResp, error)
 
 	UpdateSensorByIdWithResponse(ctx context.Context, id int, body UpdateSensorByIdJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateSensorByIdResp, error)
+
+	// SendSensorCommandWithBodyWithResponse request with any body
+	SendSensorCommandWithBodyWithResponse(ctx context.Context, id int, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SendSensorCommandResp, error)
+
+	SendSensorCommandWithResponse(ctx context.Context, id int, body SendSensorCommandJSONRequestBody, reqEditors ...RequestEditorFn) (*SendSensorCommandResp, error)
 
 	// DeleteSensorByNameWithResponse request
 	DeleteSensorByNameWithResponse(ctx context.Context, name string, reqEditors ...RequestEditorFn) (*DeleteSensorByNameResp, error)
@@ -7122,6 +7203,34 @@ func (r UpdateSensorByIdResp) StatusCode() int {
 	return 0
 }
 
+type SendSensorCommandResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON202      *SensorCommandAccepted
+	JSON400      *ErrorResponse
+	JSON403      *ErrorResponse
+	JSON404      *ErrorResponse
+	JSON409      *ErrorResponse
+	JSON429      *ErrorResponse
+	JSON503      *ErrorResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r SendSensorCommandResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r SendSensorCommandResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type DeleteSensorByNameResp struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -8187,6 +8296,23 @@ func (c *ClientWithResponses) UpdateSensorByIdWithResponse(ctx context.Context, 
 		return nil, err
 	}
 	return ParseUpdateSensorByIdResp(rsp)
+}
+
+// SendSensorCommandWithBodyWithResponse request with arbitrary body returning *SendSensorCommandResp
+func (c *ClientWithResponses) SendSensorCommandWithBodyWithResponse(ctx context.Context, id int, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SendSensorCommandResp, error) {
+	rsp, err := c.SendSensorCommandWithBody(ctx, id, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSendSensorCommandResp(rsp)
+}
+
+func (c *ClientWithResponses) SendSensorCommandWithResponse(ctx context.Context, id int, body SendSensorCommandJSONRequestBody, reqEditors ...RequestEditorFn) (*SendSensorCommandResp, error) {
+	rsp, err := c.SendSensorCommand(ctx, id, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSendSensorCommandResp(rsp)
 }
 
 // DeleteSensorByNameWithResponse request returning *DeleteSensorByNameResp
@@ -10842,6 +10968,74 @@ func ParseUpdateSensorByIdResp(rsp *http.Response) (*UpdateSensorByIdResp, error
 			return nil, err
 		}
 		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseSendSensorCommandResp parses an HTTP response from a SendSensorCommandWithResponse call
+func ParseSendSensorCommandResp(rsp *http.Response) (*SendSensorCommandResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &SendSensorCommandResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 202:
+		var dest SensorCommandAccepted
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON202 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 429:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON429 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON503 = &dest
 
 	}
 

--- a/sensor_hub/gen/server.gen.go
+++ b/sensor_hub/gen/server.gen.go
@@ -250,6 +250,9 @@ type ServerInterface interface {
 	// Update an existing sensor by id
 	// (PUT /sensors/{id})
 	UpdateSensorById(c *gin.Context, id int)
+	// Send a command to a controllable sensor
+	// (POST /sensors/{id}/command)
+	SendSensorCommand(c *gin.Context, id int)
 	// Delete sensor by name
 	// (DELETE /sensors/{name})
 	DeleteSensorByName(c *gin.Context, name string)
@@ -2338,6 +2341,36 @@ func (siw *ServerInterfaceWrapper) UpdateSensorById(c *gin.Context) {
 	siw.Handler.UpdateSensorById(c, id)
 }
 
+// SendSensorCommand operation middleware
+func (siw *ServerInterfaceWrapper) SendSensorCommand(c *gin.Context) {
+
+	var err error
+
+	// ------------- Path parameter "id" -------------
+	var id int
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", c.Param("id"), &id, runtime.BindStyledParameterOptions{Explode: false, Required: true, Type: "integer", Format: ""})
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter id: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	c.Set(CookieAuthScopes, []string{})
+
+	c.Set(CsrfTokenScopes, []string{})
+
+	c.Set(ApiKeyAuthScopes, []string{})
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		middleware(c)
+		if c.IsAborted() {
+			return
+		}
+	}
+
+	siw.Handler.SendSensorCommand(c, id)
+}
+
 // DeleteSensorByName operation middleware
 func (siw *ServerInterfaceWrapper) DeleteSensorByName(c *gin.Context) {
 
@@ -2681,6 +2714,7 @@ func RegisterHandlersWithOptions(router gin.IRouter, si ServerInterface, options
 	router.GET(options.BaseURL+"/sensors/ws", wrapper.SubscribeAllSensors)
 	router.GET(options.BaseURL+"/sensors/ws/:driver", wrapper.SubscribeSensorsByDriver)
 	router.PUT(options.BaseURL+"/sensors/:id", wrapper.UpdateSensorById)
+	router.POST(options.BaseURL+"/sensors/:id/command", wrapper.SendSensorCommand)
 	router.DELETE(options.BaseURL+"/sensors/:name", wrapper.DeleteSensorByName)
 	router.GET(options.BaseURL+"/sensors/:name", wrapper.GetSensorByName)
 	router.HEAD(options.BaseURL+"/sensors/:name", wrapper.SensorExists)

--- a/sensor_hub/gen/types.gen.go
+++ b/sensor_hub/gen/types.gen.go
@@ -211,6 +211,21 @@ func (e SensorStatus) Valid() bool {
 	}
 }
 
+// Defines values for SensorCommandAcceptedStatus.
+const (
+	Sent SensorCommandAcceptedStatus = "sent"
+)
+
+// Valid indicates whether the value is a known member of the SensorCommandAcceptedStatus enum.
+func (e SensorCommandAcceptedStatus) Valid() bool {
+	switch e {
+	case Sent:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for SensorHealthStatus.
 const (
 	Bad     SensorHealthStatus = "bad"
@@ -847,6 +862,33 @@ type Sensor struct {
 // SensorStatus Lifecycle status. Push-based sensors start as "pending" until approved. "dismissed" sensors are hidden but can be restored.
 type SensorStatus string
 
+// SensorCommandAccepted Response body returned when a sensor command has been sent.
+type SensorCommandAccepted struct {
+	// Id Internal identifier of the persisted command history row.
+	Id int `json:"id"`
+
+	// Property Driver-level capability property that was commanded.
+	Property string `json:"property"`
+
+	// Status Current command status.
+	Status SensorCommandAcceptedStatus `json:"status"`
+
+	// Value Original string value supplied in the request.
+	Value string `json:"value"`
+}
+
+// SensorCommandAcceptedStatus Current command status.
+type SensorCommandAcceptedStatus string
+
+// SensorCommandRequest Request body for sending a single command to a controllable sensor.
+type SensorCommandRequest struct {
+	// Property Driver-level capability property to control.
+	Property string `json:"property"`
+
+	// Value String form of the desired value. The driver converts this to the typed MQTT payload.
+	Value string `json:"value"`
+}
+
 // SensorHealthHistory Historical health check record for a sensor.
 type SensorHealthHistory struct {
 	// HealthStatus Enum matching types.SensorHealthStatus in Go.
@@ -1087,6 +1129,9 @@ type AddSensorJSONRequestBody = Sensor
 
 // UpdateSensorByIdJSONRequestBody defines body for UpdateSensorById for application/json ContentType.
 type UpdateSensorByIdJSONRequestBody = Sensor
+
+// SendSensorCommandJSONRequestBody defines body for SendSensorCommand for application/json ContentType.
+type SendSensorCommandJSONRequestBody = SensorCommandRequest
 
 // CreateUserJSONRequestBody defines body for CreateUser for application/json ContentType.
 type CreateUserJSONRequestBody = CreateUserRequest

--- a/sensor_hub/integration/sensor_command_test.go
+++ b/sensor_hub/integration/sensor_command_test.go
@@ -1,0 +1,220 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"testing"
+	"time"
+
+	database "example/sensorHub/db"
+	gen "example/sensorHub/gen"
+	mqttpkg "example/sensorHub/mqtt"
+	"example/sensorHub/testharness"
+
+	pahomqtt "github.com/eclipse/paho.mqtt.golang"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type commandFixture struct {
+	port     int
+	brokerID int
+	subID    int
+	sensor   gen.Sensor
+	stop     func()
+}
+
+func TestSendSensorCommand_PublishesAndPersistsSentCommand(t *testing.T) {
+	fixture := setupCommandFixture(t, fmt.Sprintf("office-plug-%d", reserveTCPPort(t)))
+	defer fixture.stop()
+
+	subscriber := pahomqtt.NewClient(
+		pahomqtt.NewClientOptions().
+			AddBroker(fmt.Sprintf("tcp://127.0.0.1:%d", fixture.port)).
+			SetClientID(fmt.Sprintf("integration-command-subscriber-%d", fixture.port)),
+	)
+	token := subscriber.Connect()
+	require.True(t, token.WaitTimeout(5*time.Second))
+	require.NoError(t, token.Error())
+	defer subscriber.Disconnect(250)
+
+	messageCh := make(chan pahomqtt.Message, 1)
+	token = subscriber.Subscribe(fmt.Sprintf("zigbee2mqtt/%s/set", fixture.sensor.Name), 1, func(_ pahomqtt.Client, msg pahomqtt.Message) {
+		messageCh <- msg
+	})
+	require.True(t, token.WaitTimeout(5*time.Second))
+	require.NoError(t, token.Error())
+
+	result, status := client.SendSensorCommand(fixture.sensor.Id, "state", "ON")
+	require.Equal(t, http.StatusAccepted, status)
+	assert.Equal(t, "state", result.Property)
+	assert.Equal(t, "ON", result.Value)
+	assert.Equal(t, gen.Sent, result.Status)
+	assert.NotZero(t, result.Id)
+
+	select {
+	case msg := <-messageCh:
+		assert.Equal(t, fmt.Sprintf("zigbee2mqtt/%s/set", fixture.sensor.Name), msg.Topic())
+		assert.JSONEq(t, `{"state":"ON"}`, string(msg.Payload()))
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for published command")
+	}
+
+	adminUserID := lookupUserID(t, env.AdminUser)
+
+	var userID int
+	var property, value, statusValue, mqttTopic, mqttPayload string
+	require.NoError(t, env.DB.QueryRow(`
+		SELECT user_id, property, value, status, mqtt_topic, mqtt_payload
+		FROM sensor_command_history
+		WHERE id = ?
+	`, result.Id).Scan(&userID, &property, &value, &statusValue, &mqttTopic, &mqttPayload))
+
+	assert.Equal(t, adminUserID, userID)
+	assert.Equal(t, "state", property)
+	assert.Equal(t, "ON", value)
+	assert.Equal(t, "sent", statusValue)
+	assert.Equal(t, fmt.Sprintf("zigbee2mqtt/%s/set", fixture.sensor.Name), mqttTopic)
+	assert.JSONEq(t, `{"state":"ON"}`, mqttPayload)
+}
+
+func TestSendSensorCommand_ViewerGetsForbidden(t *testing.T) {
+	fixture := setupCommandFixture(t, fmt.Sprintf("viewer-plug-%d", reserveTCPPort(t)))
+	defer fixture.stop()
+
+	_, status := client.CreateUser(gen.CreateUserRequest{
+		Username: fmt.Sprintf("command-viewer-%d", fixture.port),
+		Password: "viewerpass123",
+		Email:    ptrStr(fmt.Sprintf("command-viewer-%d@test.com", fixture.port)),
+		Roles:    &[]string{"viewer"},
+	})
+	require.Equal(t, http.StatusCreated, status)
+
+	viewer := testharness.NewClient(t, env.ServerURL)
+	require.Equal(t, http.StatusOK, viewer.Login(fmt.Sprintf("command-viewer-%d", fixture.port), "viewerpass123"))
+	require.Equal(t, http.StatusOK, viewer.ChangePassword("viewerpass123"))
+
+	_, status = viewer.SendSensorCommand(fixture.sensor.Id, "state", "ON")
+	assert.Equal(t, http.StatusForbidden, status)
+}
+
+func TestSendSensorCommand_BrokerDisconnectedReturnsServiceUnavailable(t *testing.T) {
+	fixture := setupCommandFixture(t, fmt.Sprintf("disconnected-plug-%d", reserveTCPPort(t)))
+	defer fixture.stop()
+
+	env.ConnectionManager.DisconnectBroker(fixture.brokerID)
+	require.Eventually(t, func() bool {
+		return !env.ConnectionManager.IsConnected(fixture.brokerID)
+	}, 5*time.Second, 100*time.Millisecond)
+
+	_, status := client.SendSensorCommand(fixture.sensor.Id, "state", "ON")
+	assert.Equal(t, http.StatusServiceUnavailable, status)
+}
+
+func TestSendSensorCommand_DisabledSensorReturnsConflict(t *testing.T) {
+	fixture := setupCommandFixture(t, fmt.Sprintf("disabled-plug-%d", reserveTCPPort(t)))
+	defer fixture.stop()
+
+	require.Equal(t, http.StatusOK, client.DisableSensor(fixture.sensor.Name))
+
+	_, status := client.SendSensorCommand(fixture.sensor.Id, "state", "ON")
+	assert.Equal(t, http.StatusConflict, status)
+}
+
+func setupCommandFixture(t *testing.T, sensorName string) commandFixture {
+	t.Helper()
+
+	ctx := context.Background()
+	logger := slog.Default()
+	port := reserveTCPPort(t)
+
+	embeddedBroker := mqttpkg.NewEmbeddedBroker(mqttpkg.BrokerConfig{
+		TCPAddress: fmt.Sprintf(":%d", port),
+	}, logger)
+	require.NoError(t, embeddedBroker.Start())
+
+	brokerRepo := database.NewMQTTBrokerRepository(env.DB, logger)
+	subRepo := database.NewMQTTSubscriptionRepository(env.DB, logger)
+	sensorRepo := database.NewSensorRepository(env.DB, logger)
+
+	brokerID, err := brokerRepo.Add(ctx, gen.MQTTBroker{
+		Name:    fmt.Sprintf("integration-command-broker-%d", port),
+		Host:    "127.0.0.1",
+		Port:    port,
+		Type:    "external",
+		Enabled: true,
+	})
+	require.NoError(t, err)
+
+	subID, err := subRepo.Add(ctx, gen.MQTTSubscription{
+		BrokerId:     brokerID,
+		TopicPattern: "zigbee2mqtt/#",
+		DriverType:   "mqtt-zigbee2mqtt",
+		Enabled:      true,
+	})
+	require.NoError(t, err)
+
+	metadata := map[string]interface{}{
+		"exposes": []interface{}{
+			map[string]interface{}{
+				"type":      "binary",
+				"property":  "state",
+				"access":    float64(7),
+				"value_on":  "ON",
+				"value_off": "OFF",
+			},
+		},
+	}
+	require.NoError(t, sensorRepo.AddSensor(ctx, gen.Sensor{
+		Name:         sensorName,
+		SensorDriver: "mqtt-zigbee2mqtt",
+		Status:       gen.SensorStatusActive,
+		Config:       map[string]string{},
+		Metadata:     &metadata,
+	}))
+
+	sensor, err := sensorRepo.GetSensorByName(ctx, sensorName)
+	require.NoError(t, err)
+	require.NotNil(t, sensor)
+
+	broker := gen.MQTTBroker{
+		Id:      &brokerID,
+		Name:    fmt.Sprintf("integration-command-broker-%d", port),
+		Host:    "127.0.0.1",
+		Port:    port,
+		Type:    "external",
+		Enabled: true,
+	}
+	require.NoError(t, env.ConnectionManager.ConnectBroker(ctx, broker))
+	require.Eventually(t, func() bool {
+		return env.ConnectionManager.IsConnected(brokerID)
+	}, 5*time.Second, 100*time.Millisecond)
+
+	stop := func() {
+		env.ConnectionManager.DisconnectBroker(brokerID)
+		_ = sensorRepo.DeleteSensorByName(ctx, sensorName)
+		_ = subRepo.Delete(ctx, subID)
+		_ = brokerRepo.Delete(ctx, brokerID)
+		require.NoError(t, embeddedBroker.Stop())
+	}
+
+	return commandFixture{
+		port:     port,
+		brokerID: brokerID,
+		subID:    subID,
+		sensor:   *sensor,
+		stop:     stop,
+	}
+}
+
+func lookupUserID(t *testing.T, username string) int {
+	t.Helper()
+
+	var id int
+	require.NoError(t, env.DB.QueryRow(`SELECT id FROM users WHERE username = ?`, username).Scan(&id))
+	return id
+}

--- a/sensor_hub/mqtt/connection_manager.go
+++ b/sensor_hub/mqtt/connection_manager.go
@@ -567,6 +567,22 @@ func (cm *ConnectionManager) OnSubscriptionRemoved(sub gen.MQTTSubscription) {
 	cm.logger.Info("unsubscribed from MQTT topic", "topic", sub.TopicPattern)
 }
 
+func (cm *ConnectionManager) Publish(brokerID int, topic string, payload []byte, qos byte) error {
+	cm.mu.RLock()
+	conn, ok := cm.connections[brokerID]
+	cm.mu.RUnlock()
+	if !ok || !conn.Client.IsConnected() {
+		return fmt.Errorf("broker %d is not connected", brokerID)
+	}
+
+	token := conn.Client.Publish(topic, qos, false, payload)
+	if token.WaitTimeout(5*time.Second) && token.Error() != nil {
+		return fmt.Errorf("publish to broker %d failed: %w", brokerID, token.Error())
+	}
+
+	return nil
+}
+
 // IsConnected returns whether a broker connection is currently active.
 func (cm *ConnectionManager) IsConnected(brokerID int) bool {
 	cm.mu.RLock()

--- a/sensor_hub/mqtt/connection_manager_test.go
+++ b/sensor_hub/mqtt/connection_manager_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 // ============================================================================
@@ -169,6 +170,13 @@ func (m *MockSubRepo) GetEnabledByBrokerID(ctx context.Context, brokerID int) ([
 	args := m.Called(ctx, brokerID)
 	return args.Get(0).([]gen.MQTTSubscription), args.Error(1)
 }
+func (m *MockSubRepo) GetEnabledByDriverType(ctx context.Context, driverType string) (*gen.MQTTSubscription, error) {
+	args := m.Called(ctx, driverType)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*gen.MQTTSubscription), args.Error(1)
+}
 func (m *MockSubRepo) Update(ctx context.Context, sub gen.MQTTSubscription) error {
 	return m.Called(ctx, sub).Error(0)
 }
@@ -287,6 +295,15 @@ func TestConnectionManager_HandleMessage_KnownSensor(t *testing.T) {
 	cm.handleMessage(context.Background(), 1, "test-push-driver", "test/topic", []byte(`{}`))
 
 	mockSensor.AssertExpectations(t)
+}
+
+func TestConnectionManager_Publish_ReturnsErrorWhenBrokerNotConnected(t *testing.T) {
+	cm := NewConnectionManager(&MockSensorService{}, &MockSubRepo{}, &MockBrokerRepo{}, slog.Default())
+
+	err := cm.Publish(42, "zigbee2mqtt/office-plug/set", []byte(`{"state":"ON"}`), 1)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "broker 42 is not connected")
 }
 
 func TestConnectionManager_HandleMessage_AutoDiscovery(t *testing.T) {

--- a/sensor_hub/service/command_service.go
+++ b/sensor_hub/service/command_service.go
@@ -1,0 +1,159 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"example/sensorHub/drivers"
+	gen "example/sensorHub/gen"
+)
+
+const (
+	defaultCommandTimeoutSeconds = 10
+	commandPublishQOS            = 1
+)
+
+type CommandSensorRepository interface {
+	GetSensorById(ctx context.Context, id int) (*gen.Sensor, error)
+}
+
+type CommandSubscriptionRepository interface {
+	ListEnabledByDriverType(ctx context.Context, driverType string) ([]gen.MQTTSubscription, error)
+}
+
+type CommandHistoryRepository interface {
+	HasPendingCommand(ctx context.Context, sensorID int, property string) (bool, error)
+	AddSentCommand(ctx context.Context, sensorID int, userID *int, property string, value string, mqttTopic string, mqttPayload string, timeoutSeconds int, sentAt time.Time) (int, error)
+}
+
+type CommandPublisher interface {
+	Publish(brokerID int, topic string, payload []byte, qos byte) error
+}
+
+type SentCommandResult struct {
+	ID       int
+	Status   string
+	Property string
+	Value    string
+}
+
+type CommandError struct {
+	StatusCode int
+	Message    string
+}
+
+func (e *CommandError) Error() string {
+	return e.Message
+}
+
+func newCommandError(statusCode int, message string) *CommandError {
+	return &CommandError{StatusCode: statusCode, Message: message}
+}
+
+type CommandService struct {
+	sensorRepo  CommandSensorRepository
+	subRepo     CommandSubscriptionRepository
+	historyRepo CommandHistoryRepository
+	publisher   CommandPublisher
+	logger      *slog.Logger
+}
+
+func NewCommandService(sensorRepo CommandSensorRepository, subRepo CommandSubscriptionRepository, historyRepo CommandHistoryRepository, publisher CommandPublisher, logger *slog.Logger) *CommandService {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &CommandService{
+		sensorRepo:  sensorRepo,
+		subRepo:     subRepo,
+		historyRepo: historyRepo,
+		publisher:   publisher,
+		logger:      logger.With("component", "command_service"),
+	}
+}
+
+func (s *CommandService) Send(ctx context.Context, sensorID int, actor *gen.User, property string, value string) (SentCommandResult, error) {
+	sensor, err := s.sensorRepo.GetSensorById(ctx, sensorID)
+	if err != nil || sensor == nil {
+		if err != nil {
+			return SentCommandResult{}, newCommandError(http.StatusNotFound, fmt.Sprintf("sensor %d not found", sensorID))
+		}
+		return SentCommandResult{}, newCommandError(http.StatusNotFound, fmt.Sprintf("sensor %d not found", sensorID))
+	}
+
+	if actor == nil || !hasPermission(actor.Permissions, "control_sensors") {
+		return SentCommandResult{}, newCommandError(http.StatusForbidden, "missing control_sensors permission")
+	}
+
+	commandDriver, ok := drivers.GetCommandDriver(sensor.SensorDriver)
+	if !ok {
+		return SentCommandResult{}, newCommandError(http.StatusBadRequest, fmt.Sprintf("sensor %d is not controllable", sensorID))
+	}
+
+	if !sensor.Enabled || sensor.Status != gen.SensorStatusActive {
+		return SentCommandResult{}, newCommandError(http.StatusConflict, fmt.Sprintf("sensor %d is not in a controllable state", sensorID))
+	}
+
+	topic, payload, err := commandDriver.BuildCommand(*sensor, property, value)
+	if err != nil {
+		return SentCommandResult{}, newCommandError(http.StatusBadRequest, err.Error())
+	}
+
+	hasPending, err := s.historyRepo.HasPendingCommand(ctx, sensor.Id, property)
+	if err != nil {
+		return SentCommandResult{}, fmt.Errorf("check pending command: %w", err)
+	}
+	if hasPending {
+		return SentCommandResult{}, newCommandError(http.StatusTooManyRequests, fmt.Sprintf("sensor %d already has a pending command for property %q", sensorID, property))
+	}
+
+	subscriptions, err := s.subRepo.ListEnabledByDriverType(ctx, sensor.SensorDriver)
+	if err != nil {
+		return SentCommandResult{}, fmt.Errorf("lookup MQTT subscriptions: %w", err)
+	}
+	if len(subscriptions) == 0 {
+		return SentCommandResult{}, newCommandError(http.StatusServiceUnavailable, fmt.Sprintf("no enabled MQTT subscription for driver %q", sensor.SensorDriver))
+	}
+
+	var lastDisconnectedErr error
+	for _, subscription := range subscriptions {
+		if err := s.publisher.Publish(subscription.BrokerId, topic, payload, commandPublishQOS); err != nil {
+			if strings.Contains(err.Error(), "not connected") {
+				lastDisconnectedErr = err
+				continue
+			}
+			return SentCommandResult{}, fmt.Errorf("publish command: %w", err)
+		}
+		lastDisconnectedErr = nil
+		break
+	}
+	if lastDisconnectedErr != nil {
+		return SentCommandResult{}, newCommandError(http.StatusServiceUnavailable, lastDisconnectedErr.Error())
+	}
+
+	sentAt := time.Now().UTC()
+	userID := actor.Id
+	commandID, err := s.historyRepo.AddSentCommand(ctx, sensor.Id, &userID, property, value, topic, string(payload), defaultCommandTimeoutSeconds, sentAt)
+	if err != nil {
+		return SentCommandResult{}, fmt.Errorf("persist sent command: %w", err)
+	}
+
+	return SentCommandResult{
+		ID:       commandID,
+		Status:   "sent",
+		Property: property,
+		Value:    value,
+	}, nil
+}
+
+func hasPermission(permissions []string, required string) bool {
+	for _, permission := range permissions {
+		if strings.EqualFold(permission, required) {
+			return true
+		}
+	}
+	return false
+}

--- a/sensor_hub/service/command_service_interface.go
+++ b/sensor_hub/service/command_service_interface.go
@@ -1,0 +1,11 @@
+package service
+
+import (
+	"context"
+
+	gen "example/sensorHub/gen"
+)
+
+type CommandServiceInterface interface {
+	Send(ctx context.Context, sensorID int, actor *gen.User, property string, value string) (SentCommandResult, error)
+}

--- a/sensor_hub/service/command_service_test.go
+++ b/sensor_hub/service/command_service_test.go
@@ -1,0 +1,356 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	gen "example/sensorHub/gen"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+type mockCommandSensorRepository struct{ mock.Mock }
+
+func (m *mockCommandSensorRepository) GetSensorById(ctx context.Context, id int) (*gen.Sensor, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*gen.Sensor), args.Error(1)
+}
+
+type mockCommandSubscriptionRepository struct{ mock.Mock }
+
+func (m *mockCommandSubscriptionRepository) ListEnabledByDriverType(ctx context.Context, driverType string) ([]gen.MQTTSubscription, error) {
+	args := m.Called(ctx, driverType)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]gen.MQTTSubscription), args.Error(1)
+}
+
+type mockCommandHistoryRepository struct{ mock.Mock }
+
+func (m *mockCommandHistoryRepository) HasPendingCommand(ctx context.Context, sensorID int, property string) (bool, error) {
+	args := m.Called(ctx, sensorID, property)
+	return args.Bool(0), args.Error(1)
+}
+
+func (m *mockCommandHistoryRepository) AddSentCommand(ctx context.Context, sensorID int, userID *int, property string, value string, mqttTopic string, mqttPayload string, timeoutSeconds int, sentAt time.Time) (int, error) {
+	args := m.Called(ctx, sensorID, userID, property, value, mqttTopic, mqttPayload, timeoutSeconds, sentAt)
+	return args.Int(0), args.Error(1)
+}
+
+type mockCommandPublisher struct{ mock.Mock }
+
+func (m *mockCommandPublisher) Publish(brokerID int, topic string, payload []byte, qos byte) error {
+	return m.Called(brokerID, topic, payload, qos).Error(0)
+}
+
+func TestCommandService_Send_PublishesAndPersistsSentCommand(t *testing.T) {
+	sensorRepo := &mockCommandSensorRepository{}
+	subRepo := &mockCommandSubscriptionRepository{}
+	historyRepo := &mockCommandHistoryRepository{}
+	publisher := &mockCommandPublisher{}
+	svc := NewCommandService(sensorRepo, subRepo, historyRepo, publisher, nil)
+
+	sensor := &gen.Sensor{
+		Id:           7,
+		Name:         "office-plug",
+		SensorDriver: "mqtt-zigbee2mqtt",
+		Status:       gen.SensorStatusActive,
+		Enabled:      true,
+		Metadata: &map[string]interface{}{
+			"exposes": []interface{}{
+				map[string]interface{}{
+					"type":      "binary",
+					"property":  "state",
+					"access":    float64(7),
+					"value_on":  "ON",
+					"value_off": "OFF",
+				},
+			},
+		},
+	}
+	userID := 99
+	actor := &gen.User{Id: userID, Permissions: []string{"control_sensors"}}
+	sub := gen.MQTTSubscription{BrokerId: 12, DriverType: "mqtt-zigbee2mqtt", Enabled: true}
+
+	sensorRepo.On("GetSensorById", mock.Anything, 7).Return(sensor, nil)
+	subRepo.On("ListEnabledByDriverType", mock.Anything, "mqtt-zigbee2mqtt").Return([]gen.MQTTSubscription{sub}, nil)
+	historyRepo.On("HasPendingCommand", mock.Anything, 7, "state").Return(false, nil)
+	publisher.On("Publish", 12, "zigbee2mqtt/office-plug/set", []byte(`{"state":"ON"}`), byte(1)).Return(nil)
+	historyRepo.On("AddSentCommand",
+		mock.Anything,
+		7,
+		&userID,
+		"state",
+		"ON",
+		"zigbee2mqtt/office-plug/set",
+		`{"state":"ON"}`,
+		10,
+		mock.AnythingOfType("time.Time"),
+	).Return(42, nil)
+
+	result, err := svc.Send(context.Background(), 7, actor, "state", "ON")
+
+	require.NoError(t, err)
+	assert.Equal(t, SentCommandResult{
+		ID:       42,
+		Status:   "sent",
+		Property: "state",
+		Value:    "ON",
+	}, result)
+}
+
+func TestCommandService_Send_InsufficientPermission(t *testing.T) {
+	sensorRepo := &mockCommandSensorRepository{}
+	subRepo := &mockCommandSubscriptionRepository{}
+	historyRepo := &mockCommandHistoryRepository{}
+	publisher := &mockCommandPublisher{}
+	svc := NewCommandService(sensorRepo, subRepo, historyRepo, publisher, nil)
+
+	sensorRepo.On("GetSensorById", mock.Anything, 7).Return(&gen.Sensor{
+		Id:           7,
+		Name:         "office-plug",
+		SensorDriver: "mqtt-zigbee2mqtt",
+		Status:       gen.SensorStatusActive,
+		Enabled:      true,
+	}, nil)
+
+	_, err := svc.Send(context.Background(), 7, &gen.User{Id: 5, Permissions: []string{"view_sensors"}}, "state", "ON")
+
+	var commandErr *CommandError
+	require.ErrorAs(t, err, &commandErr)
+	assert.Equal(t, http.StatusForbidden, commandErr.StatusCode)
+}
+
+func TestCommandService_Send_NotControllable(t *testing.T) {
+	sensorRepo := &mockCommandSensorRepository{}
+	subRepo := &mockCommandSubscriptionRepository{}
+	historyRepo := &mockCommandHistoryRepository{}
+	publisher := &mockCommandPublisher{}
+	svc := NewCommandService(sensorRepo, subRepo, historyRepo, publisher, nil)
+
+	sensorRepo.On("GetSensorById", mock.Anything, 7).Return(&gen.Sensor{
+		Id:           7,
+		Name:         "living-room",
+		SensorDriver: "sensor-hub-http-temperature",
+		Status:       gen.SensorStatusActive,
+		Enabled:      true,
+	}, nil)
+
+	_, err := svc.Send(context.Background(), 7, &gen.User{Id: 5, Permissions: []string{"control_sensors"}}, "state", "ON")
+
+	var commandErr *CommandError
+	require.ErrorAs(t, err, &commandErr)
+	assert.Equal(t, http.StatusBadRequest, commandErr.StatusCode)
+}
+
+func TestCommandService_Send_SensorPending(t *testing.T) {
+	sensorRepo := &mockCommandSensorRepository{}
+	subRepo := &mockCommandSubscriptionRepository{}
+	historyRepo := &mockCommandHistoryRepository{}
+	publisher := &mockCommandPublisher{}
+	svc := NewCommandService(sensorRepo, subRepo, historyRepo, publisher, nil)
+
+	sensorRepo.On("GetSensorById", mock.Anything, 7).Return(&gen.Sensor{
+		Id:           7,
+		Name:         "office-plug",
+		SensorDriver: "mqtt-zigbee2mqtt",
+		Status:       gen.SensorStatusPending,
+		Enabled:      true,
+	}, nil)
+
+	_, err := svc.Send(context.Background(), 7, &gen.User{Id: 5, Permissions: []string{"control_sensors"}}, "state", "ON")
+
+	var commandErr *CommandError
+	require.ErrorAs(t, err, &commandErr)
+	assert.Equal(t, http.StatusConflict, commandErr.StatusCode)
+}
+
+func TestCommandService_Send_SensorDisabled(t *testing.T) {
+	sensorRepo := &mockCommandSensorRepository{}
+	subRepo := &mockCommandSubscriptionRepository{}
+	historyRepo := &mockCommandHistoryRepository{}
+	publisher := &mockCommandPublisher{}
+	svc := NewCommandService(sensorRepo, subRepo, historyRepo, publisher, nil)
+
+	sensorRepo.On("GetSensorById", mock.Anything, 7).Return(&gen.Sensor{
+		Id:           7,
+		Name:         "office-plug",
+		SensorDriver: "mqtt-zigbee2mqtt",
+		Status:       gen.SensorStatusActive,
+		Enabled:      false,
+	}, nil)
+
+	_, err := svc.Send(context.Background(), 7, &gen.User{Id: 5, Permissions: []string{"control_sensors"}}, "state", "ON")
+
+	var commandErr *CommandError
+	require.ErrorAs(t, err, &commandErr)
+	assert.Equal(t, http.StatusConflict, commandErr.StatusCode)
+}
+
+func TestCommandService_Send_InvalidValue(t *testing.T) {
+	sensorRepo := &mockCommandSensorRepository{}
+	subRepo := &mockCommandSubscriptionRepository{}
+	historyRepo := &mockCommandHistoryRepository{}
+	publisher := &mockCommandPublisher{}
+	svc := NewCommandService(sensorRepo, subRepo, historyRepo, publisher, nil)
+
+	sensorRepo.On("GetSensorById", mock.Anything, 7).Return(&gen.Sensor{
+		Id:           7,
+		Name:         "office-plug",
+		SensorDriver: "mqtt-zigbee2mqtt",
+		Status:       gen.SensorStatusActive,
+		Enabled:      true,
+		Metadata: &map[string]interface{}{
+			"exposes": []interface{}{
+				map[string]interface{}{
+					"type":      "binary",
+					"property":  "state",
+					"access":    float64(7),
+					"value_on":  "ON",
+					"value_off": "OFF",
+				},
+			},
+		},
+	}, nil)
+
+	_, err := svc.Send(context.Background(), 7, &gen.User{Id: 5, Permissions: []string{"control_sensors"}}, "state", "INVALID")
+
+	var commandErr *CommandError
+	require.ErrorAs(t, err, &commandErr)
+	assert.Equal(t, http.StatusBadRequest, commandErr.StatusCode)
+}
+
+func TestCommandService_Send_DuplicatePendingCommand(t *testing.T) {
+	sensorRepo := &mockCommandSensorRepository{}
+	subRepo := &mockCommandSubscriptionRepository{}
+	historyRepo := &mockCommandHistoryRepository{}
+	publisher := &mockCommandPublisher{}
+	svc := NewCommandService(sensorRepo, subRepo, historyRepo, publisher, nil)
+
+	sensorRepo.On("GetSensorById", mock.Anything, 7).Return(&gen.Sensor{
+		Id:           7,
+		Name:         "office-plug",
+		SensorDriver: "mqtt-zigbee2mqtt",
+		Status:       gen.SensorStatusActive,
+		Enabled:      true,
+		Metadata: &map[string]interface{}{
+			"exposes": []interface{}{
+				map[string]interface{}{
+					"type":      "binary",
+					"property":  "state",
+					"access":    float64(7),
+					"value_on":  "ON",
+					"value_off": "OFF",
+				},
+			},
+		},
+	}, nil)
+	historyRepo.On("HasPendingCommand", mock.Anything, 7, "state").Return(true, nil)
+
+	_, err := svc.Send(context.Background(), 7, &gen.User{Id: 5, Permissions: []string{"control_sensors"}}, "state", "ON")
+
+	var commandErr *CommandError
+	require.ErrorAs(t, err, &commandErr)
+	assert.Equal(t, http.StatusTooManyRequests, commandErr.StatusCode)
+}
+
+func TestCommandService_Send_BrokerDisconnected(t *testing.T) {
+	sensorRepo := &mockCommandSensorRepository{}
+	subRepo := &mockCommandSubscriptionRepository{}
+	historyRepo := &mockCommandHistoryRepository{}
+	publisher := &mockCommandPublisher{}
+	svc := NewCommandService(sensorRepo, subRepo, historyRepo, publisher, nil)
+
+	sensorRepo.On("GetSensorById", mock.Anything, 7).Return(&gen.Sensor{
+		Id:           7,
+		Name:         "office-plug",
+		SensorDriver: "mqtt-zigbee2mqtt",
+		Status:       gen.SensorStatusActive,
+		Enabled:      true,
+		Metadata: &map[string]interface{}{
+			"exposes": []interface{}{
+				map[string]interface{}{
+					"type":      "binary",
+					"property":  "state",
+					"access":    float64(7),
+					"value_on":  "ON",
+					"value_off": "OFF",
+				},
+			},
+		},
+	}, nil)
+	subRepo.On("ListEnabledByDriverType", mock.Anything, "mqtt-zigbee2mqtt").Return([]gen.MQTTSubscription{{
+		BrokerId:   12,
+		DriverType: "mqtt-zigbee2mqtt",
+		Enabled:    true,
+	}}, nil)
+	historyRepo.On("HasPendingCommand", mock.Anything, 7, "state").Return(false, nil)
+	publisher.On("Publish", 12, "zigbee2mqtt/office-plug/set", []byte(`{"state":"ON"}`), byte(1)).Return(errors.New("broker 12 is not connected"))
+
+	_, err := svc.Send(context.Background(), 7, &gen.User{Id: 5, Permissions: []string{"control_sensors"}}, "state", "ON")
+
+	var commandErr *CommandError
+	require.ErrorAs(t, err, &commandErr)
+	assert.Equal(t, http.StatusServiceUnavailable, commandErr.StatusCode)
+}
+
+func TestCommandService_Send_SkipsDisconnectedSubscriptionAndPublishesToNext(t *testing.T) {
+	sensorRepo := &mockCommandSensorRepository{}
+	subRepo := &mockCommandSubscriptionRepository{}
+	historyRepo := &mockCommandHistoryRepository{}
+	publisher := &mockCommandPublisher{}
+	svc := NewCommandService(sensorRepo, subRepo, historyRepo, publisher, nil)
+
+	sensorRepo.On("GetSensorById", mock.Anything, 7).Return(&gen.Sensor{
+		Id:           7,
+		Name:         "office-plug",
+		SensorDriver: "mqtt-zigbee2mqtt",
+		Status:       gen.SensorStatusActive,
+		Enabled:      true,
+		Metadata: &map[string]interface{}{
+			"exposes": []interface{}{
+				map[string]interface{}{
+					"type":      "binary",
+					"property":  "state",
+					"access":    float64(7),
+					"value_on":  "ON",
+					"value_off": "OFF",
+				},
+			},
+		},
+	}, nil)
+	subRepo.On("ListEnabledByDriverType", mock.Anything, "mqtt-zigbee2mqtt").Return([]gen.MQTTSubscription{
+		{BrokerId: 12, DriverType: "mqtt-zigbee2mqtt", Enabled: true},
+		{BrokerId: 18, DriverType: "mqtt-zigbee2mqtt", Enabled: true},
+	}, nil)
+	historyRepo.On("HasPendingCommand", mock.Anything, 7, "state").Return(false, nil)
+	publisher.On("Publish", 12, "zigbee2mqtt/office-plug/set", []byte(`{"state":"ON"}`), byte(1)).Return(errors.New("broker 12 is not connected"))
+	publisher.On("Publish", 18, "zigbee2mqtt/office-plug/set", []byte(`{"state":"ON"}`), byte(1)).Return(nil)
+	userID := 5
+	historyRepo.On("AddSentCommand",
+		mock.Anything,
+		7,
+		&userID,
+		"state",
+		"ON",
+		"zigbee2mqtt/office-plug/set",
+		`{"state":"ON"}`,
+		10,
+		mock.AnythingOfType("time.Time"),
+	).Return(42, nil)
+
+	result, err := svc.Send(context.Background(), 7, &gen.User{Id: userID, Permissions: []string{"control_sensors"}}, "state", "ON")
+
+	require.NoError(t, err)
+	assert.Equal(t, 42, result.ID)
+	assert.Equal(t, "sent", result.Status)
+}

--- a/sensor_hub/service/mqtt_service_test.go
+++ b/sensor_hub/service/mqtt_service_test.go
@@ -77,6 +77,13 @@ func (m *MockMQTTSubRepo) GetEnabledByBrokerID(ctx context.Context, brokerID int
 	args := m.Called(ctx, brokerID)
 	return args.Get(0).([]gen.MQTTSubscription), args.Error(1)
 }
+func (m *MockMQTTSubRepo) GetEnabledByDriverType(ctx context.Context, driverType string) (*gen.MQTTSubscription, error) {
+	args := m.Called(ctx, driverType)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*gen.MQTTSubscription), args.Error(1)
+}
 func (m *MockMQTTSubRepo) Update(ctx context.Context, sub gen.MQTTSubscription) error {
 	return m.Called(ctx, sub).Error(0)
 }

--- a/sensor_hub/testharness/client.go
+++ b/sensor_hub/testharness/client.go
@@ -251,6 +251,16 @@ func (c *Client) GetSensorCapabilities(sensorID int) ([]gen.Capability, int) {
 	return result, status
 }
 
+func (c *Client) SendSensorCommand(sensorID int, property, value string) (gen.SensorCommandAccepted, int) {
+	var result gen.SensorCommandAccepted
+	resp, err := c.gen.SendSensorCommand(c.ctx(), sensorID, gen.SendSensorCommandJSONRequestBody{
+		Property: property,
+		Value:    value,
+	})
+	status := c.decodeInto(resp, err, &result)
+	return result, status
+}
+
 // --- Alerts ---
 
 func (c *Client) CreateAlertRule(rule gen.AlertRule) (json.RawMessage, int) {

--- a/sensor_hub/testharness/harness.go
+++ b/sensor_hub/testharness/harness.go
@@ -19,6 +19,7 @@ import (
 	database "example/sensorHub/db"
 	_ "example/sensorHub/drivers" // register sensor drivers
 	gen "example/sensorHub/gen"
+	mqttpkg "example/sensorHub/mqtt"
 	"example/sensorHub/notifications"
 	"example/sensorHub/service"
 	"example/sensorHub/smtp"
@@ -29,10 +30,11 @@ import (
 
 // Env holds references to the running test server and its components.
 type Env struct {
-	ServerURL string
-	AdminUser string
-	AdminPass string
-	DB        *sql.DB
+	ServerURL         string
+	AdminUser         string
+	AdminPass         string
+	DB                *sql.DB
+	ConnectionManager *mqttpkg.ConnectionManager
 }
 
 const (
@@ -151,10 +153,15 @@ func startServer(sensorURLs []string) (*Env, func(), error) {
 
 	mqttBrokerRepo := database.NewMQTTBrokerRepository(db, logger)
 	mqttSubRepo := database.NewMQTTSubscriptionRepository(db, logger)
+	commandHistoryRepo := database.NewSensorCommandHistoryRepository(db, logger)
 	mqttService := service.NewMQTTService(mqttBrokerRepo, mqttSubRepo, logger)
+	connManager := mqttpkg.NewConnectionManager(sensorService, mqttSubRepo, mqttBrokerRepo, logger)
+	mqttService.SetSubscriptionNotifier(connManager)
+	commandService := service.NewCommandService(sensorRepo, mqttSubRepo, commandHistoryRepo, connManager, logger)
 
 	server := api.NewServer(
 		sensorService,
+		commandService,
 		readingsService,
 		authService,
 		userService,
@@ -166,7 +173,7 @@ func startServer(sensorURLs []string) (*Env, func(), error) {
 		propertiesService,
 		mqttService,
 		nil, // no OAuth in tests
-		nil, // no MQTT stats provider in tests
+		connManager,
 	)
 
 	// Build Gin router (mirrors api.go without TLS/OTEL/CORS/SPA)
@@ -196,6 +203,7 @@ func startServer(sensorURLs []string) (*Env, func(), error) {
 	cleanup := func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
+		connManager.Stop()
 		srv.Shutdown(ctx)
 		db.Close()
 		cleanupDir()
@@ -207,11 +215,17 @@ func startServer(sensorURLs []string) (*Env, func(), error) {
 		return nil, func() {}, fmt.Errorf("failed to create admin user: %w", err)
 	}
 
+	if err := connManager.Start(context.Background()); err != nil {
+		cleanup()
+		return nil, func() {}, fmt.Errorf("failed to start mqtt connection manager: %w", err)
+	}
+
 	return &Env{
 		ServerURL: serverURL,
 		AdminUser: DefaultAdminUser,
 		AdminPass: DefaultAdminPass,
 		DB:        db,
+		ConnectionManager: connManager,
 	}, cleanup, nil
 }
 

--- a/sensor_hub/ui/sensor_hub_ui/src/gen/schema.d.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/gen/schema.d.ts
@@ -210,6 +210,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/sensors/{id}/command": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Send a command to a controllable sensor
+         * @description Sends a single property command to a controllable sensor and returns the persisted command record metadata once the MQTT publish has been issued.
+         */
+        post: operations["sendSensorCommand"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/sensors/{name}": {
         parameters: {
             query?: never;
@@ -1780,6 +1800,41 @@ export interface components {
             values?: string[];
         };
         /**
+         * @description Request body for sending a single command to a controllable sensor.
+         * @example {
+         *       "property": "state",
+         *       "value": "ON"
+         *     }
+         */
+        SensorCommandRequest: {
+            /** @description Driver-level capability property to control. */
+            property: string;
+            /** @description String form of the desired value. The driver converts this to the typed MQTT payload. */
+            value: string;
+        };
+        /**
+         * @description Response body returned when a sensor command has been sent.
+         * @example {
+         *       "id": 42,
+         *       "status": "sent",
+         *       "property": "state",
+         *       "value": "ON"
+         *     }
+         */
+        SensorCommandAccepted: {
+            /** @description Internal identifier of the persisted command history row. */
+            id: number;
+            /**
+             * @description Current command status.
+             * @enum {string}
+             */
+            status: "sent";
+            /** @description Driver-level capability property that was commanded. */
+            property: string;
+            /** @description Original string value supplied in the request. */
+            value: string;
+        };
+        /**
          * @description Metadata for a sensor as returned by sensors endpoints and WebSocket snapshots.
          * @example {
          *       "id": 1,
@@ -2521,6 +2576,94 @@ export interface operations {
             };
             /** @description Server error */
             500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    sendSensorCommand: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Numeric database id of the sensor */
+                id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SensorCommandRequest"];
+            };
+        };
+        responses: {
+            /** @description Command accepted and sent */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SensorCommandAccepted"];
+                };
+            };
+            /** @description Invalid command request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Not authenticated */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Insufficient permissions */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Sensor not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Sensor is not in a controllable state */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description A pending command already exists for this property */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description MQTT broker unavailable */
+            503: {
                 headers: {
                     [name: string]: unknown;
                 };


### PR DESCRIPTION
## Summary
- add the first POST /api/sensors/:id/command flow with command history persistence and service validation
- build and publish Zigbee2MQTT commands through the live MQTT connection manager
- cover the command path with unit tests, route tests, and end-to-end integration tests

## Testing
- cd sensor_hub && go test ./...
- cd sensor_hub && go test -tags integration -v -timeout 300s ./integration/
- cd sensor_hub/ui/sensor_hub_ui && npm run build

Closes #73
Related to #14