### PR TITLE
Add sensor control CLI commands

### DIFF
--- a/sensor_hub/cmd/api_client.go
+++ b/sensor_hub/cmd/api_client.go
@@ -5,28 +5,37 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"
 
+	"github.com/gorilla/websocket"
 	"github.com/spf13/cobra"
 
 	gen "example/sensorHub/gen"
 )
+
+type clientConfig struct {
+	serverURL string
+	apiKey    string
+	insecure  bool
+}
 
 // newAPIClient builds a generated `gen.Client` configured from the CLI's
 // existing config sources (config file + flags). The returned client injects
 // the API key on every request via a RequestEditorFn and honours the
 // `--insecure` flag for self-signed TLS endpoints.
 func newAPIClient(cmd *cobra.Command) (*gen.Client, context.Context, error) {
-	serverURL, apiKey, insecure, err := loadClientConfig(cmd)
+	cfg, err := loadResolvedClientConfig(cmd)
 	if err != nil {
 		return nil, nil, err
 	}
-	return buildAPIClient(serverURL, apiKey, insecure)
+	return buildAPIClient(cfg.serverURL, cfg.apiKey, cfg.insecure)
 }
 
 // newAPIClientNoAuth is used by the `health` command, which intentionally
@@ -36,20 +45,43 @@ func newAPIClientNoAuth(serverURL string, insecure bool) (*gen.Client, context.C
 	return buildAPIClient(serverURL, "", insecure)
 }
 
