### PR TITLE
Add sensor-toggle dashboard widget

### DIFF
--- a/docs/docs/dashboards.md
+++ b/docs/docs/dashboards.md
@@ -15,8 +15,11 @@ across sessions.
 Some widgets require or accept configuration:
 
 - **sensorId** — which sensor to display (e.g. Health Timeline, Current
-  Reading, Gauge, Uptime, Sensor Detail, Heatmap, Min/Max/Avg)
+  Reading, Gauge, Uptime, Sensor Detail, Heatmap, Min/Max/Avg, Sensor Toggle)
 - **sensorIds** — multiple sensors to display (e.g. Comparison Chart)
+- **property** — which controllable binary property to switch (used by Sensor
+  Toggle, defaults to `state` and is chosen from the selected sensor's
+  available binary capabilities)
 - **measurementType** — which measurement type to chart or display
   (e.g. `temperature`, `humidity`, `contact`, `power`)
 - **timeRange** — time window for historical data: `1h`, `6h`, `24h`,

--- a/docs/docs/development/docker-dev-environment.md
+++ b/docs/docs/development/docker-dev-environment.md
@@ -54,8 +54,10 @@ Register them in the Sensor Hub UI to test the full pull-based pipeline.
 The `mock-mqtt-sensor` container simulates three Zigbee2MQTT devices that
 publish to the embedded MQTT broker inside sensor-hub every 5 seconds:
 
-Values drift randomly within realistic ranges. The contact sensor and smart
-plug toggle state occasionally to produce interesting binary data.
+Values drift randomly within realistic ranges. The container also publishes a
+retained `zigbee2mqtt/bridge/devices` message so Sensor Hub can discover device
+metadata and controllable capabilities, and the `office-plug` device accepts
+`zigbee2mqtt/office-plug/set` commands for manual control testing.
 
 #### Setting Up MQTT Ingest
 
@@ -70,3 +72,6 @@ stack is running:
 **3. Check that devices were auto-discovered as pending sensors:**
 
 You should see some sensors listed as pending. Approve them to start recording readings.
+
+Once the `office-plug` sensor is approved, it can be used with the Sensor Toggle
+dashboard widget or the command API for end-to-end local actuator testing.

--- a/sensor_hub/docker_tests/mock-mqtt-sensor.py
+++ b/sensor_hub/docker_tests/mock-mqtt-sensor.py
@@ -3,7 +3,7 @@
 Simulates three devices:
   - living-room-sensor: temperature, humidity, battery, linkquality
   - front-door:         contact (binary), battery
-  - office-plug:        power, energy, current, state (binary)
+  - office-plug:        power, energy, current, state (binary, commandable)
 
 Each device publishes every PUBLISH_INTERVAL seconds (default 5) to topics
 matching the zigbee2mqtt/<device-name> convention.
@@ -28,6 +28,51 @@ state = {
     "front-door": {"contact": True, "battery": 88},
     "office-plug": {"energy": 1.2, "state": "ON"},
 }
+
+BRIDGE_DEVICES = [
+    {
+        "ieee_address": "0x00158d0001000001",
+        "friendly_name": "living-room-sensor",
+        "definition": {
+            "model": "WSDCGQ11LM",
+            "vendor": "Aqara",
+            "description": "Temperature and humidity sensor",
+            "exposes": [
+                {"type": "numeric", "property": "temperature", "name": "temperature", "access": 1, "unit": "°C"},
+                {"type": "numeric", "property": "humidity", "name": "humidity", "access": 1, "unit": "%"},
+                {"type": "numeric", "property": "battery", "name": "battery", "access": 1, "unit": "%"},
+            ],
+        },
+    },
+    {
+        "ieee_address": "0x00158d0001000002",
+        "friendly_name": "front-door",
+        "definition": {
+            "model": "MCCGQ11LM",
+            "vendor": "Aqara",
+            "description": "Door and window sensor",
+            "exposes": [
+                {"type": "binary", "property": "contact", "name": "contact", "access": 1},
+                {"type": "numeric", "property": "battery", "name": "battery", "access": 1, "unit": "%"},
+            ],
+        },
+    },
+    {
+        "ieee_address": "0x00158d0001000003",
+        "friendly_name": "office-plug",
+        "definition": {
+            "model": "TS011F",
+            "vendor": "Tuya",
+            "description": "Smart plug",
+            "exposes": [
+                {"type": "binary", "property": "state", "name": "state", "access": 7, "value_on": "ON", "value_off": "OFF"},
+                {"type": "numeric", "property": "power", "name": "power", "access": 1, "unit": "W", "value_min": 0, "value_max": 2500},
+                {"type": "numeric", "property": "energy", "name": "energy", "access": 1, "unit": "kWh", "value_min": 0},
+                {"type": "numeric", "property": "current", "name": "current", "access": 1, "unit": "A", "value_min": 0},
+            ],
+        },
+    },
+]
 
 
 def drift(value, low, high, step=0.3):
@@ -63,9 +108,6 @@ def build_front_door():
 
 def build_office_plug():
     s = state["office-plug"]
-    # Toggle on/off occasionally (~5% chance)
-    if random.random() < 0.05:
-        s["state"] = "OFF" if s["state"] == "ON" else "ON"
     if s["state"] == "ON":
         power = round(random.uniform(40.0, 120.0), 1)
         current = round(power / 230.0, 3)
@@ -91,13 +133,60 @@ DEVICES = {
 def on_connect(client, userdata, flags, rc, properties=None):
     if rc == 0:
         print(f"Connected to MQTT broker at {BROKER_HOST}:{BROKER_PORT}", flush=True)
+        client.subscribe("zigbee2mqtt/+/set", qos=1)
+        publish_bridge_devices(client)
     else:
         print(f"Connection failed with code {rc}", flush=True)
+
+
+def normalise_switch_value(value):
+    if isinstance(value, bool):
+        return "ON" if value else "OFF"
+    if isinstance(value, str):
+        upper = value.strip().upper()
+        if upper in {"ON", "OFF"}:
+            return upper
+    return None
+
+
+def publish_bridge_devices(client):
+    payload = json.dumps(BRIDGE_DEVICES)
+    client.publish("zigbee2mqtt/bridge/devices", payload, qos=1, retain=True)
+    print("  → zigbee2mqtt/bridge/devices: retained device metadata", flush=True)
+
+
+def publish_device_state(client, name):
+    topic = f"zigbee2mqtt/{name}"
+    payload = json.dumps(DEVICES[name]())
+    client.publish(topic, payload, qos=0)
+    print(f"  → {topic}: {payload}", flush=True)
+
+
+def on_message(client, userdata, msg):
+    try:
+        payload = json.loads(msg.payload.decode("utf-8"))
+    except json.JSONDecodeError:
+        print(f"Ignoring invalid command payload on {msg.topic}: {msg.payload!r}", flush=True)
+        return
+
+    if msg.topic != "zigbee2mqtt/office-plug/set":
+        print(f"Ignoring command for unsupported topic {msg.topic}", flush=True)
+        return
+
+    requested_state = normalise_switch_value(payload.get("state"))
+    if requested_state is None:
+        print(f"Ignoring unsupported office-plug state payload: {payload!r}", flush=True)
+        return
+
+    state["office-plug"]["state"] = requested_state
+    print(f"  ← {msg.topic}: setting office-plug state to {requested_state}", flush=True)
+    publish_device_state(client, "office-plug")
 
 
 def main():
     client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2, client_id="mock-mqtt-sensor")
     client.on_connect = on_connect
+    client.on_message = on_message
 
     print(f"Connecting to {BROKER_HOST}:{BROKER_PORT}...", flush=True)
 
@@ -127,11 +216,8 @@ def main():
     print(f"Publishing {len(device_names)} devices every {PUBLISH_INTERVAL}s", flush=True)
 
     while True:
-        for i, (name, builder) in enumerate(DEVICES.items()):
-            topic = f"zigbee2mqtt/{name}"
-            payload = json.dumps(builder())
-            client.publish(topic, payload, qos=0)
-            print(f"  → {topic}: {payload}", flush=True)
+        for i, name in enumerate(DEVICES):
+            publish_device_state(client, name)
             if i < len(device_names) - 1:
                 time.sleep(stagger)
         remaining = PUBLISH_INTERVAL - stagger * (len(device_names) - 1)

--- a/sensor_hub/skills/claude.md
+++ b/sensor_hub/skills/claude.md
@@ -235,6 +235,7 @@ The `update` command requires a JSON file with the full dashboard structure.
 | `uptime`             | `sensorId` (number), `limit` (number, default 1000)                                                                        | Uptime percentage for a sensor               |
 | `heatmap`            | `sensorId` (number), `measurementType` (measurement-type), `scaleMin` (number, default 10), `scaleMax` (number, default 30) | Colour-coded 30-day heatmap                 |
 | `sensor-detail`      | `sensorId` (number)                                                                                                        | Latest readings grid for a sensor            |
