### PR TITLE
Document controllable sensors

### DIFF
--- a/UBIQUITOUS_LANGUAGE.md
+++ b/UBIQUITOUS_LANGUAGE.md
@@ -19,6 +19,15 @@ Use these terms consistently in code, docs, issues, and conversation.
 | **Health Reason** | A short human-readable explanation of the current health state | health message, error reason |
 | **Health Check** | A periodic evaluation that updates a sensor's health status and records a history entry | health probe, liveness check |
 | **Retention** | The period for which a sensor's readings are kept; configurable globally or overridden per sensor | TTL, expiry |
+| **Controllable Sensor** | A **Sensor** with one or more writable **Capabilities** that Sensor Hub can command | actuator, switchable device |
+
+## Device Control
+
+| Term | Definition | Aliases to avoid |
+|------|------------|-----------------|
+| **Capability** | A writable control exposed by a **Controllable Sensor**, including its property and allowed value shape | property, feature, control |
+| **Command** | A single requested value change sent to one **Capability** of one **Controllable Sensor** | action, toggle, message |
+| **Command History** | The ordered record of recent **Commands** and their outcomes for a **Controllable Sensor** | command log, audit trail, history |
 
 ## Readings
 
@@ -77,8 +86,11 @@ Use these terms consistently in code, docs, issues, and conversation.
 ## Relationships
 
 - A **Sensor** is always associated with exactly one **Sensor Driver**.
+- A **Controllable Sensor** is a **Sensor** and has one or more **Capabilities**.
 - A **Pull-based Sensor** produces **Readings** via **Collection**; a **Push-based Sensor** produces **Readings** via an MQTT **Subscription**.
 - A **Push-based Sensor** gains an **External ID** at **Auto-discovery** and enters a pending **Sensor Status** until approved.
+- A **Command** targets exactly one **Capability** on exactly one **Controllable Sensor**.
+- A **Command History** belongs to one **Controllable Sensor** and contains zero or more **Commands** in newest-first order.
 - **Aggregated Readings** are derived from **Readings** at query time; no pre-computed aggregate data is stored.
 - A **Dashboard** is owned by one **User** and contains zero or more **Widgets**.
 - A **Permission** belongs to one or more **Roles**; a **User** may have multiple **Roles**.
@@ -89,27 +101,29 @@ Use these terms consistently in code, docs, issues, and conversation.
 
 ## Example dialogue
 
-> **Dev:** "A new Zigbee device sent its first message. What happens?"
+> **Dev:** "This smart plug is showing power readings. Is it also a **Controllable Sensor**?"
 >
-> **Domain expert:** "**Auto-discovery** fires — the hub creates a new **Sensor** with a pending **Sensor Status** and assigns it an **External ID** from the device's hardware identifier. It won't produce **Readings** until approved."
+> **Domain expert:** "Only if Sensor Hub sees a writable **Capability** for it. Power is a **Measurement Type**; control comes from capability metadata."
 >
-> **Dev:** "Which **Sensor Driver** handles it?"
+> **Dev:** "So when the **Sensor Toggle** flips it off, what is Sensor Hub sending?"
 >
-> **Domain expert:** "Whatever driver the matching **Subscription** declares. The **Subscription** maps a **Topic Pattern** to a **Sensor Driver**, so all messages on that topic are parsed by that driver."
+> **Domain expert:** "A **Command** against that **Capability**. The command targets one **Controllable Sensor** and one property value change."
 >
-> **Dev:** "If the sensor goes quiet after approval, does its **Health Status** change?"
+> **Dev:** "Where do I see whether it worked?"
 >
-> **Domain expert:** "Yes — the next **Health Check** will record a new **Health Reason** explaining why. The full history of those checks is kept against the sensor."
+> **Domain expert:** "In the **Command History**. Each entry shows whether the **Command** was sent, acknowledged, timed out, or failed."
 >
-> **Dev:** "And if someone queries a year's worth of **Readings**, do we return them all?"
+> **Dev:** "And if I only see readings with no control?"
 >
-> **Domain expert:** "No — the response will be **Aggregated Readings** with an **Aggregation Function** selected automatically based on the **Measurement Type** and span. The caller can override it or request raw readings."
+> **Domain expert:** "Then it is still a **Sensor**, but not a **Controllable Sensor**."
 
 ---
 
 ## Flagged ambiguities
 
 - **"device" vs "sensor"** — used interchangeably in some places. Prefer **Sensor** for the system entity; reserve **device** only when referring to physical hardware independently of its system representation (e.g. during **Auto-discovery**).
+- **"capability" vs "measurement type"** — both may use the same property name such as `state`, but a **Capability** is about control while a **Measurement Type** is about recorded readings.
+- **"property" vs "capability"** — the property string identifies a control target, but the **Capability** is the richer domain concept that includes writability and allowed values.
 - **"config"** — overloaded across the codebase. Qualify it: sensor driver configuration is **Sensor Config**; dashboard-level settings are a **Dashboard**'s configuration; application-level settings are **Properties**.
 - **"status"** — overloaded. **Sensor Status** is the lifecycle state; **Health Status** is the operational health. Never use bare "status" for either.
 - **"alert"** — used loosely to mean both the condition and the message. **Alert Rule** is the configured condition; **Notification** is the message produced when it fires. Avoid bare "alert" for either.

