### PR TITLE
Fix Zigbee2MQTT boolean capability parsing

### DIFF
--- a/sensor_hub/docker_tests/mock-mqtt-sensor.py
+++ b/sensor_hub/docker_tests/mock-mqtt-sensor.py
@@ -65,7 +65,20 @@ BRIDGE_DEVICES = [
             "vendor": "Tuya",
             "description": "Smart plug",
             "exposes": [
-                {"type": "binary", "property": "state", "name": "state", "access": 7, "value_on": "ON", "value_off": "OFF"},
+                {
+                    "type": "switch",
+                    "features": [
+                        {"type": "binary", "property": "state", "name": "state", "access": 7, "value_on": "ON", "value_off": "OFF"}
+                    ],
+                },
+                {
+                    "type": "binary",
+                    "property": "network_indicator",
+                    "name": "network_indicator",
+                    "access": 7,
+                    "value_on": True,
+                    "value_off": False,
+                },
                 {"type": "numeric", "property": "power", "name": "power", "access": 1, "unit": "W", "value_min": 0, "value_max": 2500},
                 {"type": "numeric", "property": "energy", "name": "energy", "access": 1, "unit": "kWh", "value_min": 0},
                 {"type": "numeric", "property": "current", "name": "current", "access": 1, "unit": "A", "value_min": 0},

--- a/sensor_hub/drivers/zigbee2mqtt.go
+++ b/sensor_hub/drivers/zigbee2mqtt.go
@@ -187,9 +187,22 @@ type zigbeeCapabilityExpose struct {
 }
 
 func (d *Zigbee2MQTTDriver) ParseCapabilities(metadata json.RawMessage) []gen.Capability {
-	var exposes []zigbeeCapabilityExpose
-	if err := json.Unmarshal(metadata, &exposes); err != nil {
+	var exposePayloads []json.RawMessage
+	if err := json.Unmarshal(metadata, &exposePayloads); err != nil {
 		return nil
+	}
+
+	exposes := make([]zigbeeCapabilityExpose, 0, len(exposePayloads))
+	for _, exposePayload := range exposePayloads {
+		expose, err := parseCapabilityExposeJSON(exposePayload)
+		if err != nil {
+			continue
+		}
+		exposes = append(exposes, expose)
+	}
+
+	if len(exposes) == 0 {
+		return []gen.Capability{}
 	}
 
 	capabilities := make([]gen.Capability, 0)
@@ -198,6 +211,78 @@ func (d *Zigbee2MQTTDriver) ParseCapabilities(metadata json.RawMessage) []gen.Ca
 	}
 
 	return capabilities
+}
+
+type zigbeeCapabilityExposePayload struct {
+	Type     string            `json:"type"`
+	Property string            `json:"property"`
+	Access   *int              `json:"access"`
+	ValueOn  json.RawMessage   `json:"value_on"`
+	ValueOff json.RawMessage   `json:"value_off"`
+	ValueMin *float64          `json:"value_min"`
+	ValueMax *float64          `json:"value_max"`
+	Unit     *string           `json:"unit"`
+	Values   []string          `json:"values"`
+	Features []json.RawMessage `json:"features"`
+}
+
+func parseCapabilityExposeJSON(payload json.RawMessage) (zigbeeCapabilityExpose, error) {
+	var raw zigbeeCapabilityExposePayload
+	if err := json.Unmarshal(payload, &raw); err != nil {
+		return zigbeeCapabilityExpose{}, err
+	}
+
+	valueOn, err := parseCapabilityStringValue(raw.ValueOn)
+	if err != nil {
+		return zigbeeCapabilityExpose{}, err
+	}
+
+	valueOff, err := parseCapabilityStringValue(raw.ValueOff)
+	if err != nil {
+		return zigbeeCapabilityExpose{}, err
+	}
+
+	expose := zigbeeCapabilityExpose{
+		Type:     raw.Type,
+		Property: raw.Property,
+		Access:   raw.Access,
+		ValueOn:  valueOn,
+		ValueOff: valueOff,
+		ValueMin: raw.ValueMin,
+		ValueMax: raw.ValueMax,
+		Unit:     raw.Unit,
+		Values:   raw.Values,
+		Features: make([]zigbeeCapabilityExpose, 0, len(raw.Features)),
+	}
+
+	for _, featurePayload := range raw.Features {
+		feature, err := parseCapabilityExposeJSON(featurePayload)
+		if err != nil {
+			continue
+		}
+		expose.Features = append(expose.Features, feature)
+	}
+
+	return expose, nil
+}
+
+func parseCapabilityStringValue(raw json.RawMessage) (*string, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, nil
+	}
+
+	var stringValue string
+	if err := json.Unmarshal(raw, &stringValue); err == nil {
+		return &stringValue, nil
+	}
+
+	var boolValue bool
+	if err := json.Unmarshal(raw, &boolValue); err == nil {
+		value := strconv.FormatBool(boolValue)
+		return &value, nil
+	}
+
+	return nil, fmt.Errorf("unsupported capability value type: %s", string(raw))
 }
 
 func (d *Zigbee2MQTTDriver) BuildCommand(sensor gen.Sensor, property string, value string) (string, []byte, error) {

--- a/sensor_hub/drivers/zigbee2mqtt_test.go
+++ b/sensor_hub/drivers/zigbee2mqtt_test.go
@@ -323,6 +323,38 @@ func TestParseCapabilities_BinarySwitch(t *testing.T) {
 	}, capabilities[0])
 }
 