-func buildAPIClient(serverURL, apiKey string, insecure bool) (*gen.Client, context.Context, error) {
+func newAPIClientWithResponses(cmd *cobra.Command) (*gen.ClientWithResponses, context.Context, clientConfig, error) {
+	cfg, err := loadResolvedClientConfig(cmd)
+	if err != nil {
+		return nil, nil, clientConfig{}, err
+	}
+
+	client, ctx, err := buildAPIClientWithResponses(cfg.serverURL, cfg.apiKey, cfg.insecure)
+	if err != nil {
+		return nil, nil, clientConfig{}, err
+	}
+	return client, ctx, cfg, nil
+}
+
+func loadResolvedClientConfig(cmd *cobra.Command) (clientConfig, error) {
+	serverURL, apiKey, insecure, err := loadClientConfig(cmd)
+	if err != nil {
+		return clientConfig{}, err
+	}
+	return clientConfig{
+		serverURL: serverURL,
+		apiKey:    apiKey,
+		insecure:  insecure,
+	}, nil
+}
+
+func buildHTTPClient(insecure bool) *http.Client {
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	if insecure {
 		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec // user-requested via --insecure flag
 	}
-	httpClient := &http.Client{
+	return &http.Client{
 		Timeout:   30 * time.Second,
 		Transport: transport,
 	}
+}
 
-	// Generated Client base URL must include the /api prefix because operation
-	// paths in the spec are mounted under /api by gen.RegisterHandlers.
-	baseURL := strings.TrimRight(serverURL, "/") + "/api"
-
+func buildClientOptions(httpClient *http.Client, apiKey string) []gen.ClientOption {
 	opts := []gen.ClientOption{gen.WithHTTPClient(httpClient)}
 	if apiKey != "" {
 		opts = append(opts, gen.WithRequestEditorFn(func(_ context.Context, req *http.Request) error {
@@ -57,12 +89,102 @@ func buildAPIClient(serverURL, apiKey string, insecure bool) (*gen.Client, conte
 			return nil
 		}))
 	}
+	return opts
+}
+
+func buildAPIClient(serverURL, apiKey string, insecure bool) (*gen.Client, context.Context, error) {
+	// Generated Client base URL must include the /api prefix because operation
+	// paths in the spec are mounted under /api by gen.RegisterHandlers.
+	baseURL := strings.TrimRight(serverURL, "/") + "/api"
+	opts := buildClientOptions(buildHTTPClient(insecure), apiKey)
 
 	client, err := gen.NewClient(baseURL, opts...)
 	if err != nil {
 		return nil, nil, err
 	}
 	return client, context.Background(), nil
+}
+
+func buildAPIClientWithResponses(serverURL, apiKey string, insecure bool) (*gen.ClientWithResponses, context.Context, error) {
+	baseURL := strings.TrimRight(serverURL, "/") + "/api"
+	opts := buildClientOptions(buildHTTPClient(insecure), apiKey)
+
+	client, err := gen.NewClientWithResponses(baseURL, opts...)
+	if err != nil {
+		return nil, nil, err
+	}
+	return client, context.Background(), nil
+}
+
+func currentReadingsSnapshot(ctx context.Context, cfg clientConfig) ([]gen.Reading, error) {
+	wsURL, err := currentReadingsWSURL(cfg.serverURL)
+	if err != nil {
+		return nil, err
+	}
+
+	dialer := websocket.Dialer{
+		TLSClientConfig:  &tls.Config{InsecureSkipVerify: cfg.insecure}, //nolint:gosec // user-requested via --insecure flag
+		HandshakeTimeout: 30 * time.Second,
+	}
+	headers := http.Header{}
+	if cfg.apiKey != "" {
+		headers.Set("X-API-Key", cfg.apiKey)
+	}
+
+	conn, resp, err := dialer.DialContext(ctx, wsURL, headers)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	if err != nil {
+		if resp != nil {
+			data, readErr := io.ReadAll(resp.Body)
+			if readErr == nil && len(data) > 0 {
+				return nil, apiResponseError(resp.StatusCode, data)
+			}
+		}
+		return nil, err
+	}
+	defer conn.Close()
+	requireReadDeadline := time.Now().Add(30 * time.Second)
+	if err := conn.SetReadDeadline(requireReadDeadline); err != nil {
+		return nil, err
+	}
+
+	var readings []gen.Reading
+	if err := conn.ReadJSON(&readings); err != nil {
+		return nil, fmt.Errorf("failed to read current readings snapshot: %w", err)
+	}
+	return readings, nil
+}
+
+func currentReadingsWSURL(serverURL string) (string, error) {
+	parsed, err := url.Parse(strings.TrimRight(serverURL, "/"))
+	if err != nil {
+		return "", fmt.Errorf("invalid server URL: %w", err)
+	}
+	switch parsed.Scheme {
+	case "http":
+		parsed.Scheme = "ws"
+	case "https":
+		parsed.Scheme = "wss"
+	default:
+		return "", fmt.Errorf("unsupported server URL scheme %q", parsed.Scheme)
+	}
+	parsed.Path = strings.TrimRight(parsed.Path, "/") + "/api/readings/ws/current"
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return parsed.String(), nil
+}
+
+func apiResponseError(status int, body []byte) error {
+	if len(body) > 0 {
+		var errorResponse gen.ErrorResponse
+		if json.Unmarshal(body, &errorResponse) == nil && errorResponse.Message != "" {
+			return errors.New(errorResponse.Message)
+		}
+		return fmt.Errorf("HTTP %d: %s", status, strings.TrimSpace(string(body)))
+	}
+	return fmt.Errorf("HTTP %d", status)
 }
 
 // consumeJSON reads the response body, prints it as pretty-printed JSON on

--- a/sensor_hub/cmd/sensors.go
+++ b/sensor_hub/cmd/sensors.go
@@ -1,8 +1,12 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"strconv"
+	"strings"
+	"text/tabwriter"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -27,6 +31,9 @@ func init() {
 	sensorsCmd.AddCommand(sensorsHealthCmd)
 	sensorsCmd.AddCommand(sensorsStatsCmd)
 	sensorsCmd.AddCommand(sensorsCollectCmd)
+	sensorsCmd.AddCommand(sensorsCapabilitiesCmd)
+	sensorsCmd.AddCommand(sensorsCommandCmd)
+	sensorsCmd.AddCommand(sensorsCommandsCmd)
 	sensorsCmd.AddCommand(sensorsPendingCmd)
 	sensorsCmd.AddCommand(sensorsApproveCmd)
 	sensorsCmd.AddCommand(sensorsDismissCmd)
@@ -192,6 +199,110 @@ var sensorsCollectCmd = &cobra.Command{
 	},
 }
 
+var sensorsCapabilitiesCmd = &cobra.Command{
+	Use:   "capabilities [id]",
+	Short: "List controllable capabilities for a sensor ID",
+	Long:  "List controllable capabilities for a sensor ID, including allowed values/range and the latest reading for each property.",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		id, err := parseSensorIDArg(args[0])
+		if err != nil {
+			return err
+		}
+
+		client, ctx, cfg, err := newAPIClientWithResponses(cmd)
+		if err != nil {
+			return err
+		}
+
+		sensor, err := lookupSensorByID(ctx, client, id)
+		if err != nil {
+			return err
+		}
+
+		capResp, err := client.GetSensorCapabilitiesWithResponse(ctx, id)
+		if err != nil {
+			return err
+		}
+		if capResp.StatusCode() != 200 || capResp.JSON200 == nil {
+			return apiResponseError(capResp.StatusCode(), capResp.Body)
+		}
+
+		readings, err := currentReadingsSnapshot(ctx, cfg)
+		if err != nil {
+			return err
+		}
+
+		writeCapabilityTable(cmd, *capResp.JSON200, latestReadingsByProperty(sensor.Name, readings))
+		return nil
+	},
+}
+
+var sensorsCommandCmd = &cobra.Command{
+	Use:   "command [id] [property] [value]",
+	Short: "Send a command to a controllable sensor by ID",
+	Long:  "Send a command to a controllable sensor by ID and print the accepted command record.",
+	Args:  cobra.ExactArgs(3),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		id, err := parseSensorIDArg(args[0])
+		if err != nil {
+			return err
+		}
+
+		client, ctx, _, err := newAPIClientWithResponses(cmd)
+		if err != nil {
+			return err
+		}
+
+		response, err := client.SendSensorCommandWithResponse(ctx, id, gen.SendSensorCommandJSONRequestBody{
+			Property: args[1],
+			Value:    args[2],
+		})
+		if err != nil {
+			return err
+		}
+		if response.StatusCode() != 202 || response.JSON202 == nil {
+			return apiResponseError(response.StatusCode(), response.Body)
+		}
+
+		writeAcceptedCommandTable(cmd, *response.JSON202)
+		return nil
+	},
+}
+
+var sensorsCommandsCmd = &cobra.Command{
+	Use:   "commands [id]",
+	Short: "List recent command history for a sensor ID",
+	Long:  "List the most recent command history entries for a sensor ID.",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		id, err := parseSensorIDArg(args[0])
+		if err != nil {
+			return err
+		}
+
+		client, ctx, _, err := newAPIClientWithResponses(cmd)
+		if err != nil {
+			return err
+		}
+
+		response, err := client.GetSensorCommandHistoryWithResponse(ctx, id)
+		if err != nil {
+			return err
+		}
+		if response.StatusCode() != 200 || response.JSON200 == nil {
+			return apiResponseError(response.StatusCode(), response.Body)
+		}
+
+		history := *response.JSON200
+		if len(history) > 20 {
+			history = history[:20]
+		}
+		writeCommandHistoryTable(cmd, history)
+		return nil
+	},
+}
+
 var sensorsUpdateCmd = &cobra.Command{
 	Use:   "update [id]",
 	Short: "Update an existing sensor",
@@ -306,4 +417,134 @@ var sensorsDismissCmd = &cobra.Command{
 		}
 		return consumeJSON(client.DismissSensor(ctx, id))
 	},
