### PR TITLE
Add sensor command history API

### DIFF
--- a/sensor_hub/api/mocks_test.go
+++ b/sensor_hub/api/mocks_test.go
@@ -306,6 +306,14 @@ type MockCommandService struct {
 	mock.Mock
 }
 
+func (m *MockCommandService) GetHistory(ctx context.Context, sensorID int) ([]gen.CommandHistoryEntry, error) {
+	args := m.Called(ctx, sensorID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]gen.CommandHistoryEntry), args.Error(1)
+}
+
 func (m *MockCommandService) Send(ctx context.Context, sensorID int, actor *gen.User, property string, value string) (service.SentCommandResult, error) {
 	args := m.Called(ctx, sensorID, actor, property, value)
 	if args.Get(0) == nil {

--- a/sensor_hub/api/openapi.yaml
+++ b/sensor_hub/api/openapi.yaml
@@ -519,6 +519,45 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /sensors/by-id/{id}/commands:
+    get:
+      tags:
+        - sensors
+      summary: Get sensor command history by id
+      description: >-
+        Returns up to the 50 most recent command history entries for the sensor,
+        newest first. Sensors with no command history return an empty array.
+      operationId: getSensorCommandHistory
+      x-required-permission: view_sensors
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+          description: Numeric database id of the sensor
+      responses:
+        '200':
+          description: Command history entries for the sensor
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CommandHistoryEntry'
+        '404':
+          description: Sensor not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /sensors/{id}/command:
     post:
       tags:
@@ -3653,6 +3692,91 @@ components:
         status: "acknowledged"
         acknowledged_value: "true"
         acknowledged_at: "2026-01-10T12:00:01Z"
+
+    CommandHistoryUser:
+      type: object
+      description: Minimal user identity recorded against a sent command.
+      properties:
+        id:
+          type: integer
+          description: Numeric database id of the acting user.
+        username:
+          type: string
+          description: Username of the acting user at query time.
+      required:
+        - id
+        - username
+      example:
+        id: 3
+        username: "alice"
+
+    CommandHistoryEntry:
+      type: object
+      description: Durable audit record for a sensor command.
+      properties:
+        id:
+          type: integer
+          description: Internal identifier of the persisted command history row.
+        property:
+          type: string
+          description: Driver-level capability property that was commanded.
+        value:
+          type: string
+          description: Original string value supplied in the command request.
+        status:
+          type: string
+          enum: [sent, acknowledged, timed_out, failed]
+          description: Current command status.
+        sent_at:
+          type: string
+          format: date-time
+          description: RFC3339 timestamp when the command was sent.
+        acknowledged_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: RFC3339 timestamp of the first echoed reading that acknowledged the command.
+        acknowledged_value:
+          type: string
+          nullable: true
+          description: Actual value seen on the first echoed reading for the commanded property.
+        timeout_seconds:
+          type: integer
+          description: Timeout budget used while waiting for command acknowledgement.
+        mqtt_topic:
+          type: string
+          description: Exact MQTT topic the command was published to.
+        mqtt_payload:
+          type: string
+          description: Exact MQTT payload that was published.
+        user:
+          allOf:
+            - $ref: '#/components/schemas/CommandHistoryUser'
+          nullable: true
+          description: Acting user that sent the command, or null for system-issued commands.
+      required:
+        - id
+        - property
+        - value
+        - status
+        - sent_at
+        - timeout_seconds
+        - mqtt_topic
+        - mqtt_payload
+      example:
+        id: 42
+        property: "state"
+        value: "ON"
+        status: "acknowledged"
+        sent_at: "2026-01-10T12:00:00Z"
+        acknowledged_at: "2026-01-10T12:00:01Z"
+        acknowledged_value: "true"
+        timeout_seconds: 10
+        mqtt_topic: "zigbee2mqtt/office-plug/set"
+        mqtt_payload: "{\"state\":\"ON\"}"
+        user:
+          id: 1
+          username: "admin"
 
     Capability:
       type: object

--- a/sensor_hub/api/route_permissions.go
+++ b/sensor_hub/api/route_permissions.go
@@ -101,6 +101,7 @@ var routePermissions = map[string]string{
 	"POST /api/sensors/enable/:sensorName":         "manage_sensors",
 	"GET /api/sensors/health/:name":                "view_sensors",
 	"GET /api/sensors/by-id/:id/capabilities":      "view_sensors",
+	"GET /api/sensors/by-id/:id/commands":          "view_sensors",
 	"GET /api/sensors/stats/total-readings":        "view_sensors",
 	"GET /api/sensors/status/:status":              "view_sensors",
 	"POST /api/sensors/approve/:id":                "manage_sensors",

--- a/sensor_hub/api/route_permissions_test.go
+++ b/sensor_hub/api/route_permissions_test.go
@@ -98,3 +98,25 @@ func TestRouteMiddleware_BlocksInsufficientPermissionForSendSensorCommand(t *tes
 
 	assert.Equal(t, http.StatusForbidden, w.Code)
 }
+
+func TestRouteMiddleware_BlocksInsufficientPermissionForGetSensorCommandHistory(t *testing.T) {
+	mockAuth := &MockAuthService{}
+	middleware.InitAuthMiddleware(mockAuth)
+
+	userWithNoPerms := &gen.User{
+		Id:          1,
+		Username:    "testuser",
+		Roles:       []string{"viewer"},
+		Permissions: []string{},
+	}
+	mockAuth.On("ValidateSession", mock.Anything, "valid-token").Return(userWithNoPerms, nil)
+
+	router := setupGenRouter(&Server{authService: mockAuth})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/sensors/by-id/7/commands", nil)
+	req.AddCookie(&http.Cookie{Name: "sensor_hub_session", Value: "valid-token"})
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}

--- a/sensor_hub/api/sensor_api.go
+++ b/sensor_hub/api/sensor_api.go
@@ -166,6 +166,28 @@ func (s *Server) GetSensorCapabilities(c *gin.Context, id int) {
 	c.IndentedJSON(http.StatusOK, capabilities)
 }
 
+func (s *Server) GetSensorCommandHistory(c *gin.Context, id int) {
+	if s.commandService == nil {
+		c.IndentedJSON(http.StatusServiceUnavailable, gin.H{"message": "Command service unavailable"})
+		return
+	}
+
+	history, err := s.commandService.GetHistory(c.Request.Context(), id)
+	if err != nil {
+		var commandErr *service.CommandError
+		if errors.As(err, &commandErr) {
+			c.IndentedJSON(commandErr.StatusCode, gin.H{"message": commandErr.Message})
+			return
+		}
+		c.IndentedJSON(http.StatusInternalServerError, gin.H{"message": "Error retrieving sensor command history", "error": err.Error()})
+		return
+	}
+	if history == nil {
+		history = []gen.CommandHistoryEntry{}
+	}
+	c.IndentedJSON(http.StatusOK, history)
+}
+
 func (s *Server) SendSensorCommand(c *gin.Context, id int) {
 	if s.commandService == nil {
 		c.IndentedJSON(http.StatusServiceUnavailable, gin.H{"message": "Command service unavailable"})

--- a/sensor_hub/api/sensor_api_test.go
+++ b/sensor_hub/api/sensor_api_test.go
@@ -288,6 +288,52 @@ func TestGetSensorCapabilitiesHandler_NotFound(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
+func TestGetSensorCommandHistoryHandler_EmptyHistory(t *testing.T) {
+	router, api, s, _ := setupSensorRouter()
+	mockCommandService := new(MockCommandService)
+	s.commandService = mockCommandService
+	api.GET("/sensors/by-id/:id/commands", func(c *gin.Context) {
+		var id int
+		if _, err := fmt.Sscan(c.Param("id"), &id); err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid sensor ID"})
+			return
+		}
+		s.GetSensorCommandHistory(c, id)
+	})
+
+	mockCommandService.On("GetHistory", mock.Anything, 7).Return([]gen.CommandHistoryEntry{}, nil)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/sensors/by-id/7/commands", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.JSONEq(t, `[]`, w.Body.String())
+}
+
+func TestGetSensorCommandHistoryHandler_NotFound(t *testing.T) {
+	router, api, s, _ := setupSensorRouter()
+	mockCommandService := new(MockCommandService)
+	s.commandService = mockCommandService
+	api.GET("/sensors/by-id/:id/commands", func(c *gin.Context) {
+		var id int
+		if _, err := fmt.Sscan(c.Param("id"), &id); err != nil {
+			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid sensor ID"})
+			return
+		}
+		s.GetSensorCommandHistory(c, id)
+	})
+
+	mockCommandService.On("GetHistory", mock.Anything, 7).
+		Return([]gen.CommandHistoryEntry(nil), &servicepkg.CommandError{StatusCode: http.StatusNotFound, Message: "sensor 7 not found"})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/sensors/by-id/7/commands", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
 func TestSendSensorCommandHandler(t *testing.T) {
 	router, api, s, _ := setupSensorRouter()
 	mockCommandService := new(MockCommandService)

--- a/sensor_hub/db/sensor_command_history_repository.go
+++ b/sensor_hub/db/sensor_command_history_repository.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"log/slog"
 	"time"
+
+	gen "example/sensorHub/gen"
 )
 
 type PendingCommandRecord struct {
@@ -135,6 +137,68 @@ func (r *SensorCommandHistoryRepository) ListPendingCommands(ctx context.Context
 		return nil, fmt.Errorf("error iterating pending sensor commands: %w", err)
 	}
 	return commands, nil
+}
+
+func (r *SensorCommandHistoryRepository) ListBySensorID(ctx context.Context, sensorID int, limit int) ([]gen.CommandHistoryEntry, error) {
+	query := `SELECT h.id, h.property, h.value, h.status, h.sent_at, h.acknowledged_at, h.acknowledged_value,
+			h.timeout_seconds, h.mqtt_topic, h.mqtt_payload, u.id, u.username
+		FROM sensor_command_history h
+		LEFT JOIN users u ON u.id = h.user_id
+		WHERE h.sensor_id = ?
+		ORDER BY h.sent_at DESC, h.id DESC
+		LIMIT ?`
+	rows, err := r.db.QueryContext(ctx, query, sensorID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("error querying sensor command history: %w", err)
+	}
+	defer rows.Close()
+
+	history := make([]gen.CommandHistoryEntry, 0)
+	for rows.Next() {
+		var entry gen.CommandHistoryEntry
+		var status string
+		var acknowledgedAt sql.NullTime
+		var acknowledgedValue sql.NullString
+		var userID sql.NullInt64
+		var username sql.NullString
+		if err := rows.Scan(
+			&entry.Id,
+			&entry.Property,
+			&entry.Value,
+			&status,
+			&entry.SentAt,
+			&acknowledgedAt,
+			&acknowledgedValue,
+			&entry.TimeoutSeconds,
+			&entry.MqttTopic,
+			&entry.MqttPayload,
+			&userID,
+			&username,
+		); err != nil {
+			return nil, fmt.Errorf("error scanning sensor command history row: %w", err)
+		}
+		entry.Status = gen.CommandHistoryEntryStatus(status)
+		if acknowledgedAt.Valid {
+			entry.AcknowledgedAt = &acknowledgedAt.Time
+		}
+		if acknowledgedValue.Valid {
+			value := acknowledgedValue.String
+			entry.AcknowledgedValue = &value
+		}
+		if userID.Valid {
+			entry.User = &gen.CommandHistoryUser{
+				Id: int(userID.Int64),
+			}
+			if username.Valid {
+				entry.User.Username = username.String
+			}
+		}
+		history = append(history, entry)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating sensor command history rows: %w", err)
+	}
+	return history, nil
 }
 
 func rowsAffected(result sql.Result) (bool, error) {

--- a/sensor_hub/db/sensor_command_history_repository_test.go
+++ b/sensor_hub/db/sensor_command_history_repository_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	gen "example/sensorHub/gen"
+
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/stretchr/testify/assert"
 )
@@ -90,5 +92,54 @@ func TestSensorCommandHistoryRepository_ListPendingCommands_ReturnsRows(t *testi
 	assert.Equal(t, "sent", commands[0].Status)
 	assert.Equal(t, 10, commands[0].TimeoutSeconds)
 	assert.Equal(t, sentAt, commands[0].SentAt)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSensorCommandHistoryRepository_ListBySensorID_ReturnsNewestEntriesWithUserMetadata(t *testing.T) {
+	db, mock := newMockDB(t)
+	repo := NewSensorCommandHistoryRepository(db, slog.Default())
+
+	sentAt := time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC)
+	acknowledgedAt := sentAt.Add(2 * time.Second)
+	ackValue := "true"
+
+	mock.ExpectQuery("SELECT h.id, h.property, h.value, h.status, h.sent_at, h.acknowledged_at, h.acknowledged_value, h.timeout_seconds, h.mqtt_topic, h.mqtt_payload, u.id, u.username").
+		WithArgs(7, 50).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "property", "value", "status", "sent_at", "acknowledged_at", "acknowledged_value", "timeout_seconds", "mqtt_topic", "mqtt_payload", "user_id", "username",
+		}).
+			AddRow(42, "state", "ON", "acknowledged", sentAt, acknowledgedAt, ackValue, 10, "zigbee2mqtt/office-plug/set", `{"state":"ON"}`, 99, "admin").
+			AddRow(41, "state", "OFF", "timed_out", sentAt.Add(-time.Minute), nil, nil, 10, "zigbee2mqtt/office-plug/set", `{"state":"OFF"}`, nil, nil))
+
+	history, err := repo.ListBySensorID(context.Background(), 7, 50)
+	assert.NoError(t, err)
+	assert.Equal(t, []gen.CommandHistoryEntry{
+		{
+			Id:                42,
+			Property:          "state",
+			Value:             "ON",
+			Status:            gen.CommandHistoryEntryStatusAcknowledged,
+			SentAt:            sentAt,
+			AcknowledgedAt:    &acknowledgedAt,
+			AcknowledgedValue: &ackValue,
+			TimeoutSeconds:    10,
+			MqttTopic:         "zigbee2mqtt/office-plug/set",
+			MqttPayload:       `{"state":"ON"}`,
+			User: &gen.CommandHistoryUser{
+				Id:       99,
+				Username: "admin",
+			},
+		},
+		{
+			Id:             41,
+			Property:       "state",
+			Value:          "OFF",
+			Status:         gen.CommandHistoryEntryStatusTimedOut,
+			SentAt:         sentAt.Add(-time.Minute),
+			TimeoutSeconds: 10,
+			MqttTopic:      "zigbee2mqtt/office-plug/set",
+			MqttPayload:    `{"state":"OFF"}`,
+		},
+	}, history)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }

--- a/sensor_hub/gen/client.gen.go
+++ b/sensor_hub/gen/client.gen.go
@@ -323,6 +323,9 @@ type ClientInterface interface {
 	// GetSensorCapabilities request
 	GetSensorCapabilities(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// GetSensorCommandHistory request
+	GetSensorCommandHistory(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// GetSensorMeasurementTypes request
 	GetSensorMeasurementTypes(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -1391,6 +1394,18 @@ func (c *Client) ApproveSensor(ctx context.Context, id int, reqEditors ...Reques
 
 func (c *Client) GetSensorCapabilities(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetSensorCapabilitiesRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetSensorCommandHistory(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetSensorCommandHistoryRequest(c.Server, id)
 	if err != nil {
 		return nil, err
 	}
@@ -4184,6 +4199,40 @@ func NewGetSensorCapabilitiesRequest(server string, id int) (*http.Request, erro
 	return req, nil
 }
 
+// NewGetSensorCommandHistoryRequest generates requests for GetSensorCommandHistory
+func NewGetSensorCommandHistoryRequest(server string, id int) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "integer", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/sensors/by-id/%s/commands", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewGetSensorMeasurementTypesRequest generates requests for GetSensorMeasurementTypes
 func NewGetSensorMeasurementTypesRequest(server string, id int) (*http.Request, error) {
 	var err error
@@ -5298,6 +5347,9 @@ type ClientWithResponsesInterface interface {
 
 	// GetSensorCapabilitiesWithResponse request
 	GetSensorCapabilitiesWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*GetSensorCapabilitiesResp, error)
+
+	// GetSensorCommandHistoryWithResponse request
+	GetSensorCommandHistoryWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*GetSensorCommandHistoryResp, error)
 
 	// GetSensorMeasurementTypesWithResponse request
 	GetSensorMeasurementTypesWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*GetSensorMeasurementTypesResp, error)
@@ -6905,6 +6957,30 @@ func (r GetSensorCapabilitiesResp) StatusCode() int {
 	return 0
 }
 
+type GetSensorCommandHistoryResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *[]CommandHistoryEntry
+	JSON404      *ErrorResponse
+	JSON500      *ErrorResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r GetSensorCommandHistoryResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetSensorCommandHistoryResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type GetSensorMeasurementTypesResp struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -8171,6 +8247,15 @@ func (c *ClientWithResponses) GetSensorCapabilitiesWithResponse(ctx context.Cont
 		return nil, err
 	}
 	return ParseGetSensorCapabilitiesResp(rsp)
+}
+
+// GetSensorCommandHistoryWithResponse request returning *GetSensorCommandHistoryResp
+func (c *ClientWithResponses) GetSensorCommandHistoryWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*GetSensorCommandHistoryResp, error) {
+	rsp, err := c.GetSensorCommandHistory(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetSensorCommandHistoryResp(rsp)
 }
 
 // GetSensorMeasurementTypesWithResponse request returning *GetSensorMeasurementTypesResp
@@ -10528,6 +10613,46 @@ func ParseGetSensorCapabilitiesResp(rsp *http.Response) (*GetSensorCapabilitiesR
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest []Capability
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetSensorCommandHistoryResp parses an HTTP response from a GetSensorCommandHistoryWithResponse call
+func ParseGetSensorCommandHistoryResp(rsp *http.Response) (*GetSensorCommandHistoryResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetSensorCommandHistoryResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest []CommandHistoryEntry
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/sensor_hub/gen/server.gen.go
+++ b/sensor_hub/gen/server.gen.go
@@ -211,6 +211,9 @@ type ServerInterface interface {
 	// Get sensor capabilities by id
 	// (GET /sensors/by-id/{id}/capabilities)
 	GetSensorCapabilities(c *gin.Context, id int)
+	// Get sensor command history by id
+	// (GET /sensors/by-id/{id}/commands)
+	GetSensorCommandHistory(c *gin.Context, id int)
 	// Get measurement types for a sensor
 	// (GET /sensors/by-id/{id}/measurement-types)
 	GetSensorMeasurementTypes(c *gin.Context, id int)
@@ -1973,6 +1976,36 @@ func (siw *ServerInterfaceWrapper) GetSensorCapabilities(c *gin.Context) {
 	siw.Handler.GetSensorCapabilities(c, id)
 }
 
+// GetSensorCommandHistory operation middleware
+func (siw *ServerInterfaceWrapper) GetSensorCommandHistory(c *gin.Context) {
+
+	var err error
+
+	// ------------- Path parameter "id" -------------
+	var id int
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", c.Param("id"), &id, runtime.BindStyledParameterOptions{Explode: false, Required: true, Type: "integer", Format: ""})
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter id: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	c.Set(CookieAuthScopes, []string{})
+
+	c.Set(CsrfTokenScopes, []string{})
+
+	c.Set(ApiKeyAuthScopes, []string{})
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		middleware(c)
+		if c.IsAborted() {
+			return
+		}
+	}
+
+	siw.Handler.GetSensorCommandHistory(c, id)
+}
+
 // GetSensorMeasurementTypes operation middleware
 func (siw *ServerInterfaceWrapper) GetSensorMeasurementTypes(c *gin.Context) {
 
@@ -2701,6 +2734,7 @@ func RegisterHandlersWithOptions(router gin.IRouter, si ServerInterface, options
 	router.POST(options.BaseURL+"/sensors", wrapper.AddSensor)
 	router.POST(options.BaseURL+"/sensors/approve/:id", wrapper.ApproveSensor)
 	router.GET(options.BaseURL+"/sensors/by-id/:id/capabilities", wrapper.GetSensorCapabilities)
+	router.GET(options.BaseURL+"/sensors/by-id/:id/commands", wrapper.GetSensorCommandHistory)
 	router.GET(options.BaseURL+"/sensors/by-id/:id/measurement-types", wrapper.GetSensorMeasurementTypes)
 	router.POST(options.BaseURL+"/sensors/collect", wrapper.CollectAllSensorReadings)
 	router.POST(options.BaseURL+"/sensors/collect/:sensorName", wrapper.CollectFromSensor)

--- a/sensor_hub/gen/types.gen.go
+++ b/sensor_hub/gen/types.gen.go
@@ -130,6 +130,30 @@ func (e ChannelPreferenceCategory) Valid() bool {
 	}
 }
 
+// Defines values for CommandHistoryEntryStatus.
+const (
+	CommandHistoryEntryStatusAcknowledged CommandHistoryEntryStatus = "acknowledged"
+	CommandHistoryEntryStatusFailed       CommandHistoryEntryStatus = "failed"
+	CommandHistoryEntryStatusSent         CommandHistoryEntryStatus = "sent"
+	CommandHistoryEntryStatusTimedOut     CommandHistoryEntryStatus = "timed_out"
+)
+
+// Valid indicates whether the value is a known member of the CommandHistoryEntryStatus enum.
+func (e CommandHistoryEntryStatus) Valid() bool {
+	switch e {
+	case CommandHistoryEntryStatusAcknowledged:
+		return true
+	case CommandHistoryEntryStatusFailed:
+		return true
+	case CommandHistoryEntryStatusSent:
+		return true
+	case CommandHistoryEntryStatusTimedOut:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for MeasurementTypeCategory.
 const (
 	MeasurementTypeCategoryBinary  MeasurementTypeCategory = "binary"
@@ -213,13 +237,13 @@ func (e SensorStatus) Valid() bool {
 
 // Defines values for SensorCommandAcceptedStatus.
 const (
-	Sent SensorCommandAcceptedStatus = "sent"
+	SensorCommandAcceptedStatusSent SensorCommandAcceptedStatus = "sent"
 )
 
 // Valid indicates whether the value is a known member of the SensorCommandAcceptedStatus enum.
 func (e SensorCommandAcceptedStatus) Valid() bool {
 	switch e {
-	case Sent:
+	case SensorCommandAcceptedStatusSent:
 		return true
 	default:
 		return false
@@ -482,6 +506,54 @@ type ChannelPreference struct {
 
 // ChannelPreferenceCategory defines model for ChannelPreference.Category.
 type ChannelPreferenceCategory string
+
+// CommandHistoryEntry Durable audit record for a sensor command.
+type CommandHistoryEntry struct {
+	// AcknowledgedAt RFC3339 timestamp of the first echoed reading that acknowledged the command.
+	AcknowledgedAt *time.Time `json:"acknowledged_at,omitempty"`
+
+	// AcknowledgedValue Actual value seen on the first echoed reading for the commanded property.
+	AcknowledgedValue *string `json:"acknowledged_value,omitempty"`
+
+	// Id Internal identifier of the persisted command history row.
+	Id int `json:"id"`
+
+	// MqttPayload Exact MQTT payload that was published.
+	MqttPayload string `json:"mqtt_payload"`
+
+	// MqttTopic Exact MQTT topic the command was published to.
+	MqttTopic string `json:"mqtt_topic"`
+
+	// Property Driver-level capability property that was commanded.
+	Property string `json:"property"`
+
+	// SentAt RFC3339 timestamp when the command was sent.
+	SentAt time.Time `json:"sent_at"`
+
+	// Status Current command status.
+	Status CommandHistoryEntryStatus `json:"status"`
+
+	// TimeoutSeconds Timeout budget used while waiting for command acknowledgement.
+	TimeoutSeconds int `json:"timeout_seconds"`
+
+	// User Acting user that sent the command, or null for system-issued commands.
+	User *CommandHistoryUser `json:"user,omitempty"`
+
+	// Value Original string value supplied in the command request.
+	Value string `json:"value"`
+}
+
+// CommandHistoryEntryStatus Current command status.
+type CommandHistoryEntryStatus string
+
+// CommandHistoryUser Minimal user identity recorded against a sent command.
+type CommandHistoryUser struct {
+	// Id Numeric database id of the acting user.
+	Id int `json:"id"`
+
+	// Username Username of the acting user at query time.
+	Username string `json:"username"`
+}
 
 // ConfigFieldSpec Describes a single configuration field that a driver expects.
 type ConfigFieldSpec struct {

--- a/sensor_hub/integration/sensor_command_test.go
+++ b/sensor_hub/integration/sensor_command_test.go
@@ -58,7 +58,7 @@ func TestSendSensorCommand_PublishesAndPersistsSentCommand(t *testing.T) {
 	require.Equal(t, http.StatusAccepted, status)
 	assert.Equal(t, "state", result.Property)
 	assert.Equal(t, "ON", result.Value)
-	assert.Equal(t, gen.Sent, result.Status)
+	assert.Equal(t, gen.SensorCommandAcceptedStatusSent, result.Status)
 	assert.NotZero(t, result.Id)
 
 	select {
@@ -189,6 +189,74 @@ func TestSendSensorCommand_AcknowledgesAndBroadcastsCommandStatus(t *testing.T) 
 	require.NotNil(t, message.AcknowledgedValue)
 	assert.Equal(t, "true", *message.AcknowledgedValue)
 	require.NotNil(t, message.AcknowledgedAt)
+}
+
+func TestGetSensorCommandHistory_ReturnsAcknowledgedCommandWithActor(t *testing.T) {
+	fixture := setupCommandFixture(t, fmt.Sprintf("history-plug-%d", reserveTCPPort(t)))
+	defer fixture.stop()
+
+	subscriber := pahomqtt.NewClient(
+		pahomqtt.NewClientOptions().
+			AddBroker(fmt.Sprintf("tcp://127.0.0.1:%d", fixture.port)).
+			SetClientID(fmt.Sprintf("integration-command-history-%d", fixture.port)),
+	)
+	token := subscriber.Connect()
+	require.True(t, token.WaitTimeout(5*time.Second))
+	require.NoError(t, token.Error())
+	defer subscriber.Disconnect(250)
+
+	messageCh := make(chan pahomqtt.Message, 1)
+	token = subscriber.Subscribe(fmt.Sprintf("zigbee2mqtt/%s/set", fixture.sensor.Name), 1, func(_ pahomqtt.Client, msg pahomqtt.Message) {
+		messageCh <- msg
+	})
+	require.True(t, token.WaitTimeout(5*time.Second))
+	require.NoError(t, token.Error())
+
+	result, status := client.SendSensorCommand(fixture.sensor.Id, "state", "ON")
+	require.Equal(t, http.StatusAccepted, status)
+
+	select {
+	case <-messageCh:
+		pub := subscriber.Publish(fmt.Sprintf("zigbee2mqtt/%s", fixture.sensor.Name), 1, false, `{"state":"ON"}`)
+		require.True(t, pub.WaitTimeout(5*time.Second))
+		require.NoError(t, pub.Error())
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for command publish")
+	}
+
+	adminUserID := lookupUserID(t, env.AdminUser)
+
+	var history []gen.CommandHistoryEntry
+	require.Eventually(t, func() bool {
+		var historyStatus int
+		history, historyStatus = client.GetSensorCommandHistory(fixture.sensor.Id)
+		if historyStatus != http.StatusOK || len(history) != 1 {
+			return false
+		}
+		entry := history[0]
+		return entry.Id == result.Id &&
+			entry.Status == gen.CommandHistoryEntryStatusAcknowledged &&
+			entry.AcknowledgedAt != nil &&
+			entry.AcknowledgedValue != nil &&
+			entry.User != nil &&
+			entry.User.Username == env.AdminUser
+	}, 5*time.Second, 100*time.Millisecond)
+
+	entry := history[0]
+	assert.Equal(t, result.Id, entry.Id)
+	assert.Equal(t, "state", entry.Property)
+	assert.Equal(t, "ON", entry.Value)
+	assert.Equal(t, gen.CommandHistoryEntryStatusAcknowledged, entry.Status)
+	assert.NotZero(t, entry.SentAt)
+	require.NotNil(t, entry.AcknowledgedAt)
+	require.NotNil(t, entry.AcknowledgedValue)
+	assert.Equal(t, "true", *entry.AcknowledgedValue)
+	assert.Positive(t, entry.TimeoutSeconds)
+	assert.Equal(t, fmt.Sprintf("zigbee2mqtt/%s/set", fixture.sensor.Name), entry.MqttTopic)
+	assert.JSONEq(t, `{"state":"ON"}`, entry.MqttPayload)
+	require.NotNil(t, entry.User)
+	assert.Equal(t, adminUserID, entry.User.Id)
+	assert.Equal(t, env.AdminUser, entry.User.Username)
 }
 
 func TestSendSensorCommand_TimesOutAndBroadcastsCommandStatus(t *testing.T) {

--- a/sensor_hub/service/command_service.go
+++ b/sensor_hub/service/command_service.go
@@ -17,6 +17,7 @@ import (
 
 const (
 	defaultCommandTimeoutSeconds = 10
+	defaultCommandHistoryLimit   = 50
 	commandPublishQOS            = 1
 )
 
@@ -31,6 +32,7 @@ type CommandSubscriptionRepository interface {
 type CommandHistoryRepository interface {
 	HasPendingCommand(ctx context.Context, sensorID int, property string) (bool, error)
 	AddSentCommand(ctx context.Context, sensorID int, userID *int, property string, value string, mqttTopic string, mqttPayload string, timeoutSeconds int, sentAt time.Time) (int, error)
+	ListBySensorID(ctx context.Context, sensorID int, limit int) ([]gen.CommandHistoryEntry, error)
 }
 
 type CommandPublisher interface {
@@ -78,6 +80,25 @@ func NewCommandService(sensorRepo CommandSensorRepository, subRepo CommandSubscr
 		lifecycle:   lifecycle,
 		logger:      logger.With("component", "command_service"),
 	}
+}
+
+func (s *CommandService) GetHistory(ctx context.Context, sensorID int) ([]gen.CommandHistoryEntry, error) {
+	sensor, err := s.sensorRepo.GetSensorById(ctx, sensorID)
+	if err != nil || sensor == nil {
+		if err != nil {
+			return nil, newCommandError(http.StatusNotFound, fmt.Sprintf("sensor %d not found", sensorID))
+		}
+		return nil, newCommandError(http.StatusNotFound, fmt.Sprintf("sensor %d not found", sensorID))
+	}
+
+	history, err := s.historyRepo.ListBySensorID(ctx, sensor.Id, defaultCommandHistoryLimit)
+	if err != nil {
+		return nil, fmt.Errorf("list command history: %w", err)
+	}
+	if history == nil {
+		return []gen.CommandHistoryEntry{}, nil
+	}
+	return history, nil
 }
 
 func (s *CommandService) Send(ctx context.Context, sensorID int, actor *gen.User, property string, value string) (SentCommandResult, error) {

--- a/sensor_hub/service/command_service_interface.go
+++ b/sensor_hub/service/command_service_interface.go
@@ -7,5 +7,6 @@ import (
 )
 
 type CommandServiceInterface interface {
+	GetHistory(ctx context.Context, sensorID int) ([]gen.CommandHistoryEntry, error)
 	Send(ctx context.Context, sensorID int, actor *gen.User, property string, value string) (SentCommandResult, error)
 }

--- a/sensor_hub/service/command_service_test.go
+++ b/sensor_hub/service/command_service_test.go
@@ -83,6 +83,17 @@ func (m *mockCommandHistoryRepository) ListPendingCommands(ctx context.Context) 
 	return args.Get(0).([]database.PendingCommandRecord), args.Error(1)
 }
 
+func (m *mockCommandHistoryRepository) ListBySensorID(ctx context.Context, sensorID int, limit int) ([]gen.CommandHistoryEntry, error) {
+	if !m.hasExpectation("ListBySensorID") {
+		return nil, nil
+	}
+	args := m.Called(ctx, sensorID, limit)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]gen.CommandHistoryEntry), args.Error(1)
+}
+
 func (m *mockCommandHistoryRepository) hasExpectation(method string) bool {
 	for _, call := range m.ExpectedCalls {
 		if call.Method == method {
@@ -178,6 +189,39 @@ func TestCommandService_Send_PublishesAndPersistsSentCommand(t *testing.T) {
 	}, result)
 	require.Len(t, lifecycle.tracked, 1)
 	assert.Equal(t, 42, lifecycle.tracked[0].ID)
+}
+
+func TestCommandService_GetHistory_ReturnsLatestEntriesFromRepository(t *testing.T) {
+	sensorRepo := &mockCommandSensorRepository{}
+	subRepo := &mockCommandSubscriptionRepository{}
+	historyRepo := &mockCommandHistoryRepository{}
+	publisher := &mockCommandPublisher{}
+	svc, _ := newCommandServiceForTest(sensorRepo, subRepo, historyRepo, publisher, nil)
+
+	sensorRepo.On("GetSensorById", mock.Anything, 7).Return(&gen.Sensor{Id: 7, Name: "office-plug"}, nil)
+	expected := []gen.CommandHistoryEntry{
+		{
+			Id:             42,
+			Property:       "state",
+			Value:          "ON",
+			Status:         gen.CommandHistoryEntryStatusAcknowledged,
+			SentAt:         time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC),
+			TimeoutSeconds: 10,
+			MqttTopic:      "zigbee2mqtt/office-plug/set",
+			MqttPayload:    `{"state":"ON"}`,
+			User: &gen.CommandHistoryUser{
+				Id:       99,
+				Username: "admin",
+			},
+		},
+	}
+	historyRepo.On("ListBySensorID", mock.Anything, 7, 50).Return(expected, nil)
+
+	history, err := svc.GetHistory(context.Background(), 7)
+	require.NoError(t, err)
+	assert.Equal(t, expected, history)
+	sensorRepo.AssertExpectations(t)
+	historyRepo.AssertExpectations(t)
 }
 
 func TestCommandService_Send_InsufficientPermission(t *testing.T) {

--- a/sensor_hub/testharness/client.go
+++ b/sensor_hub/testharness/client.go
@@ -278,6 +278,13 @@ func (c *Client) GetSensorCapabilities(sensorID int) ([]gen.Capability, int) {
 	return result, status
 }
 
+func (c *Client) GetSensorCommandHistory(sensorID int) ([]gen.CommandHistoryEntry, int) {
+	var result []gen.CommandHistoryEntry
+	resp, err := c.gen.GetSensorCommandHistory(c.ctx(), sensorID)
+	status := c.decodeInto(resp, err, &result)
+	return result, status
+}
+
 func (c *Client) SendSensorCommand(sensorID int, property, value string) (gen.SensorCommandAccepted, int) {
 	var result gen.SensorCommandAccepted
 	resp, err := c.gen.SendSensorCommand(c.ctx(), sensorID, gen.SendSensorCommandJSONRequestBody{

--- a/sensor_hub/ui/sensor_hub_ui/src/gen/schema.d.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/gen/schema.d.ts
@@ -210,6 +210,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/sensors/by-id/{id}/commands": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get sensor command history by id
+         * @description Returns up to the 50 most recent command history entries for the sensor, newest first. Sensors with no command history return an empty array.
+         */
+        get: operations["getSensorCommandHistory"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/sensors/{id}/command": {
         parameters: {
             query?: never;
@@ -1813,6 +1833,71 @@ export interface components {
              */
             acknowledged_at?: string | null;
         };
+        /**
+         * @description Minimal user identity recorded against a sent command.
+         * @example {
+         *       "id": 3,
+         *       "username": "alice"
+         *     }
+         */
+        CommandHistoryUser: {
+            /** @description Numeric database id of the acting user. */
+            id: number;
+            /** @description Username of the acting user at query time. */
+            username: string;
+        };
+        /**
+         * @description Durable audit record for a sensor command.
+         * @example {
+         *       "id": 42,
+         *       "property": "state",
+         *       "value": "ON",
+         *       "status": "acknowledged",
+         *       "sent_at": "2026-01-10T12:00:00Z",
+         *       "acknowledged_at": "2026-01-10T12:00:01Z",
+         *       "acknowledged_value": "true",
+         *       "timeout_seconds": 10,
+         *       "mqtt_topic": "zigbee2mqtt/office-plug/set",
+         *       "mqtt_payload": "{\"state\":\"ON\"}",
+         *       "user": {
+         *         "id": 1,
+         *         "username": "admin"
+         *       }
+         *     }
+         */
+        CommandHistoryEntry: {
+            /** @description Internal identifier of the persisted command history row. */
+            id: number;
+            /** @description Driver-level capability property that was commanded. */
+            property: string;
+            /** @description Original string value supplied in the command request. */
+            value: string;
+            /**
+             * @description Current command status.
+             * @enum {string}
+             */
+            status: "sent" | "acknowledged" | "timed_out" | "failed";
+            /**
+             * Format: date-time
+             * @description RFC3339 timestamp when the command was sent.
+             */
+            sent_at: string;
+            /**
+             * Format: date-time
+             * @description RFC3339 timestamp of the first echoed reading that acknowledged the command.
+             */
+            acknowledged_at?: string | null;
+            /** @description Actual value seen on the first echoed reading for the commanded property. */
+            acknowledged_value?: string | null;
+            /** @description Timeout budget used while waiting for command acknowledgement. */
+            timeout_seconds: number;
+            /** @description Exact MQTT topic the command was published to. */
+            mqtt_topic: string;
+            /** @description Exact MQTT payload that was published. */
+            mqtt_payload: string;
+            /** @description Acting user that sent the command, or null for system-issued commands. */
+            user?: components["schemas"]["CommandHistoryUser"] | null;
+        };
         /** @description A controllable property exposed by a driver. This is derived from driver metadata and is never user-configurable. */
         Capability: {
             /** @description Driver-level property name used when sending commands. */
@@ -2605,6 +2690,47 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["Capability"][];
+                };
+            };
+            /** @description Sensor not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    getSensorCommandHistory: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Numeric database id of the sensor */
+                id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Command history entries for the sensor */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CommandHistoryEntry"][];
                 };
             };
             /** @description Sensor not found */


### PR DESCRIPTION
## Summary
- add the command history OpenAPI contract and regenerate Go/TypeScript clients
- implement `GET /sensors/by-id/{id}/commands` through the command service and history repository
- cover the endpoint with API, repository, service, permission, and integration tests

## Verification
- `cd sensor_hub && go test ./...`
- `cd sensor_hub/ui/sensor_hub_ui && npm run build`
- `cd sensor_hub && go test -tags integration -v -timeout 300s ./integration/`

Closes #75
Refs #14