+| `sensor-toggle`      | `sensorId` (controllable binary sensor), `property` (binary capability property, default `state`)                         | Large optimistic on/off switch for a controllable sensor |
 
 **Config field notes:**
 - `sensorId` is a numeric sensor ID (see `sensor-hub sensors list` to find IDs)

--- a/sensor_hub/skills/copilot.md
+++ b/sensor_hub/skills/copilot.md
@@ -235,6 +235,7 @@ The `update` command requires a JSON file with the full dashboard structure.
 | `uptime`             | `sensorId` (number), `limit` (number, default 1000)                                                                        | Uptime percentage for a sensor               |
 | `heatmap`            | `sensorId` (number), `measurementType` (measurement-type), `scaleMin` (number, default 10), `scaleMax` (number, default 30) | Colour-coded 30-day heatmap                 |
 | `sensor-detail`      | `sensorId` (number)                                                                                                        | Latest readings grid for a sensor            |
+| `sensor-toggle`      | `sensorId` (controllable binary sensor), `property` (binary capability property, default `state`)                         | Large optimistic on/off switch for a controllable sensor |
 
 **Config field notes:**
 - `sensorId` is a numeric sensor ID (see `sensor-hub sensors list` to find IDs)

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/WidgetConfigDialog.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/WidgetConfigDialog.tsx
@@ -30,15 +30,29 @@ export default function WidgetConfigDialog({ open, widgetId, onClose }: WidgetCo
     const definition = widget ? getWidget(widget.type) : null;
 
     const hasSensorSelect = definition?.configFields?.some(f => f.type === 'sensor-select') ?? false;
+    const hasControllableSensorSelect = definition?.configFields?.some(f => f.type === 'controllable-sensor-select') ?? false;
     const hasMultiSensorSelect = definition?.configFields?.some(f => f.type === 'multi-sensor-select') ?? false;
+    const hasBinaryCapabilitySelect = definition?.configFields?.some(f => f.type === 'binary-capability-select') ?? false;
     const hasMeasurementTypeSelect = definition?.configFields?.some(f => f.type === 'measurement-type-select') ?? false;
 
     const selectedSensorId = (localConfig.sensorId as number | undefined) ?? null;
     const selectedSensorIds = (Array.isArray(localConfig.sensorIds) ? localConfig.sensorIds : []) as number[];
+    const selectedSensor = useMemo(
+        () => (selectedSensorId ? sensors.find((sensor) => sensor.id === selectedSensorId) ?? null : null),
+        [selectedSensorId, sensors],
+    );
+    const controllableSensors = useMemo(
+        () => sensors.filter((sensor) => sensor.capabilities?.some((capability) => capability.type === 'binary')),
+        [sensors],
+    );
+    const binaryCapabilities = useMemo(
+        () => (selectedSensor?.capabilities ?? []).filter((capability) => capability.type === 'binary'),
+        [selectedSensor],
+    );
 
     // Fetch measurement types based on context
     const sensorMT = useSensorMeasurementTypes(
-        hasSensorSelect && hasMeasurementTypeSelect && selectedSensorId ? selectedSensorId : null
+        (hasSensorSelect || hasControllableSensorSelect) && hasMeasurementTypeSelect && selectedSensorId ? selectedSensorId : null
     );
     const globalMT = useMeasurementTypesWithReadings();
 
@@ -60,11 +74,11 @@ export default function WidgetConfigDialog({ open, widgetId, onClose }: WidgetCo
 
     // Determine which measurement type list to display
     const filteredMeasurementTypes = useMemo(() => {
-        if (hasSensorSelect && selectedSensorId) return sensorMT.measurementTypes;
+        if ((hasSensorSelect || hasControllableSensorSelect) && selectedSensorId) return sensorMT.measurementTypes;
         if (hasMultiSensorSelect && selectedSensorIds.length > 0) return intersectedTypes;
         if (hasMeasurementTypeSelect) return globalMT.measurementTypes;
         return [];
-    }, [hasSensorSelect, selectedSensorId, sensorMT.measurementTypes,
+    }, [hasSensorSelect, hasControllableSensorSelect, selectedSensorId, sensorMT.measurementTypes,
         hasMultiSensorSelect, selectedSensorIds.length, intersectedTypes,
         hasMeasurementTypeSelect, globalMT.measurementTypes]);
 
@@ -78,6 +92,24 @@ export default function WidgetConfigDialog({ open, widgetId, onClose }: WidgetCo
             }
         }
     }, [filteredMeasurementTypes]);
