### PR TITLE
Fix sensor toggle widget initial state and context

### DIFF
--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/WidgetConfigDialog.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/WidgetConfigDialog.tsx
@@ -13,6 +13,7 @@ import { useSensorMeasurementTypes, useMeasurementTypesWithReadings } from '../h
 import { apiClient } from '../gen/client';
 import type { MeasurementTypeInfo } from '../gen/aliases';
 import { TIME_RANGE_PRESETS } from './timeRange';
+import { getBinaryCapabilities, getControllableSensors, normalizeSensorToggleProperty } from './sensorToggleConfig';
 
 interface WidgetConfigDialogProps {
     open: boolean;
@@ -42,11 +43,11 @@ export default function WidgetConfigDialog({ open, widgetId, onClose }: WidgetCo
         [selectedSensorId, sensors],
     );
     const controllableSensors = useMemo(
-        () => sensors.filter((sensor) => sensor.capabilities?.some((capability) => capability.type === 'binary')),
+        () => getControllableSensors(sensors),
         [sensors],
     );
     const binaryCapabilities = useMemo(
-        () => (selectedSensor?.capabilities ?? []).filter((capability) => capability.type === 'binary'),
+        () => getBinaryCapabilities(selectedSensor),
         [selectedSensor],
     );
 
@@ -96,19 +97,17 @@ export default function WidgetConfigDialog({ open, widgetId, onClose }: WidgetCo
     useEffect(() => {
         if (!hasBinaryCapabilitySelect) return;
 
-        const currentProperty = typeof localConfig.property === 'string' ? localConfig.property : '';
         if (binaryCapabilities.length === 0) {
-            if (currentProperty) {
+            if (localConfig.property) {
                 setLocalConfig(prev => ({ ...prev, property: '' }));
             }
             return;
         }
 
-        const propertyStillValid = binaryCapabilities.some(capability => capability.property === currentProperty);
-        if (propertyStillValid) return;
-
-        const preferredCapability = binaryCapabilities.find(capability => capability.property === 'state') ?? binaryCapabilities[0];
-        setLocalConfig(prev => ({ ...prev, property: preferredCapability?.property ?? '' }));
+        const normalizedProperty = normalizeSensorToggleProperty(localConfig.property, binaryCapabilities);
+        if (normalizedProperty !== localConfig.property) {
+            setLocalConfig(prev => ({ ...prev, property: normalizedProperty }));
+        }
     }, [binaryCapabilities, hasBinaryCapabilitySelect, localConfig.property]);
 
     useEffect(() => {
@@ -118,7 +117,13 @@ export default function WidgetConfigDialog({ open, widgetId, onClose }: WidgetCo
     if (!widget || !definition?.configFields?.length) return null;
 
     const handleSave = () => {
-        if (widgetId) updateWidgetConfig(widgetId, localConfig);
+        if (!widgetId) return;
+
+        const nextConfig = definition.type === 'sensor-toggle'
+            ? { ...localConfig, property: normalizeSensorToggleProperty(localConfig.property, binaryCapabilities) }
+            : localConfig;
+
+        updateWidgetConfig(widgetId, nextConfig);
         onClose();
     };
 

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/sensorToggleConfig.test.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/sensorToggleConfig.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import type { Capability, Sensor } from '../gen/aliases';
+import { getControllableSensors, getBinaryCapabilities, normalizeSensorToggleProperty } from './sensorToggleConfig';
+
+function makeCapability(overrides: Partial<Capability> = {}): Capability {
+  return {
+    property: 'state',
+    type: 'binary',
+    value_on: 'ON',
+    value_off: 'OFF',
+    ...overrides,
+  };
+}
+
+function makeSensor(overrides: Partial<Sensor> = {}): Sensor {
+  return {
+    id: 7,
+    name: 'office-plug',
+    external_id: 'office-plug',
+    sensor_driver: 'zigbee2mqtt',
+    config: {},
+    metadata: {},
+    capabilities: [makeCapability()],
+    health_status: 'good',
+    health_reason: 'ok',
+    enabled: true,
+    status: 'active',
+    retention_hours: null,
+    ...overrides,
+  };
+}
+
+describe('sensorToggleConfig', () => {
+  it('treats only sensors with binary capabilities as controllable toggle targets', () => {
+    const sensors = [
+      makeSensor(),
+      makeSensor({
+        id: 8,
+        name: 'mode-selector',
+        capabilities: [{ property: 'mode', type: 'enum', values: ['off', 'on'] }],
+      }),
+    ];
+
+    expect(getControllableSensors(sensors).map((sensor) => sensor.name)).toEqual(['office-plug']);
+  });
+
+  it('filters the property list down to binary capabilities and normalizes stale enum properties', () => {
+    const binaryCapabilities = getBinaryCapabilities(makeSensor({
+      capabilities: [
+        makeCapability({ property: 'state' }),
+        { property: 'power_on_behavior', type: 'enum', values: ['off', 'on'] },
+      ],
+    }));
+
+    expect(binaryCapabilities.map((capability) => capability.property)).toEqual(['state']);
+    expect(normalizeSensorToggleProperty('power_on_behavior', binaryCapabilities)).toBe('state');
+  });
+});

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/sensorToggleConfig.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/sensorToggleConfig.ts
@@ -1,0 +1,20 @@
+import type { Capability, Sensor } from '../gen/aliases';
+
+export function getBinaryCapabilities(sensor: Sensor | null | undefined): Capability[] {
+  return (sensor?.capabilities ?? []).filter((capability) => capability.type === 'binary');
+}
+
+export function getControllableSensors(sensors: Sensor[]): Sensor[] {
+  return sensors.filter((sensor) => getBinaryCapabilities(sensor).length > 0);
+}
+
+export function normalizeSensorToggleProperty(property: unknown, binaryCapabilities: Capability[]): string {
+  const currentProperty = typeof property === 'string' ? property : '';
+  if (binaryCapabilities.some((capability) => capability.property === currentProperty)) {
+    return currentProperty;
+  }
+
+  return binaryCapabilities.find((capability) => capability.property === 'state')?.property
+    ?? binaryCapabilities[0]?.property
+    ?? '';
+}

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/useWidgetSubtitle.test.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/useWidgetSubtitle.test.tsx
@@ -1,0 +1,66 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useWidgetSubtitle } from './useWidgetSubtitle';
+import type { Sensor } from '../gen/aliases';
+
+const sensors: Sensor[] = [];
+const properties: Record<string, string> = {};
+
+vi.mock('../hooks/useSensorContext', () => ({
+  useSensorContext: () => ({
+    sensors,
+  }),
+}));
+
+vi.mock('../hooks/useProperties', () => ({
+  useProperties: () => properties,
+}));
+
+describe('useWidgetSubtitle', () => {
+  beforeEach(() => {
+    sensors.splice(0, sensors.length);
+    Object.keys(properties).forEach((key) => delete properties[key]);
+  });
+
+  it('includes the selected property for sensor toggle widgets', () => {
+    sensors.splice(0, sensors.length, {
+      id: 7,
+      name: 'office-plug',
+      external_id: 'office-plug',
+      sensor_driver: 'zigbee2mqtt',
+      config: {},
+      metadata: {},
+      capabilities: [],
+      health_status: 'good',
+      health_reason: 'ok',
+      enabled: true,
+      status: 'active',
+      retention_hours: null,
+    });
+
+    const { result } = renderHook(() => useWidgetSubtitle('sensor-toggle', { sensorId: 7, property: 'state' }));
+
+    expect(result.current).toBe('office-plug · state');
+  });
+
+  it('keeps the existing sensor-only subtitle for other sensor widgets', () => {
+    sensors.splice(0, sensors.length, {
+      id: 7,
+      name: 'office-plug',
+      external_id: 'office-plug',
+      sensor_driver: 'zigbee2mqtt',
+      config: {},
+      metadata: {},
+      capabilities: [],
+      health_status: 'good',
+      health_reason: 'ok',
+      enabled: true,
+      status: 'active',
+      retention_hours: null,
+    });
+
+    const { result } = renderHook(() => useWidgetSubtitle('gauge', { sensorId: 7, property: 'state' }));
+
+    expect(result.current).toBe('office-plug');
+  });
+});

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/useWidgetSubtitle.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/useWidgetSubtitle.ts
@@ -10,6 +10,13 @@ export function useWidgetSubtitle(type: string, config: Record<string, unknown>)
         return typeof name === 'string' && name ? name : null;
     }
 
+    if (type === 'sensor-toggle' && typeof config.sensorId === 'number') {
+        const sensor = sensors.find(s => s.id === config.sensorId);
+        const property = typeof config.property === 'string' && config.property ? config.property : null;
+        if (!sensor) return null;
+        return property ? `${sensor.name} · ${property}` : sensor.name;
+    }
+
     if (typeof config.sensorId === 'number') {
         const sensor = sensors.find(s => s.id === config.sensorId);
         return sensor?.name ?? null;

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/SensorToggleWidget.test.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/SensorToggleWidget.test.tsx
@@ -102,6 +102,44 @@ describe('SensorToggleWidget', () => {
     reportUpdateMock.mockReset();
   });
 
+  it('stays indeterminate until the first reading arrives instead of defaulting to off', () => {
+    sensors.splice(0, sensors.length, makeSensor());
+    authUser = {
+      id: 1,
+      username: 'operator',
+      roles: [],
+      permissions: ['control_sensors'],
+    };
+
+    const { rerender } = render(
+      <SensorToggleWidget
+        id="widget-1"
+        config={{ sensorId: 7, property: 'state' }}
+        isEditing={false}
+      />,
+    );
+
+    const initialToggle = screen.getByRole('checkbox', { name: /toggle office-plug state/i });
+    expect(initialToggle).toHaveAttribute('aria-checked', 'mixed');
+    expect(initialToggle).toHaveAttribute('aria-disabled', 'true');
+
+    fireEvent.click(initialToggle);
+    expect(postMock).not.toHaveBeenCalled();
+
+    currentReadings['office-plug'] = { state: makeReading() };
+    rerender(
+      <SensorToggleWidget
+        id="widget-1"
+        config={{ sensorId: 7, property: 'state' }}
+        isEditing={false}
+      />,
+    );
+
+    const resolvedToggle = screen.getByRole('checkbox', { name: /toggle office-plug state/i });
+    expect(resolvedToggle).toBeChecked();
+    expect(resolvedToggle).toHaveAttribute('aria-disabled', 'false');
+  });
+
   it('renders the current binary state and flips optimistically when sending a command', async () => {
     sensors.splice(0, sensors.length, makeSensor());
     currentReadings['office-plug'] = { state: makeReading() };

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/SensorToggleWidget.test.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/SensorToggleWidget.test.tsx
@@ -140,6 +140,29 @@ describe('SensorToggleWidget', () => {
     expect(resolvedToggle).toHaveAttribute('aria-disabled', 'false');
   });
 
+  it('treats canonical true readings as on when capability values are ON and OFF', () => {
+    sensors.splice(0, sensors.length, makeSensor({
+      capabilities: [makeCapability({ value_on: 'ON', value_off: 'OFF' })],
+    }));
+    currentReadings['office-plug'] = { state: makeReading({ text_state: 'true' }) };
+    authUser = {
+      id: 1,
+      username: 'operator',
+      roles: [],
+      permissions: ['control_sensors'],
+    };
+
+    render(
+      <SensorToggleWidget
+        id="widget-1"
+        config={{ sensorId: 7, property: 'state' }}
+        isEditing={false}
+      />,
+    );
+
+    expect(screen.getByRole('checkbox', { name: /toggle office-plug state/i })).toBeChecked();
+  });
+
   it('renders the current binary state and flips optimistically when sending a command', async () => {
     sensors.splice(0, sensors.length, makeSensor());
     currentReadings['office-plug'] = { state: makeReading() };
@@ -241,6 +264,64 @@ describe('SensorToggleWidget', () => {
     );
     expect(await screen.findByText('Command failed')).toBeInTheDocument();
     expect(reportUpdateMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('clears optimistic state when the live reading matches semantically', async () => {
+    sensors.splice(0, sensors.length, makeSensor({
+      capabilities: [makeCapability({ value_on: 'ON', value_off: 'OFF' })],
+    }));
+    currentReadings['office-plug'] = { state: makeReading({ text_state: 'false' }) };
+    authUser = {
+      id: 1,
+      username: 'operator',
+      roles: [],
+      permissions: ['control_sensors'],
+    };
+
+    postMock.mockResolvedValue({
+      data: {
+        id: 44,
+        status: 'sent',
+        property: 'state',
+        value: 'ON',
+      } satisfies SensorCommandAccepted,
+    });
+
+    const { rerender } = render(
+      <SensorToggleWidget
+        id="widget-1"
+        config={{ sensorId: 7, property: 'state' }}
+        isEditing={false}
+      />,
+    );
+
+    const toggle = screen.getByRole('checkbox', { name: /toggle office-plug state/i });
+    expect(toggle).not.toBeChecked();
+
+    fireEvent.click(toggle);
+    expect(toggle).toBeChecked();
+
+    currentReadings['office-plug'] = { state: makeReading({ text_state: 'true' }) };
+    rerender(
+      <SensorToggleWidget
+        id="widget-1"
+        config={{ sensorId: 7, property: 'state' }}
+        isEditing={false}
+      />,
+    );
+
+    currentReadings['office-plug'] = { state: makeReading({ text_state: 'false' }) };
+    rerender(
+      <SensorToggleWidget
+        id="widget-1"
+        config={{ sensorId: 7, property: 'state' }}
+        isEditing={false}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole('checkbox', { name: /toggle office-plug state/i })).not.toBeChecked(),
+    );
   });
 
   it('renders as a read-only switch when the user lacks control permission', () => {

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/SensorToggleWidget.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/SensorToggleWidget.tsx
@@ -52,6 +52,41 @@ function applyLateLatchProgress(progress: number, startChecked: boolean): number
   return startChecked ? 1 - mappedDistance : mappedDistance;
 }
 
+function normalizeBinaryStateToken(value: string | null | undefined): string | null {
+  if (value == null) return null;
+
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) return null;
+
+  if (['on', 'true', '1', 'enabled', 'enable'].includes(normalized)) {
+    return 'on';
+  }
+
+  if (['off', 'false', '0', 'disabled', 'disable'].includes(normalized)) {
+    return 'off';
+  }
+
+  return normalized;
+}
+
+function resolveCheckedState(
+  value: string | null | undefined,
+  valueOn: string,
+  valueOff: string,
+): boolean | null {
+  const currentToken = normalizeBinaryStateToken(value);
+  const onToken = normalizeBinaryStateToken(valueOn);
+  const offToken = normalizeBinaryStateToken(valueOff);
+
+  if (currentToken == null || onToken == null || offToken == null) {
+    return null;
+  }
+
+  if (currentToken === onToken) return true;
+  if (currentToken === offToken) return false;
+  return null;
+}
+
 export default function SensorToggleWidget({ config }: WidgetProps) {
   const theme = useTheme();
   const { sensors } = useSensorContext();
@@ -93,8 +128,9 @@ export default function SensorToggleWidget({ config }: WidgetProps) {
   const reading = sensor && property ? readings[sensor.name]?.[property] : undefined;
 
   const effectiveValue = optimisticValue ?? reading?.text_state ?? null;
-  const hasResolvedValue = effectiveValue != null;
-  const checked = hasResolvedValue && effectiveValue === valueOn;
+  const resolvedCheckedState = resolveCheckedState(effectiveValue, valueOn, valueOff);
+  const hasResolvedValue = resolvedCheckedState != null;
+  const checked = resolvedCheckedState ?? false;
   const canControl = hasPerm(user, 'control_sensors');
   const canInteract = canControl && hasResolvedValue;
   const rawProgress = dragProgress ?? (hasResolvedValue ? (checked ? 1 : 0) : 0.5);
@@ -118,10 +154,14 @@ export default function SensorToggleWidget({ config }: WidgetProps) {
   }), [canControl, hasResolvedValue, visualChecked, theme.palette.common.white, theme.palette.primary.main, theme.palette.text.secondary]);
 
   useEffect(() => {
-    if (optimisticValue != null && reading?.text_state === optimisticValue) {
+    if (
+      optimisticValue != null
+      && resolveCheckedState(optimisticValue, valueOn, valueOff) != null
+      && resolveCheckedState(optimisticValue, valueOn, valueOff) === resolveCheckedState(reading?.text_state, valueOn, valueOff)
+    ) {
       setOptimisticValue(null);
     }
-  }, [optimisticValue, reading?.text_state]);
+  }, [optimisticValue, reading?.text_state, valueOff, valueOn]);
 
   if (!sensor || !property || !capability) {
     return <NeedsConfiguration message="Select a controllable sensor and binary property" />;

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/SensorToggleWidget.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/SensorToggleWidget.tsx
@@ -93,9 +93,11 @@ export default function SensorToggleWidget({ config }: WidgetProps) {
   const reading = sensor && property ? readings[sensor.name]?.[property] : undefined;
 
   const effectiveValue = optimisticValue ?? reading?.text_state ?? null;
-  const checked = effectiveValue === valueOn;
+  const hasResolvedValue = effectiveValue != null;
+  const checked = hasResolvedValue && effectiveValue === valueOn;
   const canControl = hasPerm(user, 'control_sensors');
-  const rawProgress = dragProgress ?? (checked ? 1 : 0);
+  const canInteract = canControl && hasResolvedValue;
+  const rawProgress = dragProgress ?? (hasResolvedValue ? (checked ? 1 : 0) : 0.5);
   const isDragging = dragProgress !== null;
   const dragStartChecked = dragStartCheckedRef.current;
   const visualChecked = isDragging
@@ -105,13 +107,15 @@ export default function SensorToggleWidget({ config }: WidgetProps) {
   const thumbLeft = CONTROL_PADDING + (thumbProgress * DRAG_TRAVEL);
 
   const visualState = useMemo(() => ({
-    trackBackground: visualChecked
-      ? alpha(theme.palette.primary.main, canControl ? 0.95 : 0.55)
-      : alpha(theme.palette.text.secondary, canControl ? 0.35 : 0.2),
+    trackBackground: !hasResolvedValue
+      ? alpha(theme.palette.text.secondary, 0.22)
+      : visualChecked
+        ? alpha(theme.palette.primary.main, canControl ? 0.95 : 0.55)
+        : alpha(theme.palette.text.secondary, canControl ? 0.35 : 0.2),
     thumbBackground: theme.palette.common.white,
-    onOpacity: visualChecked ? 1 : 0.35,
-    offOpacity: visualChecked ? 0.35 : 1,
-  }), [canControl, visualChecked, theme.palette.common.white, theme.palette.primary.main, theme.palette.text.secondary]);
+    onOpacity: !hasResolvedValue ? 0.55 : visualChecked ? 1 : 0.35,
+    offOpacity: !hasResolvedValue ? 0.55 : visualChecked ? 0.35 : 1,
+  }), [canControl, hasResolvedValue, visualChecked, theme.palette.common.white, theme.palette.primary.main, theme.palette.text.secondary]);
 
   useEffect(() => {
     if (optimisticValue != null && reading?.text_state === optimisticValue) {
@@ -124,7 +128,7 @@ export default function SensorToggleWidget({ config }: WidgetProps) {
   }
 
   const commitCheckedState = async (nextChecked: boolean) => {
-    if (!canControl) return;
+    if (!canInteract) return;
 
     const previousValue = reading?.text_state ?? null;
     const nextValue = nextChecked ? valueOn : valueOff;
@@ -150,7 +154,7 @@ export default function SensorToggleWidget({ config }: WidgetProps) {
   };
 
   const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
-    if (!canControl) return;
+    if (!canInteract) return;
 
     dragOriginXRef.current = event.clientX;
     dragStartCheckedRef.current = checked;
@@ -195,7 +199,7 @@ export default function SensorToggleWidget({ config }: WidgetProps) {
   };
 
   const handleClick = () => {
-    if (!canControl) return;
+    if (!canInteract) return;
     if (suppressClickRef.current) {
       suppressClickRef.current = false;
       return;
@@ -210,17 +214,17 @@ export default function SensorToggleWidget({ config }: WidgetProps) {
           ref={controlRef}
           data-testid="sensor-toggle-control"
           role="checkbox"
-          aria-checked={checked}
-          aria-disabled={!canControl}
+          aria-checked={hasResolvedValue ? checked : 'mixed'}
+          aria-disabled={!canInteract}
           aria-label={`Toggle ${sensor.name} ${property}`}
-          tabIndex={canControl ? 0 : -1}
+          tabIndex={canInteract ? 0 : -1}
           onClick={handleClick}
           onPointerDown={handlePointerDown}
           onPointerMove={handlePointerMove}
           onPointerUp={finishDrag}
           onPointerCancel={finishDrag}
           onKeyDown={(event) => {
-            if (!canControl) return;
+            if (!canInteract) return;
             if (event.key === ' ' || event.key === 'Enter') {
               event.preventDefault();
               void commitCheckedState(!checked);
@@ -232,14 +236,14 @@ export default function SensorToggleWidget({ config }: WidgetProps) {
             maxWidth: `${CONTROL_MAX_WIDTH}px`,
             height: `${CONTROL_HEIGHT}px`,
             borderRadius: `${CONTROL_HEIGHT / 2}px`,
-            backgroundColor: visualState.trackBackground,
-            boxShadow: visualChecked
-              ? `inset 0 0 0 1px ${alpha(theme.palette.common.white, 0.14)}, 0 0 24px ${alpha(theme.palette.primary.main, canControl ? 0.22 : 0.1)}`
-              : `inset 0 0 0 1px ${alpha(theme.palette.text.primary, 0.08)}`,
-            cursor: canControl ? (isDragging ? 'grabbing' : 'pointer') : 'default',
-            userSelect: 'none',
-            touchAction: 'none',
-            outline: 'none',
+              backgroundColor: visualState.trackBackground,
+              boxShadow: visualChecked
+                ? `inset 0 0 0 1px ${alpha(theme.palette.common.white, 0.14)}, 0 0 24px ${alpha(theme.palette.primary.main, canControl ? 0.22 : 0.1)}`
+                : `inset 0 0 0 1px ${alpha(theme.palette.text.primary, hasResolvedValue ? 0.08 : 0.12)}`,
+              cursor: canInteract ? (isDragging ? 'grabbing' : 'pointer') : 'default',
+              userSelect: 'none',
+              touchAction: 'none',
+              outline: 'none',
             transition: isDragging
               ? 'background-color 90ms linear, box-shadow 90ms linear'
               : 'background-color 180ms ease, box-shadow 180ms ease',
@@ -251,11 +255,13 @@ export default function SensorToggleWidget({ config }: WidgetProps) {
               bottom: 16,
               width: 2,
               transform: 'translateX(-50%)',
-               borderRadius: 999,
-               backgroundColor: visualChecked
-                 ? alpha(theme.palette.common.white, 0.28)
-                 : alpha(theme.palette.text.primary, 0.12),
-            },
+                borderRadius: 999,
+                backgroundColor: !hasResolvedValue
+                  ? alpha(theme.palette.text.primary, 0.16)
+                  : visualChecked
+                  ? alpha(theme.palette.common.white, 0.28)
+                  : alpha(theme.palette.text.primary, 0.12),
+             },
           }}
         >
           <Box
@@ -287,21 +293,25 @@ export default function SensorToggleWidget({ config }: WidgetProps) {
               transform: `translateX(${thumbLeft}px) scale(${isDragging ? 0.985 : 1})`,
               backgroundColor: visualState.thumbBackground,
                boxShadow: isDragging
-                 ? `0 6px 14px ${alpha(theme.palette.common.black, 0.18)}`
-                 : visualChecked
-                   ? `0 0 18px ${alpha(theme.palette.primary.main, canControl ? 0.34 : 0.18)}, 0 0 30px ${alpha(theme.palette.primary.light, canControl ? 0.22 : 0.1)}`
-                   : `0 0 10px ${alpha(theme.palette.text.secondary, 0.1)}, 0 10px 24px ${alpha(theme.palette.common.black, 0.12)}`,
+                  ? `0 6px 14px ${alpha(theme.palette.common.black, 0.18)}`
+                  : !hasResolvedValue
+                    ? `0 0 10px ${alpha(theme.palette.text.secondary, 0.14)}, 0 8px 18px ${alpha(theme.palette.common.black, 0.08)}`
+                    : visualChecked
+                    ? `0 0 18px ${alpha(theme.palette.primary.main, canControl ? 0.34 : 0.18)}, 0 0 30px ${alpha(theme.palette.primary.light, canControl ? 0.22 : 0.1)}`
+                    : `0 0 10px ${alpha(theme.palette.text.secondary, 0.1)}, 0 10px 24px ${alpha(theme.palette.common.black, 0.12)}`,
               transition: isDragging
                 ? 'none'
                 : 'transform 240ms cubic-bezier(0.2, 0.9, 0.25, 1.25), box-shadow 200ms ease',
               '&::before': {
                 content: '""',
-                position: 'absolute',
-                 inset: 16,
-                 borderRadius: 999,
-                 background: visualChecked
-                   ? `linear-gradient(90deg, ${alpha(theme.palette.primary.main, 0.28)}, ${alpha(theme.palette.primary.light, 0.12)})`
-                   : `linear-gradient(90deg, ${alpha(theme.palette.text.secondary, 0.16)}, ${alpha(theme.palette.text.secondary, 0.06)})`,
+                  position: 'absolute',
+                   inset: 16,
+                   borderRadius: 999,
+                  background: !hasResolvedValue
+                    ? `linear-gradient(90deg, ${alpha(theme.palette.text.secondary, 0.12)}, ${alpha(theme.palette.text.secondary, 0.08)})`
+                    : visualChecked
+                    ? `linear-gradient(90deg, ${alpha(theme.palette.primary.main, 0.28)}, ${alpha(theme.palette.primary.light, 0.12)})`
+                    : `linear-gradient(90deg, ${alpha(theme.palette.text.secondary, 0.16)}, ${alpha(theme.palette.text.secondary, 0.06)})`,
               },
             }}
           />

--- a/sensor_hub/ui/sensor_hub_ui/src/hooks/useCurrentReadings.test.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/hooks/useCurrentReadings.test.tsx
@@ -1,0 +1,56 @@
+import { renderHook, act } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let socketMessageHandler: ((event: MessageEvent) => void) | undefined;
+
+vi.mock('../providers/AuthContext.tsx', () => ({
+  useAuth: () => ({
+    user: {
+      id: 1,
+      username: 'operator',
+      roles: [],
+      permissions: ['view_readings'],
+    },
+  }),
+}));
+
+vi.mock('./useReconnectingWebSocket', () => ({
+  useReconnectingWebSocket: (options: { onMessage: (event: MessageEvent) => void }) => {
+    socketMessageHandler = options.onMessage;
+  },
+}));
+
+describe('useCurrentReadings', () => {
+  beforeEach(() => {
+    socketMessageHandler = undefined;
+    vi.resetModules();
+  });
+
+  it('reuses the last known readings when the hook remounts', async () => {
+    const { useCurrentReadings } = await import('./useCurrentReadings');
+    const { result, unmount } = renderHook(() => useCurrentReadings());
+
+    act(() => {
+      socketMessageHandler?.(new MessageEvent('message', {
+        data: JSON.stringify([{
+          id: 99,
+          sensor_name: 'office-plug',
+          measurement_type: 'state',
+          numeric_value: null,
+          text_state: 'ON',
+          unit: '',
+          time: '2026-05-09T20:00:00Z',
+        }]),
+      }));
+    });
+
+    expect(result.current['office-plug']?.state?.text_state).toBe('ON');
+
+    unmount();
+
+    const { useCurrentReadings: useCurrentReadingsRemount } = await import('./useCurrentReadings');
+    const { result: remountedResult } = renderHook(() => useCurrentReadingsRemount());
+
+    expect(remountedResult.current['office-plug']?.state?.text_state).toBe('ON');
+  });
+});

--- a/sensor_hub/ui/sensor_hub_ui/src/hooks/useCurrentReadings.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/hooks/useCurrentReadings.ts
@@ -7,6 +7,8 @@ import { useReconnectingWebSocket } from './useReconnectingWebSocket';
 
 export type CurrentReadingsMap = Record<string, Record<string, Reading>>;
 
+let cachedCurrentReadings: CurrentReadingsMap = {};
+
 interface UseCurrentReadingsOptions {
     onDataUpdate?: (date: Date) => void;
     onCommandStatus?: (message: CommandStatusMessage) => void;
@@ -26,7 +28,7 @@ function mergeReadings(prev: CurrentReadingsMap, readings: Reading[]): CurrentRe
 }
 
 export function useCurrentReadings(options?: UseCurrentReadingsOptions): CurrentReadingsMap {
-  const [currentReadings, setCurrentReadings] = useState<CurrentReadingsMap>({});
+  const [currentReadings, setCurrentReadings] = useState<CurrentReadingsMap>(() => cachedCurrentReadings);
   const { user } = useAuth();
 
   const onDataUpdateRef = useRef(options?.onDataUpdate);
@@ -45,7 +47,11 @@ export function useCurrentReadings(options?: UseCurrentReadingsOptions): Current
       }
 
       if (Array.isArray(parsed)) {
-        setCurrentReadings((prev) => mergeReadings(prev, parsed as Reading[]));
+        setCurrentReadings((prev) => {
+          const next = mergeReadings(prev, parsed as Reading[]);
+          cachedCurrentReadings = next;
+          return next;
+        });
         onDataUpdateRef.current?.(new Date());
         return;
       }
@@ -58,13 +64,21 @@ export function useCurrentReadings(options?: UseCurrentReadingsOptions): Current
       }
 
       if ('readings' in parsed && Array.isArray(parsed.readings)) {
-        setCurrentReadings((prev) => mergeReadings(prev, parsed.readings as Reading[]));
+        setCurrentReadings((prev) => {
+          const next = mergeReadings(prev, parsed.readings as Reading[]);
+          cachedCurrentReadings = next;
+          return next;
+        });
         onDataUpdateRef.current?.(new Date());
         return;
       }
 
       if ('sensor_name' in parsed && 'measurement_type' in parsed) {
-        setCurrentReadings((prev) => mergeReadings(prev, [parsed as Reading]));
+        setCurrentReadings((prev) => {
+          const next = mergeReadings(prev, [parsed as Reading]);
+          cachedCurrentReadings = next;
+          return next;
+        });
         onDataUpdateRef.current?.(new Date());
       }
   }, []);


### PR DESCRIPTION
## Summary
- keep sensor toggle widgets indeterminate until a live reading is known and reuse cached current readings across remounts
- show the controlled property in the widget frame title and harden toggle config normalization to binary capabilities only
- add focused UI coverage for current-reading caching, toggle loading state, subtitle formatting, and binary capability filtering

## Testing
- cd sensor_hub/ui/sensor_hub_ui && npm run test
- cd sensor_hub/ui/sensor_hub_ui && npm run build
- scripts/build-packages.sh server --arch arm64 --format deb --version 1.2.10~dev2 --output-dir dist/1.2.10-dev2-arm64

Closes #140