+}
+
+func parseSensorIDArg(value string) (int, error) {
+	id, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, fmt.Errorf("sensor ID must be a number")
+	}
+	return id, nil
+}
+
+func lookupSensorByID(ctx context.Context, client *gen.ClientWithResponses, id int) (*gen.Sensor, error) {
+	response, err := client.GetAllSensorsWithResponse(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if response.StatusCode() != 200 || response.JSON200 == nil {
+		return nil, apiResponseError(response.StatusCode(), response.Body)
+	}
+
+	for _, sensor := range *response.JSON200 {
+		if sensor.Id == id {
+			s := sensor
+			return &s, nil
+		}
+	}
+	return nil, fmt.Errorf("sensor %d not found", id)
+}
+
+func writeCapabilityTable(cmd *cobra.Command, capabilities []gen.Capability, latestValues map[string]string) {
+	writer := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(writer, "PROPERTY\tTYPE\tALLOWED\tLATEST")
+	for _, capability := range capabilities {
+		_, _ = fmt.Fprintf(
+			writer,
+			"%s\t%s\t%s\t%s\n",
+			capability.Property,
+			capability.Type,
+			capabilityAllowedValues(capability),
+			latestValues[capability.Property],
+		)
+	}
+	_ = writer.Flush()
+}
+
+func writeAcceptedCommandTable(cmd *cobra.Command, accepted gen.SensorCommandAccepted) {
+	writer := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(writer, "ID\tSTATUS\tPROPERTY\tVALUE")
+	_, _ = fmt.Fprintf(writer, "%d\t%s\t%s\t%s\n", accepted.Id, accepted.Status, accepted.Property, accepted.Value)
+	_ = writer.Flush()
+}
+
+func writeCommandHistoryTable(cmd *cobra.Command, history []gen.CommandHistoryEntry) {
+	writer := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(writer, "ID\tSENT_AT\tPROPERTY\tVALUE\tSTATUS\tUSER")
+	for _, entry := range history {
+		_, _ = fmt.Fprintf(
+			writer,
+			"%d\t%s\t%s\t%s\t%s\t%s\n",
+			entry.Id,
+			entry.SentAt.Format(time.RFC3339),
+			entry.Property,
+			entry.Value,
+			entry.Status,
+			commandUserName(entry.User),
+		)
+	}
+	_ = writer.Flush()
+}
+
+func capabilityAllowedValues(capability gen.Capability) string {
+	switch {
+	case capability.ValueOn != nil || capability.ValueOff != nil:
+		return strings.TrimSpace(strings.Join([]string{derefOrEmpty(capability.ValueOn), "/", derefOrEmpty(capability.ValueOff)}, " "))
+	case capability.Values != nil && len(*capability.Values) > 0:
+		return strings.Join(*capability.Values, ", ")
+	case capability.Min != nil || capability.Max != nil:
+		return strings.TrimSpace(fmt.Sprintf("%s..%s %s", formatOptionalFloat(capability.Min), formatOptionalFloat(capability.Max), derefOrEmpty(capability.Unit)))
+	default:
+		return ""
+	}
+}
+
+func latestReadingsByProperty(sensorName string, readings []gen.Reading) map[string]string {
+	values := make(map[string]string)
+	for _, reading := range readings {
+		if reading.SensorName != sensorName {
+			continue
+		}
+		values[reading.MeasurementType] = readingDisplayValue(reading)
+	}
+	return values
+}
+
+func readingDisplayValue(reading gen.Reading) string {
+	if reading.TextState != nil {
+		return *reading.TextState
+	}
+	if reading.NumericValue != nil {
+		value := formatFloat(*reading.NumericValue)
+		if reading.Unit == "" {
+			return value
+		}
+		return value + " " + reading.Unit
+	}
+	return ""
+}
+
+func formatOptionalFloat(value *float64) string {
+	if value == nil {
+		return ""
+	}
+	return formatFloat(*value)
+}
+
+func formatFloat(value float64) string {
+	return strconv.FormatFloat(value, 'f', -1, 64)
+}
+
+func derefOrEmpty(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func commandUserName(user *gen.CommandHistoryUser) string {
+	if user == nil {
+		return ""
+	}
+	return user.Username
 }

--- a/sensor_hub/cmd/sensors_cli_test.go
+++ b/sensor_hub/cmd/sensors_cli_test.go
@@ -1,0 +1,244 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	gen "example/sensorHub/gen"
+
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSensorsCapabilitiesCommand_PrintsCapabilitiesWithLatestReadings(t *testing.T) {
+	t.Helper()
+
+	valueOn := "ON"
+	valueOff := "OFF"
+	min := 0.0
+	max := 2500.0
+	latestState := "ON"
+	latestPower := 42.5
+
+	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/sensors":
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode([]gen.Sensor{
+				{
+					Id:           7,
+					Name:         "office-plug",
+					SensorDriver: "mqtt-zigbee2mqtt",
+					Status:       gen.SensorStatusActive,
+					Config:       map[string]string{},
+				},
+			}))
+		case "/api/sensors/by-id/7/capabilities":
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode([]gen.Capability{
+				{
+					Property: "state",
+					Type:     gen.CapabilityType("binary"),
+					ValueOn:  &valueOn,
+					ValueOff: &valueOff,
+				},
+				{
+					Property: "power",
+					Type:     gen.CapabilityType("numeric"),
+					Min:      &min,
+					Max:      &max,
+				},
+			}))
+		case "/api/readings/ws/current":
+			conn, err := upgrader.Upgrade(w, r, nil)
+			require.NoError(t, err)
+			defer conn.Close()
+
+			require.NoError(t, conn.WriteJSON([]gen.Reading{
+				{
+					SensorName:      "office-plug",
+					MeasurementType: "state",
+					TextState:       &latestState,
+				},
+				{
+					SensorName:      "office-plug",
+					MeasurementType: "power",
+					NumericValue:    &latestPower,
+					Unit:            "W",
+				},
+			}))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	stdout, stderr, err := executeRootCommand(t, "--server", server.URL, "sensors", "capabilities", "7")
+	require.NoError(t, err)
+	assert.Empty(t, stderr)
+	assert.Contains(t, stdout, "PROPERTY")
+	assert.Contains(t, stdout, "TYPE")
+	assert.Contains(t, stdout, "ALLOWED")
+	assert.Contains(t, stdout, "LATEST")
+	assert.Contains(t, stdout, "state")
+	assert.Contains(t, stdout, "binary")
+	assert.Contains(t, stdout, "ON / OFF")
+	assert.Contains(t, stdout, "power")
+	assert.Contains(t, stdout, "numeric")
+	assert.Contains(t, stdout, "0..2500")
+	assert.Contains(t, stdout, "42.5")
+}
+
+func TestSensorsCommandCommand_PrintsAcceptedCommandDetails(t *testing.T) {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/api/sensors/7/command", r.URL.Path)
+
+		var body gen.SensorCommandRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, "state", body.Property)
+		assert.Equal(t, "ON", body.Value)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		require.NoError(t, json.NewEncoder(w).Encode(gen.SensorCommandAccepted{
+			Id:       42,
+			Property: "state",
+			Status:   gen.SensorCommandAcceptedStatus("sent"),
+			Value:    "ON",
+		}))
+	}))
+	defer server.Close()
+
+	stdout, stderr, err := executeRootCommand(t, "--server", server.URL, "sensors", "command", "7", "state", "ON")
+	require.NoError(t, err)
+	assert.Empty(t, stderr)
+	assert.Contains(t, stdout, "ID")
+	assert.Contains(t, stdout, "STATUS")
+	assert.Contains(t, stdout, "42")
+	assert.Contains(t, stdout, "sent")
+}
+
+func TestSensorsCommandCommand_ReturnsServerMessageOnHTTPError(t *testing.T) {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/api/sensors/7/command", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		require.NoError(t, json.NewEncoder(w).Encode(gen.ErrorResponse{
+			Message: "sensor is disabled",
+		}))
+	}))
+	defer server.Close()
+
+	stdout, stderr, err := executeRootCommand(t, "--server", server.URL, "sensors", "command", "7", "state", "ON")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sensor is disabled")
+	assert.Empty(t, stdout)
+	assert.Empty(t, stderr)
+}
+
+func TestSensorsCommandsCommand_PrintsLatest20HistoryRows(t *testing.T) {
+	t.Helper()
+
+	now := time.Date(2026, 5, 9, 15, 30, 0, 0, time.UTC)
+	history := make([]gen.CommandHistoryEntry, 0, 21)
+	for i := 21; i >= 1; i-- {
+		sentAt := now.Add(time.Duration(-i) * time.Minute)
+		history = append(history, gen.CommandHistoryEntry{
+			Id:       i,
+			SentAt:   sentAt,
+			Property: fmt.Sprintf("property-%03d", i),
+			Value:    fmt.Sprintf("value-%03d", i),
+			Status:   gen.CommandHistoryEntryStatusSent,
+			User: &gen.CommandHistoryUser{
+				Id:       i,
+				Username: fmt.Sprintf("user-%03d", i),
+			},
+		})
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, "/api/sensors/by-id/7/commands", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(history))
+	}))
+	defer server.Close()
+
+	stdout, stderr, err := executeRootCommand(t, "--server", server.URL, "sensors", "commands", "7")
+	require.NoError(t, err)
+	assert.Empty(t, stderr)
+	assert.Contains(t, stdout, "ID")
+	assert.Contains(t, stdout, "SENT_AT")
+	assert.Contains(t, stdout, "PROPERTY")
+	assert.Contains(t, stdout, "VALUE")
+	assert.Contains(t, stdout, "STATUS")
+	assert.Contains(t, stdout, "USER")
+	assert.Contains(t, stdout, "property-021")
+	assert.NotContains(t, stdout, "property-001")
+	assert.Len(t, nonEmptyLines(stdout), 21)
+}
+
+func TestSensorsControlHelp_DocumentsIDArgumentConvention(t *testing.T) {
+	t.Helper()
+
+	capabilitiesHelp, _, err := executeRootCommand(t, "sensors", "capabilities", "--help")
+	require.NoError(t, err)
+	assert.Contains(t, capabilitiesHelp, "capabilities [id]")
+
+	commandHelp, _, err := executeRootCommand(t, "sensors", "command", "--help")
+	require.NoError(t, err)
+	assert.Contains(t, commandHelp, "command [id] [property] [value]")
+
+	commandsHelp, _, err := executeRootCommand(t, "sensors", "commands", "--help")
+	require.NoError(t, err)
+	assert.Contains(t, commandsHelp, "commands [id]")
+}
+
+func executeRootCommand(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	rootCmd.SetOut(&stdout)
+	rootCmd.SetErr(&stderr)
+	rootCmd.SetArgs(args)
+	rootCmd.SilenceErrors = true
+	rootCmd.SilenceUsage = true
+	t.Cleanup(func() {
+		rootCmd.SetOut(io.Discard)
+		rootCmd.SetErr(io.Discard)
+		rootCmd.SetArgs(nil)
+		rootCmd.SilenceErrors = false
+		rootCmd.SilenceUsage = false
+	})
+
+	_, err := rootCmd.ExecuteC()
+	return stdout.String(), stderr.String(), err
+}
+
+func nonEmptyLines(value string) []string {
+	lines := strings.Split(value, "\n")
+	out := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if strings.TrimSpace(line) != "" {
+			out = append(out, line)
+		}
+	}
+	return out
+}