+
+    useEffect(() => {
+        if (!hasBinaryCapabilitySelect) return;
+
+        const currentProperty = typeof localConfig.property === 'string' ? localConfig.property : '';
+        if (binaryCapabilities.length === 0) {
+            if (currentProperty) {
+                setLocalConfig(prev => ({ ...prev, property: '' }));
+            }
+            return;
+        }
+
+        const propertyStillValid = binaryCapabilities.some(capability => capability.property === currentProperty);
+        if (propertyStillValid) return;
+
+        const preferredCapability = binaryCapabilities.find(capability => capability.property === 'state') ?? binaryCapabilities[0];
+        setLocalConfig(prev => ({ ...prev, property: preferredCapability?.property ?? '' }));
+    }, [binaryCapabilities, hasBinaryCapabilitySelect, localConfig.property]);
 
     useEffect(() => {
         if (widget) setLocalConfig({ ...widget.config });
@@ -154,6 +186,8 @@ export default function WidgetConfigDialog({ open, widgetId, onClose }: WidgetCo
                                 </FormControl>
                             );
                         case 'sensor-select':
+                        case 'controllable-sensor-select': {
+                            const selectableSensors = field.type === 'controllable-sensor-select' ? controllableSensors : sensors;
                             return (
                                 <FormControl sx={{ mt: 1 }} key={field.key} fullWidth>
                                     <InputLabel>{field.label}</InputLabel>
@@ -161,8 +195,23 @@ export default function WidgetConfigDialog({ open, widgetId, onClose }: WidgetCo
                                         value={(value as number) || ''} label={field.label}
                                         onChange={(e) => setLocalConfig({ ...localConfig, [field.key]: Number(e.target.value) })}
                                     >
-                                        {sensors.map((s) => (
+                                        {selectableSensors.map((s) => (
                                             <MenuItem key={s.id} value={s.id}>{s.name}</MenuItem>
+                                        ))}
+                                    </Select>
+                                </FormControl>
+                            );
+                        }
+                        case 'binary-capability-select':
+                            return (
+                                <FormControl sx={{ mt: 1 }} key={field.key} fullWidth disabled={selectedSensor == null || binaryCapabilities.length === 0}>
+                                    <InputLabel>{field.label}</InputLabel>
+                                    <Select
+                                        value={(value as string) || ''} label={field.label}
+                                        onChange={(e) => setLocalConfig({ ...localConfig, [field.key]: e.target.value })}
+                                    >
+                                        {binaryCapabilities.map((capability) => (
+                                            <MenuItem key={capability.property} value={capability.property}>{capability.property}</MenuItem>
                                         ))}
                                     </Select>
                                 </FormControl>

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/types.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/types.ts
@@ -23,7 +23,7 @@ export interface WidgetDefinition {
 export interface WidgetConfigField {
     key: string;
     label: string;
-    type: 'text' | 'textarea' | 'number' | 'boolean' | 'select' | 'sensor-select' | 'multi-sensor-select' | 'date' | 'measurement-type-select' | 'time-range' | 'aggregation-function-select';
+    type: 'text' | 'textarea' | 'number' | 'boolean' | 'select' | 'sensor-select' | 'controllable-sensor-select' | 'binary-capability-select' | 'multi-sensor-select' | 'date' | 'measurement-type-select' | 'time-range' | 'aggregation-function-select';
     options?: { value: string; label: string }[];
     defaultValue?: unknown;
 }

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/SensorToggleWidget.test.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/SensorToggleWidget.test.tsx
@@ -1,0 +1,226 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Capability, CommandStatusMessage, Reading, Sensor, SensorCommandAccepted } from '../../gen/aliases';
+import SensorToggleWidget from './SensorToggleWidget';
+
+const { postMock, reportUpdateMock } = vi.hoisted(() => ({
+  postMock: vi.fn(),
+  reportUpdateMock: vi.fn(),
+}));
+
+const currentReadings: Record<string, Record<string, Reading>> = {};
+const sensors: Sensor[] = [];
+let authUser: { id: number; username: string; roles: string[]; permissions?: string[] } | null = null;
+let commandStatusHandler: ((message: CommandStatusMessage) => void) | undefined;
+
+vi.mock('../../gen/client', () => ({
+  apiClient: {
+    POST: postMock,
+  },
+}));
+
+vi.mock('../../hooks/useSensorContext', () => ({
+  useSensorContext: () => ({
+    sensors,
+    loaded: true,
+  }),
+}));
+
+vi.mock('../../hooks/useCurrentReadings', () => ({
+  useCurrentReadings: (options?: { onCommandStatus?: (message: CommandStatusMessage) => void }) => {
+    commandStatusHandler = options?.onCommandStatus;
+    return currentReadings;
+  },
+}));
+
+vi.mock('../../providers/AuthContext', () => ({
+  useAuth: () => ({
+    user: authUser,
+  }),
+}));
+
+vi.mock('../WidgetUpdateContext', () => ({
+  useReportWidgetUpdate: () => reportUpdateMock,
+}));
+
+function makeCapability(overrides: Partial<Capability> = {}): Capability {
+  return {
+    property: 'state',
+    type: 'binary',
+    value_on: 'ENABLED',
+    value_off: 'DISABLED',
+    ...overrides,
+  };
+}
+
+function makeSensor(overrides: Partial<Sensor> = {}): Sensor {
+  return {
+    id: 7,
+    name: 'office-plug',
+    external_id: 'office-plug',
+    sensor_driver: 'zigbee2mqtt',
+    config: {},
+    metadata: {},
+    capabilities: [makeCapability()],
+    health_status: 'good',
+    health_reason: 'ok',
+    enabled: true,
+    status: 'active',
+    retention_hours: null,
+    ...overrides,
+  };
+}
+
+function makeReading(overrides: Partial<Reading> = {}): Reading {
+  return {
+    id: 99,
+    sensor_name: 'office-plug',
+    measurement_type: 'state',
+    numeric_value: null,
+    text_state: 'ENABLED',
+    unit: '',
+    time: '2026-05-09T18:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('SensorToggleWidget', () => {
+  beforeEach(() => {
+    sensors.splice(0, sensors.length);
+    Object.keys(currentReadings).forEach((key) => delete currentReadings[key]);
+    authUser = null;
+    commandStatusHandler = undefined;
+    postMock.mockReset();
+    reportUpdateMock.mockReset();
+  });
+
+  it('renders the current binary state and flips optimistically when sending a command', async () => {
+    sensors.splice(0, sensors.length, makeSensor());
+    currentReadings['office-plug'] = { state: makeReading() };
+    authUser = {
+      id: 1,
+      username: 'operator',
+      roles: [],
+      permissions: ['control_sensors'],
+    };
+
+    let resolvePost: ((value: { data: SensorCommandAccepted }) => void) | undefined;
+    postMock.mockImplementation(
+      () =>
+        new Promise<{ data: SensorCommandAccepted }>((resolve) => {
+          resolvePost = resolve;
+        }),
+    );
+
+    render(
+      <SensorToggleWidget
+        id="widget-1"
+        config={{ sensorId: 7, property: 'state' }}
+        isEditing={false}
+      />,
+    );
+
+    const toggle = screen.getByRole('checkbox', { name: /toggle office-plug state/i });
+    expect(toggle).toBeChecked();
+
+    fireEvent.click(toggle);
+
+    expect(postMock).toHaveBeenCalledWith('/sensors/{id}/command', {
+      params: { path: { id: 7 } },
+      body: { property: 'state', value: 'DISABLED' },
+    });
+    expect(toggle).not.toBeChecked();
+    expect(reportUpdateMock).toHaveBeenCalledTimes(1);
+
+    if (!resolvePost) {
+      throw new Error('Expected command request to be pending');
+    }
+
+    resolvePost({
+      data: {
+        id: 42,
+        status: 'sent',
+        property: 'state',
+        value: 'DISABLED',
+      },
+    });
+  });
+
+  it('reverts the optimistic state and shows an error snackbar when the command fails', async () => {
+    sensors.splice(0, sensors.length, makeSensor());
+    currentReadings['office-plug'] = { state: makeReading() };
+    authUser = {
+      id: 1,
+      username: 'operator',
+      roles: [],
+      permissions: ['control_sensors'],
+    };
+
+    postMock.mockResolvedValue({
+      data: {
+        id: 42,
+        status: 'sent',
+        property: 'state',
+        value: 'DISABLED',
+      } satisfies SensorCommandAccepted,
+    });
+
+    render(
+      <SensorToggleWidget
+        id="widget-1"
+        config={{ sensorId: 7, property: 'state' }}
+        isEditing={false}
+      />,
+    );
+
+    const toggle = screen.getByRole('checkbox', { name: /toggle office-plug state/i });
+    fireEvent.click(toggle);
+
+    expect(toggle).not.toBeChecked();
+    await Promise.resolve();
+
+    commandStatusHandler?.({
+      type: 'command_status',
+      id: 42,
+      sensor_id: 7,
+      property: 'state',
+      value: 'DISABLED',
+      status: 'failed',
+      acknowledged_at: null,
+      acknowledged_value: null,
+    });
+
+    await waitFor(() =>
+      expect(screen.getByRole('checkbox', { name: /toggle office-plug state/i })).toBeChecked(),
+    );
+    expect(await screen.findByText('Command failed')).toBeInTheDocument();
+    expect(reportUpdateMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('renders as a read-only switch when the user lacks control permission', () => {
+    sensors.splice(0, sensors.length, makeSensor());
+    currentReadings['office-plug'] = { state: makeReading() };
+    authUser = {
+      id: 2,
+      username: 'viewer',
+      roles: [],
+      permissions: ['view_readings'],
+    };
+
+    render(
+      <SensorToggleWidget
+        id="widget-1"
+        config={{ sensorId: 7, property: 'state' }}
+        isEditing={false}
+      />,
+    );
+
+    const toggle = screen.getByRole('checkbox', { name: /toggle office-plug state/i });
+    expect(toggle).toBeChecked();
+    expect(toggle).toBeDisabled();
+
+    fireEvent.click(toggle);
+
+    expect(postMock).not.toHaveBeenCalled();
+  });
+});

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/SensorToggleWidget.test.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/SensorToggleWidget.test.tsx
@@ -232,7 +232,7 @@ describe('SensorToggleWidget', () => {
     expect(postMock).not.toHaveBeenCalled();
   });
 
-  it('snaps on when dragged past the midpoint', () => {
+  it('snaps on when dragged past the late latch', () => {
     sensors.splice(0, sensors.length, makeSensor());
     currentReadings['office-plug'] = { state: makeReading({ text_state: 'DISABLED' }) };
     authUser = {
@@ -265,8 +265,8 @@ describe('SensorToggleWidget', () => {
     expect(toggle).not.toBeChecked();
 
     fireEvent.pointerDown(control, { clientX: 100, pointerId: 1 });
-    fireEvent.pointerMove(control, { clientX: 180, pointerId: 1 });
-    fireEvent.pointerUp(control, { clientX: 180, pointerId: 1 });
+    fireEvent.pointerMove(control, { clientX: 195, pointerId: 1 });
+    fireEvent.pointerUp(control, { clientX: 195, pointerId: 1 });
 
     expect(postMock).toHaveBeenCalledWith('/sensors/{id}/command', {
       params: { path: { id: 7 } },
@@ -348,10 +348,13 @@ describe('SensorToggleWidget', () => {
       />,
     );
 
-    expect(getComputedStyle(screen.getByTestId('sensor-toggle-thumb')).boxShadow).toContain('0 0 18px');
+    const boxShadow = getComputedStyle(screen.getByTestId('sensor-toggle-thumb')).boxShadow;
+
+    expect(boxShadow).toContain('0 0 18px');
+    expect(boxShadow).not.toContain('0 10px 24px');
   });
 
-  it('adds a soft detent so drag movement compresses near the midpoint', () => {
+  it('holds the thumb on its starting side until a late latch is crossed', () => {
     sensors.splice(0, sensors.length, makeSensor());
     currentReadings['office-plug'] = { state: makeReading({ text_state: 'DISABLED' }) };
     authUser = {
@@ -373,8 +376,12 @@ describe('SensorToggleWidget', () => {
     const thumb = screen.getByTestId('sensor-toggle-thumb');
 
     fireEvent.pointerDown(control, { clientX: 100, pointerId: 1 });
-    fireEvent.pointerMove(control, { clientX: 156, pointerId: 1 });
+    fireEvent.pointerMove(control, { clientX: 175, pointerId: 1 });
 
     expect(extractTranslateXPixels(getComputedStyle(thumb).transform)).toBeLessThan(60);
+
+    fireEvent.pointerMove(control, { clientX: 195, pointerId: 1 });
+
+    expect(extractTranslateXPixels(getComputedStyle(thumb).transform)).toBeGreaterThan(84);
   });
 });

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/SensorToggleWidget.test.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/SensorToggleWidget.test.tsx
@@ -84,6 +84,14 @@ function makeReading(overrides: Partial<Reading> = {}): Reading {
   };
 }
 
+function extractTranslateXPixels(transform: string): number {
+  const match = transform.match(/translateX\(([-\d.]+)px\)/);
+  if (!match) {
+    throw new Error(`Expected translateX(...) in transform string, received: ${transform}`);
+  }
+  return Number(match[1]);
+}
+
 describe('SensorToggleWidget', () => {
   beforeEach(() => {
     sensors.splice(0, sensors.length);
@@ -320,5 +328,53 @@ describe('SensorToggleWidget', () => {
       maxWidth: '220px',
       height: '72px',
     });
+  });
+
+  it('uses a stronger centered glow around the thumb when switched on', () => {
+    sensors.splice(0, sensors.length, makeSensor());
+    currentReadings['office-plug'] = { state: makeReading({ text_state: 'ENABLED' }) };
+    authUser = {
+      id: 1,
+      username: 'operator',
+      roles: [],
+      permissions: ['control_sensors'],
+    };
+
+    render(
+      <SensorToggleWidget
+        id="widget-1"
+        config={{ sensorId: 7, property: 'state' }}
+        isEditing={false}
+      />,
+    );
+
+    expect(getComputedStyle(screen.getByTestId('sensor-toggle-thumb')).boxShadow).toContain('0 0 18px');
+  });
+
+  it('adds a soft detent so drag movement compresses near the midpoint', () => {
+    sensors.splice(0, sensors.length, makeSensor());
+    currentReadings['office-plug'] = { state: makeReading({ text_state: 'DISABLED' }) };
+    authUser = {
+      id: 1,
+      username: 'operator',
+      roles: [],
+      permissions: ['control_sensors'],
+    };
+
+    render(
+      <SensorToggleWidget
+        id="widget-1"
+        config={{ sensorId: 7, property: 'state' }}
+        isEditing={false}
+      />,
+    );
+
+    const control = screen.getByTestId('sensor-toggle-control');
+    const thumb = screen.getByTestId('sensor-toggle-thumb');
+
+    fireEvent.pointerDown(control, { clientX: 100, pointerId: 1 });
+    fireEvent.pointerMove(control, { clientX: 156, pointerId: 1 });
+
+    expect(extractTranslateXPixels(getComputedStyle(thumb).transform)).toBeLessThan(60);
   });
 });

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/SensorToggleWidget.test.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/SensorToggleWidget.test.tsx
@@ -217,10 +217,108 @@ describe('SensorToggleWidget', () => {
 
     const toggle = screen.getByRole('checkbox', { name: /toggle office-plug state/i });
     expect(toggle).toBeChecked();
-    expect(toggle).toBeDisabled();
+    expect(toggle).toHaveAttribute('aria-disabled', 'true');
 
     fireEvent.click(toggle);
 
     expect(postMock).not.toHaveBeenCalled();
+  });
+
+  it('snaps on when dragged past the midpoint', () => {
+    sensors.splice(0, sensors.length, makeSensor());
+    currentReadings['office-plug'] = { state: makeReading({ text_state: 'DISABLED' }) };
+    authUser = {
+      id: 1,
+      username: 'operator',
+      roles: [],
+      permissions: ['control_sensors'],
+    };
+
+    postMock.mockResolvedValue({
+      data: {
+        id: 43,
+        status: 'sent',
+        property: 'state',
+        value: 'ENABLED',
+      } satisfies SensorCommandAccepted,
+    });
+
+    render(
+      <SensorToggleWidget
+        id="widget-1"
+        config={{ sensorId: 7, property: 'state' }}
+        isEditing={false}
+      />,
+    );
+
+    const toggle = screen.getByRole('checkbox', { name: /toggle office-plug state/i });
+    const control = screen.getByTestId('sensor-toggle-control');
+
+    expect(toggle).not.toBeChecked();
+
+    fireEvent.pointerDown(control, { clientX: 100, pointerId: 1 });
+    fireEvent.pointerMove(control, { clientX: 180, pointerId: 1 });
+    fireEvent.pointerUp(control, { clientX: 180, pointerId: 1 });
+
+    expect(postMock).toHaveBeenCalledWith('/sensors/{id}/command', {
+      params: { path: { id: 7 } },
+      body: { property: 'state', value: 'ENABLED' },
+    });
+    expect(toggle).toBeChecked();
+    expect(reportUpdateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns to the original side when dragged short of the midpoint', () => {
+    sensors.splice(0, sensors.length, makeSensor());
+    currentReadings['office-plug'] = { state: makeReading({ text_state: 'DISABLED' }) };
+    authUser = {
+      id: 1,
+      username: 'operator',
+      roles: [],
+      permissions: ['control_sensors'],
+    };
+
+    render(
+      <SensorToggleWidget
+        id="widget-1"
+        config={{ sensorId: 7, property: 'state' }}
+        isEditing={false}
+      />,
+    );
+
+    const toggle = screen.getByRole('checkbox', { name: /toggle office-plug state/i });
+    const control = screen.getByTestId('sensor-toggle-control');
+
+    fireEvent.pointerDown(control, { clientX: 100, pointerId: 1 });
+    fireEvent.pointerMove(control, { clientX: 135, pointerId: 1 });
+    fireEvent.pointerUp(control, { clientX: 135, pointerId: 1 });
+
+    expect(toggle).not.toBeChecked();
+    expect(postMock).not.toHaveBeenCalled();
+    expect(reportUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it('renders the tactile control wider within the existing widget body', () => {
+    sensors.splice(0, sensors.length, makeSensor());
+    currentReadings['office-plug'] = { state: makeReading() };
+    authUser = {
+      id: 1,
+      username: 'operator',
+      roles: [],
+      permissions: ['control_sensors'],
+    };
+
+    render(
+      <SensorToggleWidget
+        id="widget-1"
+        config={{ sensorId: 7, property: 'state' }}
+        isEditing={false}
+      />,
+    );
+
+    expect(screen.getByTestId('sensor-toggle-control')).toHaveStyle({
+      maxWidth: '220px',
+      height: '72px',
+    });
   });
 });

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/SensorToggleWidget.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/SensorToggleWidget.tsx
@@ -1,0 +1,183 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Alert, Box, Snackbar, Switch } from '@mui/material';
+import { alpha, useTheme } from '@mui/material/styles';
+import type { WidgetProps } from '../types';
+import type { Capability, CommandStatusMessage } from '../../gen/aliases';
+import { apiClient } from '../../gen/client';
+import { useCurrentReadings } from '../../hooks/useCurrentReadings';
+import { useSensorContext } from '../../hooks/useSensorContext';
+import { useAuth } from '../../providers/AuthContext';
+import { hasPerm } from '../../tools/Utils';
+import NeedsConfiguration from '../NeedsConfiguration';
+import { useReportWidgetUpdate } from '../WidgetUpdateContext';
+
+function resolveBinaryCapability(
+  capabilities: Capability[] | undefined,
+  property: string,
+): Capability | undefined {
+  return capabilities?.find((capability) => capability.type === 'binary' && capability.property === property);
+}
+
+export default function SensorToggleWidget({ config }: WidgetProps) {
+  const theme = useTheme();
+  const { sensors } = useSensorContext();
+  const { user } = useAuth();
+  const reportUpdate = useReportWidgetUpdate();
+
+  const sensorId = config.sensorId as number | undefined;
+  const property = config.property as string | undefined;
+  const sensor = sensorId ? sensors.find((candidate) => candidate.id === sensorId) : undefined;
+  const capability = sensor && property ? resolveBinaryCapability(sensor.capabilities, property) : undefined;
+  const valueOn = capability?.value_on ?? 'ON';
+  const valueOff = capability?.value_off ?? 'OFF';
+  const [optimisticValue, setOptimisticValue] = useState<string | null>(null);
+  const pendingCommandRef = useRef<{ id: number; previousValue: string | null } | null>(null);
+  const [snackbarMessage, setSnackbarMessage] = useState<string | null>(null);
+
+  const handleCommandStatus = useCallback((message: CommandStatusMessage) => {
+    const pendingCommand = pendingCommandRef.current;
+    if (!pendingCommand || !sensor || !property) return;
+    if (message.id !== pendingCommand.id || message.sensor_id !== sensor.id || message.property !== property) return;
+
+    if (message.status === 'failed' || message.status === 'timed_out') {
+      setOptimisticValue(pendingCommand.previousValue);
+      setSnackbarMessage(message.status === 'timed_out' ? 'Command timed out' : 'Command failed');
+      reportUpdate(new Date());
+    }
+
+    pendingCommandRef.current = null;
+  }, [property, reportUpdate, sensor]);
+
+  const readings = useCurrentReadings({ onDataUpdate: reportUpdate, onCommandStatus: handleCommandStatus });
+  const reading = sensor && property ? readings[sensor.name]?.[property] : undefined;
+
+  const effectiveValue = optimisticValue ?? reading?.text_state ?? null;
+  const checked = effectiveValue === valueOn;
+  const canControl = hasPerm(user, 'control_sensors');
+
+  const visualState = useMemo(() => ({
+    trackBackground: checked
+      ? alpha(theme.palette.primary.main, canControl ? 0.95 : 0.55)
+      : alpha(theme.palette.text.secondary, canControl ? 0.35 : 0.2),
+    thumbBackground: theme.palette.common.white,
+    onOpacity: checked ? 1 : 0.35,
+    offOpacity: checked ? 0.35 : 1,
+  }), [canControl, checked, theme.palette.common.white, theme.palette.primary.main, theme.palette.text.secondary]);
+
+  useEffect(() => {
+    if (optimisticValue != null && reading?.text_state === optimisticValue) {
+      setOptimisticValue(null);
+    }
+  }, [optimisticValue, reading?.text_state]);
+
+  if (!sensor || !property || !capability) {
+    return <NeedsConfiguration message="Select a controllable sensor and binary property" />;
+  }
+
+  const handleToggle = async () => {
+    if (!canControl) return;
+
+    const previousValue = reading?.text_state ?? null;
+    const nextValue = checked ? valueOff : valueOn;
+    setOptimisticValue(nextValue);
+    reportUpdate(new Date());
+
+    const { data, error } = await apiClient.POST('/sensors/{id}/command', {
+      params: { path: { id: sensor.id } },
+      body: { property, value: nextValue },
+    });
+
+    if (error) {
+      setOptimisticValue(previousValue);
+      setSnackbarMessage('Failed to send command');
+      return;
+    }
+
+    if (data) {
+      pendingCommandRef.current = { id: data.id, previousValue };
+    }
+  };
+
+  return (
+    <>
+      <Box sx={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', p: 2 }}>
+        <Switch
+          checked={checked}
+          disabled={!canControl}
+          disableRipple={!canControl}
+          onChange={() => {
+            void handleToggle();
+          }}
+          slotProps={{ input: { 'aria-label': `Toggle ${sensor.name} ${property}` } }}
+          sx={{
+            width: 110,
+            height: 64,
+            p: 0,
+            '& .MuiSwitch-switchBase': {
+              p: '4px',
+              transitionDuration: '220ms',
+              '&.Mui-checked': {
+                transform: 'translateX(46px)',
+                color: theme.palette.common.white,
+                '& + .MuiSwitch-track': {
+                  backgroundColor: visualState.trackBackground,
+                  opacity: 1,
+                },
+                '&.Mui-disabled + .MuiSwitch-track': {
+                  opacity: 1,
+                },
+              },
+              '&.Mui-disabled': {
+                color: theme.palette.common.white,
+              },
+            },
+            '& .MuiSwitch-thumb': {
+              boxSizing: 'border-box',
+              width: 56,
+              height: 56,
+              backgroundColor: visualState.thumbBackground,
+              boxShadow: checked
+                ? `0 0 12px ${alpha(theme.palette.primary.main, canControl ? 0.35 : 0.2)}`
+                : undefined,
+            },
+            '& .MuiSwitch-track': {
+              borderRadius: 32,
+              opacity: 1,
+              backgroundColor: visualState.trackBackground,
+              position: 'relative',
+              '&::before, &::after': {
+                position: 'absolute',
+                top: '50%',
+                transform: 'translateY(-50%)',
+                fontSize: '0.82rem',
+                fontWeight: 700,
+                letterSpacing: '0.08em',
+                color: checked ? theme.palette.common.white : theme.palette.text.primary,
+              },
+              '&::before': {
+                content: '"ON"',
+                left: 14,
+                opacity: visualState.onOpacity,
+              },
+              '&::after': {
+                content: '"OFF"',
+                right: 12,
+                opacity: visualState.offOpacity,
+              },
+            },
+          }}
+        />
+      </Box>
+      <Snackbar
+        open={snackbarMessage != null}
+        autoHideDuration={3000}
+        onClose={() => setSnackbarMessage(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert severity="error" onClose={() => setSnackbarMessage(null)} sx={{ width: '100%' }}>
+          {snackbarMessage}
+        </Alert>
+      </Snackbar>
+    </>
+  );
+}

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/SensorToggleWidget.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/SensorToggleWidget.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Alert, Box, Snackbar, Switch } from '@mui/material';
+import { Alert, Box, Snackbar } from '@mui/material';
 import { alpha, useTheme } from '@mui/material/styles';
 import type { WidgetProps } from '../types';
 import type { Capability, CommandStatusMessage } from '../../gen/aliases';
@@ -18,6 +18,17 @@ function resolveBinaryCapability(
   return capabilities?.find((capability) => capability.type === 'binary' && capability.property === property);
 }
 
+const CONTROL_MAX_WIDTH = 220;
+const CONTROL_HEIGHT = 72;
+const CONTROL_PADDING = 4;
+const THUMB_WIDTH = 104;
+const THUMB_HEIGHT = 64;
+const DRAG_TRAVEL = CONTROL_MAX_WIDTH - (CONTROL_PADDING * 2) - THUMB_WIDTH;
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
 export default function SensorToggleWidget({ config }: WidgetProps) {
   const theme = useTheme();
   const { sensors } = useSensorContext();
@@ -33,6 +44,12 @@ export default function SensorToggleWidget({ config }: WidgetProps) {
   const [optimisticValue, setOptimisticValue] = useState<string | null>(null);
   const pendingCommandRef = useRef<{ id: number; previousValue: string | null } | null>(null);
   const [snackbarMessage, setSnackbarMessage] = useState<string | null>(null);
+  const [dragProgress, setDragProgress] = useState<number | null>(null);
+  const dragOriginXRef = useRef(0);
+  const dragStartProgressRef = useRef(0);
+  const dragMovedRef = useRef(false);
+  const suppressClickRef = useRef(false);
+  const controlRef = useRef<HTMLDivElement | null>(null);
 
   const handleCommandStatus = useCallback((message: CommandStatusMessage) => {
     const pendingCommand = pendingCommandRef.current;
@@ -54,15 +71,19 @@ export default function SensorToggleWidget({ config }: WidgetProps) {
   const effectiveValue = optimisticValue ?? reading?.text_state ?? null;
   const checked = effectiveValue === valueOn;
   const canControl = hasPerm(user, 'control_sensors');
+  const progress = dragProgress ?? (checked ? 1 : 0);
+  const crossedMidpoint = progress >= 0.5;
+  const thumbLeft = CONTROL_PADDING + (progress * DRAG_TRAVEL);
+  const isDragging = dragProgress !== null;
 
   const visualState = useMemo(() => ({
-    trackBackground: checked
+    trackBackground: crossedMidpoint
       ? alpha(theme.palette.primary.main, canControl ? 0.95 : 0.55)
       : alpha(theme.palette.text.secondary, canControl ? 0.35 : 0.2),
     thumbBackground: theme.palette.common.white,
-    onOpacity: checked ? 1 : 0.35,
-    offOpacity: checked ? 0.35 : 1,
-  }), [canControl, checked, theme.palette.common.white, theme.palette.primary.main, theme.palette.text.secondary]);
+    onOpacity: 0.35 + (progress * 0.65),
+    offOpacity: 0.35 + ((1 - progress) * 0.65),
+  }), [canControl, crossedMidpoint, progress, theme.palette.common.white, theme.palette.primary.main, theme.palette.text.secondary]);
 
   useEffect(() => {
     if (optimisticValue != null && reading?.text_state === optimisticValue) {
@@ -74,11 +95,13 @@ export default function SensorToggleWidget({ config }: WidgetProps) {
     return <NeedsConfiguration message="Select a controllable sensor and binary property" />;
   }
 
-  const handleToggle = async () => {
+  const commitCheckedState = async (nextChecked: boolean) => {
     if (!canControl) return;
 
     const previousValue = reading?.text_state ?? null;
-    const nextValue = checked ? valueOff : valueOn;
+    const nextValue = nextChecked ? valueOn : valueOff;
+    if (nextValue === effectiveValue) return;
+
     setOptimisticValue(nextValue);
     reportUpdate(new Date());
 
@@ -98,75 +121,155 @@ export default function SensorToggleWidget({ config }: WidgetProps) {
     }
   };
 
+  const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (!canControl) return;
+
+    dragOriginXRef.current = event.clientX;
+    dragStartProgressRef.current = checked ? 1 : 0;
+    dragMovedRef.current = false;
+    setDragProgress(dragStartProgressRef.current);
+
+    if (typeof event.currentTarget.setPointerCapture === 'function') {
+      event.currentTarget.setPointerCapture(event.pointerId);
+    }
+  };
+
+  const handlePointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (dragProgress === null) return;
+
+    const delta = event.clientX - dragOriginXRef.current;
+    if (Math.abs(delta) > 4) {
+      dragMovedRef.current = true;
+    }
+    setDragProgress(clamp(dragStartProgressRef.current + (delta / DRAG_TRAVEL), 0, 1));
+  };
+
+  const finishDrag = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (dragProgress === null) return;
+
+    const finalProgress = dragProgress;
+    const dragged = dragMovedRef.current;
+    setDragProgress(null);
+
+    if (typeof event.currentTarget.releasePointerCapture === 'function') {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+
+    if (!dragged) return;
+
+    suppressClickRef.current = true;
+    void commitCheckedState(finalProgress >= 0.5);
+  };
+
+  const handleClick = () => {
+    if (!canControl) return;
+    if (suppressClickRef.current) {
+      suppressClickRef.current = false;
+      return;
+    }
+    void commitCheckedState(!checked);
+  };
+
   return (
     <>
       <Box sx={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', p: 2 }}>
-        <Switch
-          checked={checked}
-          disabled={!canControl}
-          disableRipple={!canControl}
-          onChange={() => {
-            void handleToggle();
+        <Box
+          ref={controlRef}
+          data-testid="sensor-toggle-control"
+          role="checkbox"
+          aria-checked={checked}
+          aria-disabled={!canControl}
+          aria-label={`Toggle ${sensor.name} ${property}`}
+          tabIndex={canControl ? 0 : -1}
+          onClick={handleClick}
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={finishDrag}
+          onPointerCancel={finishDrag}
+          onKeyDown={(event) => {
+            if (!canControl) return;
+            if (event.key === ' ' || event.key === 'Enter') {
+              event.preventDefault();
+              void commitCheckedState(!checked);
+            }
           }}
-          slotProps={{ input: { 'aria-label': `Toggle ${sensor.name} ${property}` } }}
           sx={{
-            width: 110,
-            height: 64,
-            p: 0,
-            '& .MuiSwitch-switchBase': {
-              p: '4px',
-              transitionDuration: '220ms',
-              '&.Mui-checked': {
-                transform: 'translateX(46px)',
-                color: theme.palette.common.white,
-                '& + .MuiSwitch-track': {
-                  backgroundColor: visualState.trackBackground,
-                  opacity: 1,
-                },
-                '&.Mui-disabled + .MuiSwitch-track': {
-                  opacity: 1,
-                },
-              },
-              '&.Mui-disabled': {
-                color: theme.palette.common.white,
-              },
-            },
-            '& .MuiSwitch-thumb': {
-              boxSizing: 'border-box',
-              width: 56,
-              height: 56,
-              backgroundColor: visualState.thumbBackground,
-              boxShadow: checked
-                ? `0 0 12px ${alpha(theme.palette.primary.main, canControl ? 0.35 : 0.2)}`
-                : undefined,
-            },
-            '& .MuiSwitch-track': {
-              borderRadius: 32,
-              opacity: 1,
-              backgroundColor: visualState.trackBackground,
-              position: 'relative',
-              '&::before, &::after': {
-                position: 'absolute',
-                top: '50%',
-                transform: 'translateY(-50%)',
-                fontSize: '0.82rem',
-                fontWeight: 700,
-                letterSpacing: '0.08em',
-                color: checked ? theme.palette.common.white : theme.palette.text.primary,
-              },
-              '&::before': {
-                content: '"ON"',
-                left: 14,
-                opacity: visualState.onOpacity,
-              },
-              '&::after': {
-                content: '"OFF"',
-                right: 12,
-                opacity: visualState.offOpacity,
-              },
+            position: 'relative',
+            width: '100%',
+            maxWidth: `${CONTROL_MAX_WIDTH}px`,
+            height: `${CONTROL_HEIGHT}px`,
+            borderRadius: `${CONTROL_HEIGHT / 2}px`,
+            backgroundColor: visualState.trackBackground,
+            boxShadow: crossedMidpoint
+              ? `inset 0 0 0 1px ${alpha(theme.palette.common.white, 0.14)}, 0 10px 24px ${alpha(theme.palette.primary.main, canControl ? 0.2 : 0.08)}`
+              : `inset 0 0 0 1px ${alpha(theme.palette.text.primary, 0.08)}`,
+            cursor: canControl ? (isDragging ? 'grabbing' : 'pointer') : 'default',
+            userSelect: 'none',
+            touchAction: 'none',
+            outline: 'none',
+            transition: isDragging
+              ? 'background-color 90ms linear, box-shadow 90ms linear'
+              : 'background-color 180ms ease, box-shadow 180ms ease',
+            '&::before': {
+              content: '""',
+              position: 'absolute',
+              left: '50%',
+              top: 16,
+              bottom: 16,
+              width: 2,
+              transform: 'translateX(-50%)',
+              borderRadius: 999,
+              backgroundColor: crossedMidpoint
+                ? alpha(theme.palette.common.white, 0.28)
+                : alpha(theme.palette.text.primary, 0.12),
             },
           }}
-        />
+        >
+          <Box
+            sx={{
+              position: 'absolute',
+              inset: 0,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              px: 2.5,
+              fontSize: '0.9rem',
+              fontWeight: 800,
+              letterSpacing: '0.1em',
+              color: crossedMidpoint ? theme.palette.common.white : theme.palette.text.primary,
+            }}
+          >
+            <Box component="span" sx={{ opacity: visualState.onOpacity }}>ON</Box>
+            <Box component="span" sx={{ opacity: visualState.offOpacity }}>OFF</Box>
+          </Box>
+          <Box
+            sx={{
+              position: 'absolute',
+              top: CONTROL_PADDING,
+              left: 0,
+              width: `${THUMB_WIDTH}px`,
+              height: `${THUMB_HEIGHT}px`,
+              borderRadius: `${THUMB_HEIGHT / 2}px`,
+              transform: `translateX(${thumbLeft}px) scale(${isDragging ? 0.985 : 1})`,
+              backgroundColor: visualState.thumbBackground,
+              boxShadow: isDragging
+                ? `0 6px 14px ${alpha(theme.palette.common.black, 0.18)}`
+                : `0 10px 24px ${alpha(theme.palette.common.black, crossedMidpoint ? 0.18 : 0.12)}`,
+              transition: isDragging
+                ? 'none'
+                : 'transform 240ms cubic-bezier(0.2, 0.9, 0.25, 1.25), box-shadow 200ms ease',
+              '&::before': {
+                content: '""',
+                position: 'absolute',
+                inset: 16,
+                borderRadius: 999,
+                background: crossedMidpoint
+                  ? `linear-gradient(90deg, ${alpha(theme.palette.primary.main, 0.28)}, ${alpha(theme.palette.primary.light, 0.12)})`
+                  : `linear-gradient(90deg, ${alpha(theme.palette.text.secondary, 0.16)}, ${alpha(theme.palette.text.secondary, 0.06)})`,
+              },
+            }}
+          />
+        </Box>
       </Box>
       <Snackbar
         open={snackbarMessage != null}

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/SensorToggleWidget.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/SensorToggleWidget.tsx
@@ -24,25 +24,32 @@ const CONTROL_PADDING = 4;
 const THUMB_WIDTH = 104;
 const THUMB_HEIGHT = 64;
 const DRAG_TRAVEL = CONTROL_MAX_WIDTH - (CONTROL_PADDING * 2) - THUMB_WIDTH;
-const DETENT_START = 0.38;
-const DETENT_END = 0.62;
+const LATE_LATCH_THRESHOLD = 0.78;
+const PRE_LATCH_PROGRESS_MAX = 0.34;
+const POST_LATCH_PROGRESS_MIN = 0.82;
 
 function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
 }
 
-function applySoftDetent(progress: number): number {
-  if (progress <= DETENT_START || progress >= DETENT_END) {
-    return progress;
-  }
+function getDragDistance(progress: number, startChecked: boolean): number {
+  return startChecked ? 1 - progress : progress;
+}
 
-  const midpoint = 0.5;
-  const halfBand = (DETENT_END - DETENT_START) / 2;
-  const distanceFromMidpoint = progress - midpoint;
-  const normalizedDistance = distanceFromMidpoint / halfBand;
-  const compressedDistance = Math.sign(normalizedDistance) * Math.pow(Math.abs(normalizedDistance), 1.7);
+function hasCrossedLateLatch(progress: number, startChecked: boolean): boolean {
+  return getDragDistance(progress, startChecked) >= LATE_LATCH_THRESHOLD;
+}
 
-  return midpoint + (compressedDistance * halfBand);
+function applyLateLatchProgress(progress: number, startChecked: boolean): number {
+  const distance = getDragDistance(progress, startChecked);
+  const mappedDistance = distance < LATE_LATCH_THRESHOLD
+    ? Math.pow(distance / LATE_LATCH_THRESHOLD, 1.9) * PRE_LATCH_PROGRESS_MAX
+    : POST_LATCH_PROGRESS_MIN + (
+      (1 - Math.pow(1 - ((distance - LATE_LATCH_THRESHOLD) / (1 - LATE_LATCH_THRESHOLD)), 2.2))
+      * (1 - POST_LATCH_PROGRESS_MIN)
+    );
+
+  return startChecked ? 1 - mappedDistance : mappedDistance;
 }
 
 export default function SensorToggleWidget({ config }: WidgetProps) {
@@ -63,6 +70,7 @@ export default function SensorToggleWidget({ config }: WidgetProps) {
   const [dragProgress, setDragProgress] = useState<number | null>(null);
   const dragOriginXRef = useRef(0);
   const dragStartProgressRef = useRef(0);
+  const dragStartCheckedRef = useRef(false);
   const dragMovedRef = useRef(false);
   const suppressClickRef = useRef(false);
   const controlRef = useRef<HTMLDivElement | null>(null);
@@ -88,19 +96,22 @@ export default function SensorToggleWidget({ config }: WidgetProps) {
   const checked = effectiveValue === valueOn;
   const canControl = hasPerm(user, 'control_sensors');
   const rawProgress = dragProgress ?? (checked ? 1 : 0);
-  const progress = applySoftDetent(rawProgress);
-  const crossedMidpoint = rawProgress >= 0.5;
-  const thumbLeft = CONTROL_PADDING + (progress * DRAG_TRAVEL);
   const isDragging = dragProgress !== null;
+  const dragStartChecked = dragStartCheckedRef.current;
+  const visualChecked = isDragging
+    ? (hasCrossedLateLatch(rawProgress, dragStartChecked) ? !dragStartChecked : dragStartChecked)
+    : checked;
+  const thumbProgress = isDragging ? applyLateLatchProgress(rawProgress, dragStartChecked) : rawProgress;
+  const thumbLeft = CONTROL_PADDING + (thumbProgress * DRAG_TRAVEL);
 
   const visualState = useMemo(() => ({
-    trackBackground: crossedMidpoint
+    trackBackground: visualChecked
       ? alpha(theme.palette.primary.main, canControl ? 0.95 : 0.55)
       : alpha(theme.palette.text.secondary, canControl ? 0.35 : 0.2),
     thumbBackground: theme.palette.common.white,
-    onOpacity: 0.35 + (progress * 0.65),
-    offOpacity: 0.35 + ((1 - progress) * 0.65),
-  }), [canControl, crossedMidpoint, progress, theme.palette.common.white, theme.palette.primary.main, theme.palette.text.secondary]);
+    onOpacity: visualChecked ? 1 : 0.35,
+    offOpacity: visualChecked ? 0.35 : 1,
+  }), [canControl, visualChecked, theme.palette.common.white, theme.palette.primary.main, theme.palette.text.secondary]);
 
   useEffect(() => {
     if (optimisticValue != null && reading?.text_state === optimisticValue) {
@@ -142,6 +153,7 @@ export default function SensorToggleWidget({ config }: WidgetProps) {
     if (!canControl) return;
 
     dragOriginXRef.current = event.clientX;
+    dragStartCheckedRef.current = checked;
     dragStartProgressRef.current = checked ? 1 : 0;
     dragMovedRef.current = false;
     setDragProgress(dragStartProgressRef.current);
@@ -175,7 +187,11 @@ export default function SensorToggleWidget({ config }: WidgetProps) {
     if (!dragged) return;
 
     suppressClickRef.current = true;
-    void commitCheckedState(finalProgress >= 0.5);
+    void commitCheckedState(
+      hasCrossedLateLatch(finalProgress, dragStartCheckedRef.current)
+        ? !dragStartCheckedRef.current
+        : dragStartCheckedRef.current,
+    );
   };
 
   const handleClick = () => {
@@ -217,8 +233,8 @@ export default function SensorToggleWidget({ config }: WidgetProps) {
             height: `${CONTROL_HEIGHT}px`,
             borderRadius: `${CONTROL_HEIGHT / 2}px`,
             backgroundColor: visualState.trackBackground,
-            boxShadow: crossedMidpoint
-              ? `inset 0 0 0 1px ${alpha(theme.palette.common.white, 0.14)}, 0 10px 24px ${alpha(theme.palette.primary.main, canControl ? 0.2 : 0.08)}`
+            boxShadow: visualChecked
+              ? `inset 0 0 0 1px ${alpha(theme.palette.common.white, 0.14)}, 0 0 24px ${alpha(theme.palette.primary.main, canControl ? 0.22 : 0.1)}`
               : `inset 0 0 0 1px ${alpha(theme.palette.text.primary, 0.08)}`,
             cursor: canControl ? (isDragging ? 'grabbing' : 'pointer') : 'default',
             userSelect: 'none',
@@ -235,10 +251,10 @@ export default function SensorToggleWidget({ config }: WidgetProps) {
               bottom: 16,
               width: 2,
               transform: 'translateX(-50%)',
-              borderRadius: 999,
-              backgroundColor: crossedMidpoint
-                ? alpha(theme.palette.common.white, 0.28)
-                : alpha(theme.palette.text.primary, 0.12),
+               borderRadius: 999,
+               backgroundColor: visualChecked
+                 ? alpha(theme.palette.common.white, 0.28)
+                 : alpha(theme.palette.text.primary, 0.12),
             },
           }}
         >
@@ -252,8 +268,8 @@ export default function SensorToggleWidget({ config }: WidgetProps) {
               px: 2.5,
               fontSize: '0.9rem',
               fontWeight: 800,
-              letterSpacing: '0.1em',
-              color: crossedMidpoint ? theme.palette.common.white : theme.palette.text.primary,
+               letterSpacing: '0.1em',
+               color: visualChecked ? theme.palette.common.white : theme.palette.text.primary,
             }}
           >
             <Box component="span" sx={{ opacity: visualState.onOpacity }}>ON</Box>
@@ -270,22 +286,22 @@ export default function SensorToggleWidget({ config }: WidgetProps) {
               borderRadius: `${THUMB_HEIGHT / 2}px`,
               transform: `translateX(${thumbLeft}px) scale(${isDragging ? 0.985 : 1})`,
               backgroundColor: visualState.thumbBackground,
-              boxShadow: isDragging
-                ? `0 6px 14px ${alpha(theme.palette.common.black, 0.18)}`
-                : crossedMidpoint
-                  ? `0 0 18px ${alpha(theme.palette.primary.main, canControl ? 0.34 : 0.18)}, 0 10px 24px ${alpha(theme.palette.common.black, 0.16)}`
-                  : `0 0 10px ${alpha(theme.palette.text.secondary, 0.1)}, 0 10px 24px ${alpha(theme.palette.common.black, 0.12)}`,
+               boxShadow: isDragging
+                 ? `0 6px 14px ${alpha(theme.palette.common.black, 0.18)}`
+                 : visualChecked
+                   ? `0 0 18px ${alpha(theme.palette.primary.main, canControl ? 0.34 : 0.18)}, 0 0 30px ${alpha(theme.palette.primary.light, canControl ? 0.22 : 0.1)}`
+                   : `0 0 10px ${alpha(theme.palette.text.secondary, 0.1)}, 0 10px 24px ${alpha(theme.palette.common.black, 0.12)}`,
               transition: isDragging
                 ? 'none'
                 : 'transform 240ms cubic-bezier(0.2, 0.9, 0.25, 1.25), box-shadow 200ms ease',
               '&::before': {
                 content: '""',
                 position: 'absolute',
-                inset: 16,
-                borderRadius: 999,
-                background: crossedMidpoint
-                  ? `linear-gradient(90deg, ${alpha(theme.palette.primary.main, 0.28)}, ${alpha(theme.palette.primary.light, 0.12)})`
-                  : `linear-gradient(90deg, ${alpha(theme.palette.text.secondary, 0.16)}, ${alpha(theme.palette.text.secondary, 0.06)})`,
+                 inset: 16,
+                 borderRadius: 999,
+                 background: visualChecked
+                   ? `linear-gradient(90deg, ${alpha(theme.palette.primary.main, 0.28)}, ${alpha(theme.palette.primary.light, 0.12)})`
+                   : `linear-gradient(90deg, ${alpha(theme.palette.text.secondary, 0.16)}, ${alpha(theme.palette.text.secondary, 0.06)})`,
               },
             }}
           />

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/SensorToggleWidget.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/SensorToggleWidget.tsx
@@ -24,9 +24,25 @@ const CONTROL_PADDING = 4;
 const THUMB_WIDTH = 104;
 const THUMB_HEIGHT = 64;
 const DRAG_TRAVEL = CONTROL_MAX_WIDTH - (CONTROL_PADDING * 2) - THUMB_WIDTH;
+const DETENT_START = 0.38;
+const DETENT_END = 0.62;
 
 function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
+}
+
+function applySoftDetent(progress: number): number {
+  if (progress <= DETENT_START || progress >= DETENT_END) {
+    return progress;
+  }
+
+  const midpoint = 0.5;
+  const halfBand = (DETENT_END - DETENT_START) / 2;
+  const distanceFromMidpoint = progress - midpoint;
+  const normalizedDistance = distanceFromMidpoint / halfBand;
+  const compressedDistance = Math.sign(normalizedDistance) * Math.pow(Math.abs(normalizedDistance), 1.7);
+
+  return midpoint + (compressedDistance * halfBand);
 }
 
 export default function SensorToggleWidget({ config }: WidgetProps) {
@@ -71,8 +87,9 @@ export default function SensorToggleWidget({ config }: WidgetProps) {
   const effectiveValue = optimisticValue ?? reading?.text_state ?? null;
   const checked = effectiveValue === valueOn;
   const canControl = hasPerm(user, 'control_sensors');
-  const progress = dragProgress ?? (checked ? 1 : 0);
-  const crossedMidpoint = progress >= 0.5;
+  const rawProgress = dragProgress ?? (checked ? 1 : 0);
+  const progress = applySoftDetent(rawProgress);
+  const crossedMidpoint = rawProgress >= 0.5;
   const thumbLeft = CONTROL_PADDING + (progress * DRAG_TRAVEL);
   const isDragging = dragProgress !== null;
 
@@ -243,6 +260,7 @@ export default function SensorToggleWidget({ config }: WidgetProps) {
             <Box component="span" sx={{ opacity: visualState.offOpacity }}>OFF</Box>
           </Box>
           <Box
+            data-testid="sensor-toggle-thumb"
             sx={{
               position: 'absolute',
               top: CONTROL_PADDING,
@@ -254,7 +272,9 @@ export default function SensorToggleWidget({ config }: WidgetProps) {
               backgroundColor: visualState.thumbBackground,
               boxShadow: isDragging
                 ? `0 6px 14px ${alpha(theme.palette.common.black, 0.18)}`
-                : `0 10px 24px ${alpha(theme.palette.common.black, crossedMidpoint ? 0.18 : 0.12)}`,
+                : crossedMidpoint
+                  ? `0 0 18px ${alpha(theme.palette.primary.main, canControl ? 0.34 : 0.18)}, 0 10px 24px ${alpha(theme.palette.common.black, 0.16)}`
+                  : `0 0 10px ${alpha(theme.palette.text.secondary, 0.1)}, 0 10px 24px ${alpha(theme.palette.common.black, 0.12)}`,
               transition: isDragging
                 ? 'none'
                 : 'transform 240ms cubic-bezier(0.2, 0.9, 0.25, 1.25), box-shadow 200ms ease',

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/index.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/index.ts
@@ -17,6 +17,7 @@ import AlertSummaryWidget from './AlertSummaryWidget';
 import UptimeWidget from './UptimeWidget';
 import HeatmapWidget from './HeatmapWidget';
 import SensorDetailWidget from './SensorDetailWidget';
+import SensorToggleWidget from './SensorToggleWidget';
 
 export function registerAllWidgets(): void {
     registerWidget({
@@ -266,6 +267,21 @@ export function registerAllWidgets(): void {
         minH: 3,
         configFields: [
             { key: 'sensorId', label: 'Sensor', type: 'sensor-select' },
+        ],
+    });
+
+    registerWidget({
+        type: 'sensor-toggle',
+        label: 'Sensor Toggle',
+        description: 'Large on/off switch for a controllable binary sensor property',
+        component: SensorToggleWidget,
+        defaultConfig: { property: 'state' },
+        defaultLayout: { w: 4, h: 2 },
+        minW: 3,
+        minH: 2,
+        configFields: [
+            { key: 'sensorId', label: 'Sensor', type: 'controllable-sensor-select' },
+            { key: 'property', label: 'Property', type: 'binary-capability-select', defaultValue: 'state' },
         ],
     });
 }

--- a/sensor_hub/ui/sensor_hub_ui/src/gen/aliases.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/gen/aliases.ts
@@ -6,6 +6,7 @@ import type { components } from './schema';
 
 export type Sensor                    = components['schemas']['Sensor'];
 export type Reading                   = components['schemas']['Reading'];
+export type Capability                = components['schemas']['Capability'];
 export type AggregatedReadingsResponse = components['schemas']['AggregatedReadingsResponse'];
 export type SensorHealthStatus        = components['schemas']['SensorHealthStatus'];
 export type SensorHealthHistory       = components['schemas']['SensorHealthHistory'];
@@ -26,6 +27,8 @@ export type DashboardWidget           = components['schemas']['DashboardWidget']
 export type CreateDashboardRequest    = components['schemas']['CreateDashboardRequest'];
 export type UpdateDashboardRequest    = components['schemas']['UpdateDashboardRequest'];
 export type ShareDashboardRequest     = components['schemas']['ShareDashboardRequest'];
+export type SensorCommandAccepted     = components['schemas']['SensorCommandAccepted'];
+export type CommandStatusMessage      = components['schemas']['CommandStatusMessage'];
 export type User                      = components['schemas']['User'];
 export type RoleInfo                  = components['schemas']['RoleInfo'];
 export type PermissionInfo            = components['schemas']['PermissionInfo'];

--- a/sensor_hub/ui/sensor_hub_ui/src/hooks/useCurrentReadings.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/hooks/useCurrentReadings.ts
@@ -1,5 +1,5 @@
 import { useCallback, useRef, useState } from "react";
-import type { Reading } from "../gen/aliases";
+import type { CommandStatusMessage, Reading } from "../gen/aliases";
 import { WEBSOCKET_BASE } from "../environment/Environment";
 import { useAuth } from "../providers/AuthContext.tsx";
 import { logger } from '../tools/logger';
@@ -9,6 +9,20 @@ export type CurrentReadingsMap = Record<string, Record<string, Reading>>;
 
 interface UseCurrentReadingsOptions {
     onDataUpdate?: (date: Date) => void;
+    onCommandStatus?: (message: CommandStatusMessage) => void;
+}
+
+function mergeReadings(prev: CurrentReadingsMap, readings: Reading[]): CurrentReadingsMap {
+  const next: CurrentReadingsMap = { ...prev };
+  readings.forEach((reading) => {
+    if (!reading) return;
+    const sensorEntry = next[reading.sensor_name]
+      ? { ...next[reading.sensor_name] }
+      : {};
+    sensorEntry[reading.measurement_type] = reading;
+    next[reading.sensor_name] = sensorEntry;
+  });
+  return next;
 }
 
 export function useCurrentReadings(options?: UseCurrentReadingsOptions): CurrentReadingsMap {
@@ -17,6 +31,8 @@ export function useCurrentReadings(options?: UseCurrentReadingsOptions): Current
 
   const onDataUpdateRef = useRef(options?.onDataUpdate);
   onDataUpdateRef.current = options?.onDataUpdate;
+  const onCommandStatusRef = useRef(options?.onCommandStatus);
+  onCommandStatusRef.current = options?.onCommandStatus;
 
   const handleMessage = useCallback((event: MessageEvent) => {
       if (!event.data || event.data === "null") return;
@@ -28,22 +44,29 @@ export function useCurrentReadings(options?: UseCurrentReadingsOptions): Current
         return;
       }
 
-      if (!Array.isArray(parsed)) return;
+      if (Array.isArray(parsed)) {
+        setCurrentReadings((prev) => mergeReadings(prev, parsed as Reading[]));
+        onDataUpdateRef.current?.(new Date());
+        return;
+      }
 
-      const readings = parsed as Reading[];
-      setCurrentReadings((prev) => {
-        const next: CurrentReadingsMap = { ...prev };
-        readings.forEach((reading) => {
-          if (!reading) return;
-          const sensorEntry = next[reading.sensor_name]
-            ? { ...next[reading.sensor_name] }
-            : {};
-          sensorEntry[reading.measurement_type] = reading;
-          next[reading.sensor_name] = sensorEntry;
-        });
-        return next;
-      });
-      onDataUpdateRef.current?.(new Date());
+      if (typeof parsed !== 'object' || parsed === null) return;
+
+      if ('type' in parsed && parsed.type === 'command_status') {
+        onCommandStatusRef.current?.(parsed as CommandStatusMessage);
+        return;
+      }
+
+      if ('readings' in parsed && Array.isArray(parsed.readings)) {
+        setCurrentReadings((prev) => mergeReadings(prev, parsed.readings as Reading[]));
+        onDataUpdateRef.current?.(new Date());
+        return;
+      }
+
+      if ('sensor_name' in parsed && 'measurement_type' in parsed) {
+        setCurrentReadings((prev) => mergeReadings(prev, [parsed as Reading]));
+        onDataUpdateRef.current?.(new Date());
+      }
   }, []);
 
   useReconnectingWebSocket({


### PR DESCRIPTION
## Summary
- add the new sensor-toggle dashboard widget with optimistic control, rollback on failed/timed-out command status, and read-only permission handling
- wire capability-driven widget configuration and update the related dashboard/widget docs
- make the docker dev Zigbee2MQTT mock advertise retained bridge metadata and accept smart-plug set commands for local exploratory testing

## Testing
- cd sensor_hub/ui/sensor_hub_ui && npm test
- cd sensor_hub/ui/sensor_hub_ui && npm run build
- cd sensor_hub && go test ./...
- cd sensor_hub && go test -tags integration -v -timeout 300s ./integration/
- cd sensor_hub && python -m py_compile docker_tests/mock-mqtt-sensor.py
- cd sensor_hub && docker compose -f docker_tests/docker-compose.yml config >/dev/null

Closes #77
Refs #14