+func TestParseCapabilities_BooleanBinaryValuesInMixedExposes(t *testing.T) {
+	d := &Zigbee2MQTTDriver{}
+
+	capabilities := d.ParseCapabilities(json.RawMessage(`[
+		{"type":"switch","features":[
+			{"type":"binary","property":"state","name":"state","access":7,"value_on":"ON","value_off":"OFF"}
+		]},
+		{"type":"binary","property":"network_indicator","name":"network_indicator","access":7,"value_on":true,"value_off":false}
+	]`))
+
+	require.Len(t, capabilities, 2)
+
+	byProperty := make(map[string]gen.Capability, len(capabilities))
+	for _, capability := range capabilities {
+		byProperty[capability.Property] = capability
+	}
+
+	assert.Equal(t, gen.Capability{
+		Property: "state",
+		Type:     gen.CapabilityTypeBinary,
+		ValueOn:  strPtr("ON"),
+		ValueOff: strPtr("OFF"),
+	}, byProperty["state"])
+
+	assert.Equal(t, gen.Capability{
+		Property: "network_indicator",
+		Type:     gen.CapabilityTypeBinary,
+		ValueOn:  strPtr("true"),
+		ValueOff: strPtr("false"),
+	}, byProperty["network_indicator"])
+}
+
 func TestParseCapabilities_NoWritableFeatures(t *testing.T) {
 	d := &Zigbee2MQTTDriver{}
 
@@ -473,6 +505,29 @@ func TestBuildCommand_BooleanBinaryCapability(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.JSONEq(t, `{"state":true}`, string(payload))
+}
+
+func TestBuildCommand_BooleanMetadataCapability(t *testing.T) {
+	d := &Zigbee2MQTTDriver{}
+	sensor := gen.Sensor{
+		Name: "office-plug",
+		Metadata: &map[string]interface{}{
+			"exposes": []interface{}{
+				map[string]interface{}{
+					"type":      "binary",
+					"property":  "network_indicator",
+					"access":    float64(7),
+					"value_on":  true,
+					"value_off": false,
+				},
+			},
+		},
+	}
+
+	_, payload, err := d.BuildCommand(sensor, "network_indicator", "true")
+
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"network_indicator":true}`, string(payload))
 }
 
 func TestZigbee2MQTT_SupportedMeasurementTypes(t *testing.T) {

--- a/sensor_hub/integration/mqtt_metadata_test.go
+++ b/sensor_hub/integration/mqtt_metadata_test.go
@@ -227,7 +227,10 @@ func TestZigbee2MQTTBridgeDevices_ReportsWritableCapabilitiesViaAPI(t *testing.T
 				"vendor": "Tuya",
 				"description": "Smart plug",
 				"exposes": [
-					{"type":"binary","property":"state","name":"state","access":7,"value_on":"ON","value_off":"OFF"},
+					{"type":"switch","features":[
+						{"type":"binary","property":"state","name":"state","access":7,"value_on":"ON","value_off":"OFF"}
+					]},
+					{"type":"binary","property":"network_indicator","name":"network_indicator","access":7,"value_on":true,"value_off":false},
 					{"type":"numeric","property":"power","name":"power","access":1,"unit":"W","value_min":0,"value_max":2500}
 				]
 			}
@@ -246,19 +249,36 @@ func TestZigbee2MQTTBridgeDevices_ReportsWritableCapabilitiesViaAPI(t *testing.T
 			return false
 		}
 		metadata := *sensor.Metadata
-		return metadata["model"] == "TS011F" &&
-			len(*sensor.Capabilities) == 1 &&
-			(*sensor.Capabilities)[0].Property == "state"
+		if metadata["model"] != "TS011F" || len(*sensor.Capabilities) != 2 {
+			return false
+		}
+
+		properties := make(map[string]bool, len(*sensor.Capabilities))
+		for _, capability := range *sensor.Capabilities {
+			properties[capability.Property] = true
+		}
+
+		return properties["state"] && properties["network_indicator"]
 	}, 5*time.Second, 100*time.Millisecond)
 
 	capabilities, status := client.GetSensorCapabilities(sensor.Id)
 	require.Equal(t, http.StatusOK, status)
-	require.Len(t, capabilities, 1)
+	require.Len(t, capabilities, 2)
 	assert.Equal(t, *sensor.Capabilities, capabilities)
-	require.NotNil(t, capabilities[0].ValueOn)
-	require.NotNil(t, capabilities[0].ValueOff)
-	assert.Equal(t, "ON", *capabilities[0].ValueOn)
-	assert.Equal(t, "OFF", *capabilities[0].ValueOff)
+
+	byProperty := make(map[string]gen.Capability, len(capabilities))
+	for _, capability := range capabilities {
+		byProperty[capability.Property] = capability
+	}
+
+	require.NotNil(t, byProperty["state"].ValueOn)
+	require.NotNil(t, byProperty["state"].ValueOff)
+	assert.Equal(t, "ON", *byProperty["state"].ValueOn)
+	assert.Equal(t, "OFF", *byProperty["state"].ValueOff)
+	require.NotNil(t, byProperty["network_indicator"].ValueOn)
+	require.NotNil(t, byProperty["network_indicator"].ValueOff)
+	assert.Equal(t, "true", *byProperty["network_indicator"].ValueOn)
+	assert.Equal(t, "false", *byProperty["network_indicator"].ValueOff)
 }
 
 func TestZigbee2MQTTBridgeDevices_ReadOnlySensorsReturnEmptyCapabilities(t *testing.T) {


### PR DESCRIPTION
## Summary
- accept Zigbee2MQTT binary `value_on`/`value_off` values when they are booleans as well as strings
- parse `exposes` entries individually so one unsupported entry does not zero out all capabilities
- update integration coverage and the docker test smart plug metadata to reflect real mixed expose payloads

## Testing
- cd sensor_hub && go test ./...
- cd sensor_hub && go test -tags integration -v -timeout 300s ./integration/
- scripts/build-packages.sh server --arch arm64 --format deb --version 1.2.10~dev1 --output-dir dist/1.2.10-dev1-arm64

Closes #138