--- a/sensor_hub/integration/main_test.go
+++ b/sensor_hub/integration/main_test.go
@@ -60,6 +60,7 @@ func TestMain(m *testing.M) {
 
 	code := m.Run()
 
+	cleanupSharedZigbee2MQTTBridgeBroker()
 	cleanupServer()
 	cleanupContainers()
 	os.Exit(code)

--- a/sensor_hub/integration/mqtt_metadata_test.go
+++ b/sensor_hub/integration/mqtt_metadata_test.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"sync"
 	"testing"
 	"time"
 
@@ -22,19 +23,30 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestZigbee2MQTTBridgeDevices_BackfillsSensorMetadata(t *testing.T) {
+var (
+	zigbee2MQTTBridgeBrokerOnce sync.Once
+	zigbee2MQTTBridgeBroker     *mqttpkg.EmbeddedBroker
+	zigbee2MQTTBridgeBrokerPort int
+	zigbee2MQTTBridgeBrokerErr  error
+)
+
+type zigbee2MQTTBridgeFixture struct {
+	ctx         context.Context
+	port        int
+	sensorRepo  *database.SensorRepository
+	brokerRepo  *database.MQTTBrokerRepository
+	subRepo     *database.MQTTSubscriptionRepository
+	connManager *mqttpkg.ConnectionManager
+	brokerID    int
+	subID       int
+}
+
+func setupZigbee2MQTTBridgeFixture(t *testing.T, brokerName string, cleanupSensors ...string) zigbee2MQTTBridgeFixture {
+	t.Helper()
+
 	ctx := context.Background()
 	logger := slog.Default()
-	port := reserveTCPPort(t)
-	sensorName := fmt.Sprintf("front-door-%d", port)
-
-	embeddedBroker := mqttpkg.NewEmbeddedBroker(mqttpkg.BrokerConfig{
-		TCPAddress: fmt.Sprintf(":%d", port),
-	}, logger)
-	require.NoError(t, embeddedBroker.Start())
-	defer func() {
-		require.NoError(t, embeddedBroker.Stop())
-	}()
+	port := sharedZigbee2MQTTBridgeBrokerPort(t)
 
 	sensorRepo := database.NewSensorRepository(env.DB, logger)
 	readingsRepo := database.NewReadingsRepository(env.DB, logger)
@@ -46,8 +58,9 @@ func TestZigbee2MQTTBridgeDevices_BackfillsSensorMetadata(t *testing.T) {
 	sensorService := service.NewSensorService(sensorRepo, readingsRepo, mtRepo, alertRepo, nil, logger)
 	connManager := mqttpkg.NewConnectionManager(sensorService, subRepo, brokerRepo, logger)
 
+	resolvedBrokerName := fmt.Sprintf("%s-%d", brokerName, time.Now().UnixNano())
 	brokerID, err := brokerRepo.Add(ctx, gen.MQTTBroker{
-		Name:    fmt.Sprintf("integration-z2m-%d", port),
+		Name:    resolvedBrokerName,
 		Host:    "127.0.0.1",
 		Port:    port,
 		Type:    "external",
@@ -63,17 +76,86 @@ func TestZigbee2MQTTBridgeDevices_BackfillsSensorMetadata(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	defer func() {
-		connManager.Stop()
-		_ = subRepo.Delete(ctx, subID)
-		_ = brokerRepo.Delete(ctx, brokerID)
-		_ = client.DeleteSensor(sensorName)
-	}()
-
-	require.NoError(t, connManager.Start(ctx))
+	require.NoError(t, connManager.ConnectBroker(ctx, gen.MQTTBroker{
+		Id:      &brokerID,
+		Name:    resolvedBrokerName,
+		Host:    "127.0.0.1",
+		Port:    port,
+		Type:    "external",
+		Enabled: true,
+	}))
 	require.Eventually(t, func() bool {
 		return connManager.IsConnected(brokerID)
 	}, 5*time.Second, 100*time.Millisecond)
+
+	t.Cleanup(func() {
+		connManager.DisconnectBroker(brokerID)
+		_ = subRepo.Delete(ctx, subID)
+		_ = brokerRepo.Delete(ctx, brokerID)
+		for _, sensorName := range cleanupSensors {
+			_ = client.DeleteSensor(sensorName)
+		}
+	})
+
+	return zigbee2MQTTBridgeFixture{
+		ctx:         ctx,
+		port:        port,
+		sensorRepo:  sensorRepo,
+		brokerRepo:  brokerRepo,
+		subRepo:     subRepo,
+		connManager: connManager,
+		brokerID:    brokerID,
+		subID:       subID,
+	}
+}
+
+func (f zigbee2MQTTBridgeFixture) newPublisher(t *testing.T, clientID string) pahomqtt.Client {
+	t.Helper()
+
+	mqttClient := pahomqtt.NewClient(
+		pahomqtt.NewClientOptions().
+			AddBroker(fmt.Sprintf("tcp://127.0.0.1:%d", f.port)).
+			SetClientID(clientID),
+	)
+	token := mqttClient.Connect()
+	require.True(t, token.WaitTimeout(5*time.Second))
+	require.NoError(t, token.Error())
+	t.Cleanup(func() {
+		mqttClient.Disconnect(250)
+	})
+	return mqttClient
+}
+
+func sharedZigbee2MQTTBridgeBrokerPort(t *testing.T) int {
+	t.Helper()
+
+	zigbee2MQTTBridgeBrokerOnce.Do(func() {
+		zigbee2MQTTBridgeBrokerPort, zigbee2MQTTBridgeBrokerErr = reserveTCPPortNumber()
+		if zigbee2MQTTBridgeBrokerErr != nil {
+			return
+		}
+
+		zigbee2MQTTBridgeBroker = mqttpkg.NewEmbeddedBroker(mqttpkg.BrokerConfig{
+			TCPAddress: fmt.Sprintf(":%d", zigbee2MQTTBridgeBrokerPort),
+		}, slog.Default())
+		zigbee2MQTTBridgeBrokerErr = zigbee2MQTTBridgeBroker.Start()
+	})
+
+	require.NoError(t, zigbee2MQTTBridgeBrokerErr)
+	return zigbee2MQTTBridgeBrokerPort
+}
+
+func cleanupSharedZigbee2MQTTBridgeBroker() {
+	if zigbee2MQTTBridgeBroker == nil {
+		return
+	}
+	_ = zigbee2MQTTBridgeBroker.Stop()
+}
+
+func TestZigbee2MQTTBridgeDevices_BackfillsSensorMetadata(t *testing.T) {
+	port := reserveTCPPort(t)
+	sensorName := fmt.Sprintf("front-door-%d", port)
+	fixture := setupZigbee2MQTTBridgeFixture(t, "integration-z2m", sensorName)
 
 	_, status := client.AddSensor(gen.Sensor{
 		Name:         sensorName,
@@ -82,15 +164,7 @@ func TestZigbee2MQTTBridgeDevices_BackfillsSensorMetadata(t *testing.T) {
 	})
 	require.Equal(t, http.StatusCreated, status)
 
-	mqttClient := pahomqtt.NewClient(
-		pahomqtt.NewClientOptions().
-			AddBroker(fmt.Sprintf("tcp://127.0.0.1:%d", port)).
-			SetClientID(fmt.Sprintf("integration-z2m-publisher-%d", port)),
-	)
-	token := mqttClient.Connect()
-	require.True(t, token.WaitTimeout(5*time.Second))
-	require.NoError(t, token.Error())
-	defer mqttClient.Disconnect(250)
+	mqttClient := fixture.newPublisher(t, fmt.Sprintf("integration-z2m-publisher-%d", port))
 
 	payload := fmt.Sprintf(`[
 		{
@@ -131,57 +205,9 @@ func TestZigbee2MQTTBridgeDevices_BackfillsSensorMetadata(t *testing.T) {
 }
 
 func TestZigbee2MQTTBridgeDevices_ReportsWritableCapabilitiesViaAPI(t *testing.T) {
-	ctx := context.Background()
-	logger := slog.Default()
 	port := reserveTCPPort(t)
 	sensorName := fmt.Sprintf("office-plug-%d", port)
-
-	embeddedBroker := mqttpkg.NewEmbeddedBroker(mqttpkg.BrokerConfig{
-		TCPAddress: fmt.Sprintf(":%d", port),
-	}, logger)
-	require.NoError(t, embeddedBroker.Start())
-	defer func() {
-		require.NoError(t, embeddedBroker.Stop())
-	}()
-
-	sensorRepo := database.NewSensorRepository(env.DB, logger)
-	readingsRepo := database.NewReadingsRepository(env.DB, logger)
-	mtRepo := database.NewMeasurementTypeRepository(env.DB, logger)
-	alertRepo := database.NewAlertRepository(env.DB, logger)
-	brokerRepo := database.NewMQTTBrokerRepository(env.DB, logger)
-	subRepo := database.NewMQTTSubscriptionRepository(env.DB, logger)
-
-	sensorService := service.NewSensorService(sensorRepo, readingsRepo, mtRepo, alertRepo, nil, logger)
-	connManager := mqttpkg.NewConnectionManager(sensorService, subRepo, brokerRepo, logger)
-
-	brokerID, err := brokerRepo.Add(ctx, gen.MQTTBroker{
-		Name:    fmt.Sprintf("integration-z2m-capabilities-%d", port),
-		Host:    "127.0.0.1",
-		Port:    port,
-		Type:    "external",
-		Enabled: true,
-	})
-	require.NoError(t, err)
-
-	subID, err := subRepo.Add(ctx, gen.MQTTSubscription{
-		BrokerId:     brokerID,
-		TopicPattern: "zigbee2mqtt/#",
-		DriverType:   "mqtt-zigbee2mqtt",
-		Enabled:      true,
-	})
-	require.NoError(t, err)
-
-	defer func() {
-		connManager.Stop()
-		_ = subRepo.Delete(ctx, subID)
-		_ = brokerRepo.Delete(ctx, brokerID)
-		_ = client.DeleteSensor(sensorName)
-	}()
-
-	require.NoError(t, connManager.Start(ctx))
-	require.Eventually(t, func() bool {
-		return connManager.IsConnected(brokerID)
-	}, 5*time.Second, 100*time.Millisecond)
+	fixture := setupZigbee2MQTTBridgeFixture(t, "integration-z2m-capabilities", sensorName)
 
 	_, status := client.AddSensor(gen.Sensor{
 		Name:         sensorName,
@@ -190,15 +216,7 @@ func TestZigbee2MQTTBridgeDevices_ReportsWritableCapabilitiesViaAPI(t *testing.T
 	})
 	require.Equal(t, http.StatusCreated, status)
 
-	mqttClient := pahomqtt.NewClient(
-		pahomqtt.NewClientOptions().
-			AddBroker(fmt.Sprintf("tcp://127.0.0.1:%d", port)).
-			SetClientID(fmt.Sprintf("integration-z2m-capabilities-publisher-%d", port)),
-	)
-	token := mqttClient.Connect()
-	require.True(t, token.WaitTimeout(5*time.Second))
-	require.NoError(t, token.Error())
-	defer mqttClient.Disconnect(250)
+	mqttClient := fixture.newPublisher(t, fmt.Sprintf("integration-z2m-capabilities-publisher-%d", port))
 
 	payload := fmt.Sprintf(`[
 		{
@@ -244,57 +262,9 @@ func TestZigbee2MQTTBridgeDevices_ReportsWritableCapabilitiesViaAPI(t *testing.T
 }
 
 func TestZigbee2MQTTBridgeDevices_ReadOnlySensorsReturnEmptyCapabilities(t *testing.T) {
-	ctx := context.Background()
-	logger := slog.Default()
 	port := reserveTCPPort(t)
 	sensorName := fmt.Sprintf("temperature-probe-%d", port)
-
-	embeddedBroker := mqttpkg.NewEmbeddedBroker(mqttpkg.BrokerConfig{
-		TCPAddress: fmt.Sprintf(":%d", port),
-	}, logger)
-	require.NoError(t, embeddedBroker.Start())
-	defer func() {
-		require.NoError(t, embeddedBroker.Stop())
-	}()
-
-	sensorRepo := database.NewSensorRepository(env.DB, logger)
-	readingsRepo := database.NewReadingsRepository(env.DB, logger)
-	mtRepo := database.NewMeasurementTypeRepository(env.DB, logger)
-	alertRepo := database.NewAlertRepository(env.DB, logger)
-	brokerRepo := database.NewMQTTBrokerRepository(env.DB, logger)
-	subRepo := database.NewMQTTSubscriptionRepository(env.DB, logger)
-
-	sensorService := service.NewSensorService(sensorRepo, readingsRepo, mtRepo, alertRepo, nil, logger)
-	connManager := mqttpkg.NewConnectionManager(sensorService, subRepo, brokerRepo, logger)
-
-	brokerID, err := brokerRepo.Add(ctx, gen.MQTTBroker{
-		Name:    fmt.Sprintf("integration-z2m-read-only-%d", port),
-		Host:    "127.0.0.1",
-		Port:    port,
-		Type:    "external",
-		Enabled: true,
-	})
-	require.NoError(t, err)
-
-	subID, err := subRepo.Add(ctx, gen.MQTTSubscription{
-		BrokerId:     brokerID,
-		TopicPattern: "zigbee2mqtt/#",
-		DriverType:   "mqtt-zigbee2mqtt",
-		Enabled:      true,
-	})
-	require.NoError(t, err)
-
-	defer func() {
-		connManager.Stop()
-		_ = subRepo.Delete(ctx, subID)
-		_ = brokerRepo.Delete(ctx, brokerID)
-		_ = client.DeleteSensor(sensorName)
-	}()
-
-	require.NoError(t, connManager.Start(ctx))
-	require.Eventually(t, func() bool {
-		return connManager.IsConnected(brokerID)
-	}, 5*time.Second, 100*time.Millisecond)
+	fixture := setupZigbee2MQTTBridgeFixture(t, "integration-z2m-read-only", sensorName)
 
 	_, status := client.AddSensor(gen.Sensor{
 		Name:         sensorName,
@@ -303,15 +273,7 @@ func TestZigbee2MQTTBridgeDevices_ReadOnlySensorsReturnEmptyCapabilities(t *test
 	})
 	require.Equal(t, http.StatusCreated, status)
 
-	mqttClient := pahomqtt.NewClient(
-		pahomqtt.NewClientOptions().
-			AddBroker(fmt.Sprintf("tcp://127.0.0.1:%d", port)).
-			SetClientID(fmt.Sprintf("integration-z2m-read-only-publisher-%d", port)),
-	)
-	token := mqttClient.Connect()
-	require.True(t, token.WaitTimeout(5*time.Second))
-	require.NoError(t, token.Error())
-	defer mqttClient.Disconnect(250)
+	mqttClient := fixture.newPublisher(t, fmt.Sprintf("integration-z2m-read-only-publisher-%d", port))
 
 	payload := fmt.Sprintf(`[
 		{
@@ -350,61 +312,12 @@ func TestZigbee2MQTTBridgeDevices_ReadOnlySensorsReturnEmptyCapabilities(t *test
 }
 
 func TestZigbee2MQTTBridgeDevices_RenamesPhantomIEEESensorInPlace(t *testing.T) {
-	ctx := context.Background()
-	logger := slog.Default()
 	port := reserveTCPPort(t)
 	friendlyName := fmt.Sprintf("front-door-renamed-%d", port)
 	ieeeName := "0x00158d00018255df"
+	fixture := setupZigbee2MQTTBridgeFixture(t, "integration-z2m-rename", friendlyName, ieeeName)
 
-	embeddedBroker := mqttpkg.NewEmbeddedBroker(mqttpkg.BrokerConfig{
-		TCPAddress: fmt.Sprintf(":%d", port),
-	}, logger)
-	require.NoError(t, embeddedBroker.Start())
-	defer func() {
-		require.NoError(t, embeddedBroker.Stop())
-	}()
-
-	sensorRepo := database.NewSensorRepository(env.DB, logger)
-	readingsRepo := database.NewReadingsRepository(env.DB, logger)
-	mtRepo := database.NewMeasurementTypeRepository(env.DB, logger)
-	alertRepo := database.NewAlertRepository(env.DB, logger)
-	brokerRepo := database.NewMQTTBrokerRepository(env.DB, logger)
-	subRepo := database.NewMQTTSubscriptionRepository(env.DB, logger)
-
-	sensorService := service.NewSensorService(sensorRepo, readingsRepo, mtRepo, alertRepo, nil, logger)
-	connManager := mqttpkg.NewConnectionManager(sensorService, subRepo, brokerRepo, logger)
-
-	brokerID, err := brokerRepo.Add(ctx, gen.MQTTBroker{
-		Name:    fmt.Sprintf("integration-z2m-rename-%d", port),
-		Host:    "127.0.0.1",
-		Port:    port,
-		Type:    "external",
-		Enabled: true,
-	})
-	require.NoError(t, err)
-
-	subID, err := subRepo.Add(ctx, gen.MQTTSubscription{
-		BrokerId:     brokerID,
-		TopicPattern: "zigbee2mqtt/#",
-		DriverType:   "mqtt-zigbee2mqtt",
-		Enabled:      true,
-	})
-	require.NoError(t, err)
-
-	defer func() {
-		connManager.Stop()
-		_ = subRepo.Delete(ctx, subID)
-		_ = brokerRepo.Delete(ctx, brokerID)
-		_ = client.DeleteSensor(friendlyName)
-		_ = client.DeleteSensor(ieeeName)
-	}()
-
-	require.NoError(t, connManager.Start(ctx))
-	require.Eventually(t, func() bool {
-		return connManager.IsConnected(brokerID)
-	}, 5*time.Second, 100*time.Millisecond)
-
-	require.NoError(t, sensorRepo.AddSensor(ctx, gen.Sensor{
+	require.NoError(t, fixture.sensorRepo.AddSensor(fixture.ctx, gen.Sensor{
 		Name:         ieeeName,
 		ExternalId:   &ieeeName,
 		SensorDriver: "mqtt-zigbee2mqtt",
@@ -412,18 +325,10 @@ func TestZigbee2MQTTBridgeDevices_RenamesPhantomIEEESensorInPlace(t *testing.T) 
 		Status:       gen.SensorStatusPending,
 	}))
 
-	phantom, err := sensorRepo.GetSensorByName(ctx, ieeeName)
+	phantom, err := fixture.sensorRepo.GetSensorByName(fixture.ctx, ieeeName)
 	require.NoError(t, err)
 
-	mqttClient := pahomqtt.NewClient(
-		pahomqtt.NewClientOptions().
-			AddBroker(fmt.Sprintf("tcp://127.0.0.1:%d", port)).
-			SetClientID(fmt.Sprintf("integration-z2m-rename-publisher-%d", port)),
-	)
-	token := mqttClient.Connect()
-	require.True(t, token.WaitTimeout(5*time.Second))
-	require.NoError(t, token.Error())
-	defer mqttClient.Disconnect(250)
+	mqttClient := fixture.newPublisher(t, fmt.Sprintf("integration-z2m-rename-publisher-%d", port))
 
 	payload := fmt.Sprintf(`[
 		{
@@ -466,74 +371,16 @@ func TestZigbee2MQTTBridgeDevices_RenamesPhantomIEEESensorInPlace(t *testing.T) 
 			metadata["ieee_address"] == ieeeName
 	}, 5*time.Second, 100*time.Millisecond)
 
-	_, err = sensorRepo.GetSensorByName(ctx, ieeeName)
+	_, err = fixture.sensorRepo.GetSensorByName(fixture.ctx, ieeeName)
 	assert.Error(t, err)
 }
 
 func TestZigbee2MQTTBridgeDevices_AutoDiscoversFriendlySensorFromIEEEWithMetadata(t *testing.T) {
-	ctx := context.Background()
-	logger := slog.Default()
 	port := reserveTCPPort(t)
 	friendlyName := fmt.Sprintf("front-door-new-%d", port)
 	ieeeName := "0x00158d00018255aa"
-
-	embeddedBroker := mqttpkg.NewEmbeddedBroker(mqttpkg.BrokerConfig{
-		TCPAddress: fmt.Sprintf(":%d", port),
-	}, logger)
-	require.NoError(t, embeddedBroker.Start())
-	defer func() {
-		require.NoError(t, embeddedBroker.Stop())
-	}()
-
-	sensorRepo := database.NewSensorRepository(env.DB, logger)
-	readingsRepo := database.NewReadingsRepository(env.DB, logger)
-	mtRepo := database.NewMeasurementTypeRepository(env.DB, logger)
-	alertRepo := database.NewAlertRepository(env.DB, logger)
-	brokerRepo := database.NewMQTTBrokerRepository(env.DB, logger)
-	subRepo := database.NewMQTTSubscriptionRepository(env.DB, logger)
-
-	sensorService := service.NewSensorService(sensorRepo, readingsRepo, mtRepo, alertRepo, nil, logger)
-	connManager := mqttpkg.NewConnectionManager(sensorService, subRepo, brokerRepo, logger)
-
-	brokerID, err := brokerRepo.Add(ctx, gen.MQTTBroker{
-		Name:    fmt.Sprintf("integration-z2m-autodiscover-%d", port),
-		Host:    "127.0.0.1",
-		Port:    port,
-		Type:    "external",
-		Enabled: true,
-	})
-	require.NoError(t, err)
-
-	subID, err := subRepo.Add(ctx, gen.MQTTSubscription{
-		BrokerId:     brokerID,
-		TopicPattern: "zigbee2mqtt/#",
-		DriverType:   "mqtt-zigbee2mqtt",
-		Enabled:      true,
-	})
-	require.NoError(t, err)
-
-	defer func() {
-		connManager.Stop()
-		_ = subRepo.Delete(ctx, subID)
-		_ = brokerRepo.Delete(ctx, brokerID)
-		_ = client.DeleteSensor(friendlyName)
-		_ = client.DeleteSensor(ieeeName)
-	}()
-
-	require.NoError(t, connManager.Start(ctx))
-	require.Eventually(t, func() bool {
-		return connManager.IsConnected(brokerID)
-	}, 5*time.Second, 100*time.Millisecond)
-
-	mqttClient := pahomqtt.NewClient(
-		pahomqtt.NewClientOptions().
-			AddBroker(fmt.Sprintf("tcp://127.0.0.1:%d", port)).
-			SetClientID(fmt.Sprintf("integration-z2m-autodiscover-publisher-%d", port)),
-	)
-	token := mqttClient.Connect()
-	require.True(t, token.WaitTimeout(5*time.Second))
-	require.NoError(t, token.Error())
-	defer mqttClient.Disconnect(250)
+	fixture := setupZigbee2MQTTBridgeFixture(t, "integration-z2m-autodiscover", friendlyName, ieeeName)
+	mqttClient := fixture.newPublisher(t, fmt.Sprintf("integration-z2m-autodiscover-publisher-%d", port))
 
 	payload := fmt.Sprintf(`[
 		{
@@ -577,9 +424,17 @@ func TestZigbee2MQTTBridgeDevices_AutoDiscoversFriendlySensorFromIEEEWithMetadat
 func reserveTCPPort(t *testing.T) int {
 	t.Helper()
 
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	port, err := reserveTCPPortNumber()
 	require.NoError(t, err)
+	return port
+}
+
+func reserveTCPPortNumber() (int, error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
 	defer listener.Close()
 
-	return listener.Addr().(*net.TCPAddr).Port
+	return listener.Addr().(*net.TCPAddr).Port, nil
 }


### PR DESCRIPTION
## Summary
- add `sensor-hub sensors capabilities`, `sensor-hub sensors command`, and `sensor-hub sensors commands` with CLI-level coverage
- use the generated API client plus the current-readings websocket snapshot so capabilities can show latest values without bespoke command-only HTTP code
- speed up `TestZigbee2MQTTBridgeDevices*` by sharing the embedded MQTT broker and connecting only the test broker instead of loading every enabled broker

Fixes #76
Relates to #14