--- a/docs/docs/sensors/device-control.md
+++ b/docs/docs/sensors/device-control.md
@@ -1,0 +1,102 @@
+---
+id: device-control
+title: Device Control
+sidebar_position: 4
+---
+
+# Device Control
+
+Some sensors do more than report readings: they can also accept commands. In Sensor Hub these are **controllable sensors**. A common example is a Zigbee smart plug that reports power usage and can be turned on or off from the dashboard.
+
+This page explains how Sensor Hub decides whether a sensor is controllable, how to use the **Sensor Toggle** widget, which permission is required, and what to check when controls do not appear or commands time out.
+
+## What makes a sensor controllable
+
+A sensor is controllable when Sensor Hub has at least one writable **capability** for it.
+
+For Zigbee devices, that information comes from Zigbee2MQTT metadata rather than from live readings alone. Zigbee2MQTT publishes `bridge/devices` data describing each device's available features. Sensor Hub uses that metadata to determine:
+
+- which properties are writable
+- what kind of control each property uses
+- which values represent **on** and **off** for binary controls
+
+This matters because a reading like `state: ON` tells Sensor Hub the current value, but it does not reliably tell the hub whether that property can be commanded back to `OFF`.
+
+Not every Zigbee device is controllable. Many devices are read-only sensors, while smart plugs, relays, and similar devices usually expose one or more writable capabilities.
+
+## Setting up device control
+
+### Step 1 - Connect and approve the device
+
+Follow [How to connect a Zigbee device to Sensor Hub](../how-to/connect-zigbee-device) if the device is not already connected.
+
+Once the device publishes its first message:
+
+1. Open **Sensors**
+2. Approve the device if it is still **Pending**
+3. Confirm it is an **Active** sensor
+
+### Step 2 - Confirm Sensor Hub detected a capability
+
+The easiest sign is that the sensor becomes selectable in the **Sensor Toggle** widget configuration.
+
+If you need to inspect the raw capability data or recent command history for troubleshooting or automation, use the built-in Swagger UI rather than a separate reference page.
+
+### Step 3 - Add a Sensor Toggle widget
+
+1. Open **Dashboards**
+2. Create or edit a dashboard
+3. Add a **Sensor Toggle** widget
+4. Select the controllable sensor
+5. Select the binary property you want to control (for most smart plugs this is `state`)
+
+The widget then shows a large on/off control for that property. For broader dashboard configuration details, see [Dashboards](../dashboards).
+
+## Permissions
+
+Sending commands requires the `control_sensors` permission.
+
+By default:
+
+- **admin** users have it
+- **user** users have it
+- **viewer** users do not
+
+If a user can see the widget but cannot operate it, check their assigned roles in [User Management and RBAC](../user-management).
+
+## How commands reach the device
+
+For Zigbee2MQTT devices, Sensor Hub publishes commands to the device's Zigbee2MQTT set topic using the device's friendly name:
+
+```text
+zigbee2mqtt/<friendly-name>/set
+```
+
+For example, a device named `office-plug` receives commands on:
+
+```text
+zigbee2mqtt/office-plug/set
+```
+
+Sensor Hub also records a **command history** for troubleshooting and auditing. That history lets you see whether a command was sent, acknowledged, timed out, or failed.
+
+## Troubleshooting
+
+### The sensor does not show any control options
+
+- Confirm the device is one that Zigbee2MQTT exposes as writable
+- Check that the sensor is approved and active in Sensor Hub
+- Check that Sensor Hub is ingesting Zigbee2MQTT `bridge/devices` metadata, because controllable capabilities are derived from that metadata
+- If the sensor reports readings but still looks read-only, the device may not expose any writable properties
+
+### The Sensor Toggle widget is read-only
+
+- Check that your user has the `control_sensors` permission
+- Verify the user has an **admin** or **user** role, or another custom role that grants the same permission
+
+### The command times out
+
+- Check that Sensor Hub is connected to the MQTT broker
+- Check that Zigbee2MQTT is still connected to the same broker
+- Check that the device is powered, reachable, and online in Zigbee2MQTT
+- If other readings are stale too, fix broker or device connectivity first and then retry the command

--- a/docs/docs/sensors/index.md
+++ b/docs/docs/sensors/index.md
@@ -38,3 +38,5 @@ Looking for step-by-step instructions?
 ## After connecting
 
 Once sensors are connected and reporting data, see [Managing Sensors](managing-sensors-ref) for information on data collection, health monitoring, data retention, and permissions.
+
+If your device can be switched or otherwise commanded, see [Device Control](device-control) for controllable sensor capabilities, dashboard setup, permissions, and troubleshooting.

--- a/docs/docs/sensors/zigbee.md
+++ b/docs/docs/sensors/zigbee.md
@@ -76,6 +76,12 @@ The sensor name in Sensor Hub comes from the **friendly name** you assign to the
 
 Sensor Hub uses a stable `external_id` to track devices, so renaming a sensor in the Sensor Hub UI does not break the link to the MQTT device.
 
+## Controllable devices
+
+Some Zigbee devices, such as smart plugs and relays, can also receive commands. When Zigbee2MQTT reports writable features for a device, Sensor Hub exposes those as controllable capabilities and the device can be used with the **Sensor Toggle** widget.
+
+For setup, permissions, command routing, and troubleshooting, see [Device Control](device-control).
+
 ## How-to guide
 
 For a complete step-by-step walkthrough — including installing Zigbee2MQTT, pairing devices, and configuring the subscription — see [How to connect a Zigbee device to Sensor Hub](../how-to/connect-zigbee-device).

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -15,6 +15,7 @@ const sidebars: SidebarsConfig = {
       items: [
         'sensors/http-temperature',
         'sensors/zigbee',
+        'sensors/device-control',
         'sensors/managing-sensors-ref',
       ],
     },


### PR DESCRIPTION
Closes #78

## Summary
- add a new Sensors page for device control and wire it into the docs navigation
- explain controllable capabilities, Sensor Toggle setup, permissions, command routing, and troubleshooting
- extend the ubiquitous language glossary with the new device-control terms