### PR TITLE
Preserve retained health history continuity during cleanup

### DIFF
--- a/sensor_hub/db/migrations/000019_sensor_health_history_dedup.down.sql
+++ b/sensor_hub/db/migrations/000019_sensor_health_history_dedup.down.sql
@@ -1,0 +1,1 @@
+-- No-op: deleted duplicate health history rows cannot be restored.

--- a/sensor_hub/db/migrations/000019_sensor_health_history_dedup.up.sql
+++ b/sensor_hub/db/migrations/000019_sensor_health_history_dedup.up.sql
@@ -1,0 +1,15 @@
+DELETE FROM sensor_health_history
+WHERE id IN (
+    SELECT id
+    FROM (
+        SELECT
+            id,
+            health_status,
+            LAG(health_status) OVER (
+                PARTITION BY sensor_id
+                ORDER BY datetime(recorded_at), id
+            ) AS previous_health_status
+        FROM sensor_health_history
+    ) dedup_candidates
+    WHERE previous_health_status = health_status
+);

--- a/sensor_hub/db/sensor_health_history_migration_test.go
+++ b/sensor_hub/db/sensor_health_history_migration_test.go
@@ -1,0 +1,93 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"log/slog"
+	"testing"
+	"time"
+
+	gen "example/sensorHub/gen"
+
+	"github.com/golang-migrate/migrate/v4"
+	sqlite_migrate "github.com/golang-migrate/migrate/v4/database/sqlite"
+	"github.com/golang-migrate/migrate/v4/source/iofs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHealthHistoryMigration_RemovesConsecutiveDuplicates(t *testing.T) {
+	db := newInMemoryDB(t)
+	m := newTestMigrator(t, db)
+
+	require.NoError(t, m.Migrate(18))
+
+	repo := NewSensorRepository(db, slog.Default())
+	ctx := context.Background()
+	require.NoError(t, repo.AddSensor(ctx, gen.Sensor{
+		Name:         "migration-sensor",
+		SensorDriver: "sensor-hub-http-temperature",
+	}))
+
+	sensorID, err := repo.GetSensorIdByName(ctx, "migration-sensor")
+	require.NoError(t, err)
+
+	const sqliteDateTime = "2006-01-02 15:04:05"
+	t1 := time.Date(2026, 5, 1, 8, 0, 0, 0, time.UTC)
+	t2 := t1.Add(1 * time.Hour)
+	t3 := t2.Add(1 * time.Hour)
+	t4 := t3.Add(1 * time.Hour)
+	t5 := t4.Add(1 * time.Hour)
+
+	_, err = db.ExecContext(
+		ctx,
+		`INSERT INTO sensor_health_history (sensor_id, health_status, recorded_at)
+		 VALUES (?, ?, ?), (?, ?, ?), (?, ?, ?), (?, ?, ?), (?, ?, ?)`,
+		sensorID, gen.Good, t1.Format(sqliteDateTime),
+		sensorID, gen.Good, t2.Format(sqliteDateTime),
+		sensorID, gen.Bad, t3.Format(sqliteDateTime),
+		sensorID, gen.Bad, t4.Format(sqliteDateTime),
+		sensorID, gen.Good, t5.Format(sqliteDateTime),
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, m.Up())
+
+	history, err := repo.GetSensorHealthHistoryById(ctx, sensorID, 10)
+	require.NoError(t, err)
+	require.Len(t, history, 3)
+
+	assert.Equal(t, []gen.SensorHealthStatus{gen.Good, gen.Bad, gen.Good}, []gen.SensorHealthStatus{
+		history[0].HealthStatus,
+		history[1].HealthStatus,
+		history[2].HealthStatus,
+	})
+	assert.Equal(t, []time.Time{t5, t3, t1}, []time.Time{
+		history[0].RecordedAt.UTC(),
+		history[1].RecordedAt.UTC(),
+		history[2].RecordedAt.UTC(),
+	})
+}
+
+func newTestMigrator(t *testing.T, db *sql.DB) *migrate.Migrate {
+	t.Helper()
+
+	sourceDriver, err := iofs.New(migrationsFS, "migrations")
+	require.NoError(t, err)
+
+	dbDriver, err := sqlite_migrate.WithInstance(db, &sqlite_migrate.Config{
+		NoTxWrap: true,
+	})
+	require.NoError(t, err)
+
+	m, err := migrate.NewWithInstance("iofs", sourceDriver, "sqlite", dbDriver)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		sourceErr, dbErr := m.Close()
+		require.NoError(t, sourceErr)
+		require.NoError(t, dbErr)
+	})
+
+	return m
+}

--- a/sensor_hub/db/sensor_repository.go
+++ b/sensor_hub/db/sensor_repository.go
@@ -100,11 +100,39 @@ func (s *SensorRepository) GetSensorIdByName(ctx context.Context, sensorName str
 }
 
 func (s *SensorRepository) DeleteHealthHistoryOlderThan(ctx context.Context, cutoffDate time.Time) error {
-	query := fmt.Sprintf("DELETE FROM %s WHERE recorded_at < ?", TableSensorHealthHistory)
-	_, err := s.db.ExecContext(ctx, query, cutoffDate)
+	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
+		return fmt.Errorf("error beginning transaction for health history cleanup: %w", err)
+	}
+
+	cutoff := cutoffDate.UTC().Format("2006-01-02 15:04:05")
+
+	insertCheckpointQuery := fmt.Sprintf(`
+		INSERT INTO %s (sensor_id, health_status, recorded_at)
+		SELECT sensor_id, health_status, ?
+		FROM (
+			SELECT sensor_id, health_status,
+				ROW_NUMBER() OVER (PARTITION BY sensor_id ORDER BY datetime(recorded_at) DESC, id DESC) AS row_num
+			FROM %s
+			WHERE datetime(recorded_at) < datetime(?)
+		)
+		WHERE row_num = 1
+	`, TableSensorHealthHistory, TableSensorHealthHistory)
+	if _, err := tx.ExecContext(ctx, insertCheckpointQuery, cutoff, cutoff); err != nil {
+		tx.Rollback()
+		return fmt.Errorf("error inserting retained health history checkpoints: %w", err)
+	}
+
+	deleteQuery := fmt.Sprintf("DELETE FROM %s WHERE datetime(recorded_at) < datetime(?)", TableSensorHealthHistory)
+	if _, err := tx.ExecContext(ctx, deleteQuery, cutoff); err != nil {
+		tx.Rollback()
 		return fmt.Errorf("error deleting old sensor health history: %w", err)
 	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("error committing health history cleanup: %w", err)
+	}
+
 	return nil
 }
 

--- a/sensor_hub/db/sensor_repository_test.go
+++ b/sensor_hub/db/sensor_repository_test.go
@@ -695,9 +695,15 @@ func TestSensorRepository_DeleteHealthHistoryOlderThan_Success(t *testing.T) {
 	repo := NewSensorRepository(db, slog.Default())
 
 	cutoff := time.Now().Add(-24 * time.Hour)
-	mock.ExpectExec("DELETE FROM sensor_health_history WHERE recorded_at < \\?").
-		WithArgs(cutoff).
+	formattedCutoff := cutoff.UTC().Format("2006-01-02 15:04:05")
+	mock.ExpectBegin()
+	mock.ExpectExec("INSERT INTO sensor_health_history \\(sensor_id, health_status, recorded_at\\)").
+		WithArgs(formattedCutoff, formattedCutoff).
+		WillReturnResult(sqlmock.NewResult(0, 2))
+	mock.ExpectExec("DELETE FROM sensor_health_history WHERE datetime\\(recorded_at\\) < datetime\\(\\?\\)").
+		WithArgs(formattedCutoff).
 		WillReturnResult(sqlmock.NewResult(0, 5))
+	mock.ExpectCommit()
 
 	err := repo.DeleteHealthHistoryOlderThan(context.Background(), cutoff)
 
@@ -710,9 +716,15 @@ func TestSensorRepository_DeleteHealthHistoryOlderThan_NothingToDelete(t *testin
 	repo := NewSensorRepository(db, slog.Default())
 
 	cutoff := time.Now().Add(-24 * time.Hour)
-	mock.ExpectExec("DELETE FROM sensor_health_history WHERE recorded_at < \\?").
-		WithArgs(cutoff).
+	formattedCutoff := cutoff.UTC().Format("2006-01-02 15:04:05")
+	mock.ExpectBegin()
+	mock.ExpectExec("INSERT INTO sensor_health_history \\(sensor_id, health_status, recorded_at\\)").
+		WithArgs(formattedCutoff, formattedCutoff).
 		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("DELETE FROM sensor_health_history WHERE datetime\\(recorded_at\\) < datetime\\(\\?\\)").
+		WithArgs(formattedCutoff).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectCommit()
 
 	err := repo.DeleteHealthHistoryOlderThan(context.Background(), cutoff)
 
@@ -725,9 +737,15 @@ func TestSensorRepository_DeleteHealthHistoryOlderThan_DBError(t *testing.T) {
 	repo := NewSensorRepository(db, slog.Default())
 
 	cutoff := time.Now().Add(-24 * time.Hour)
-	mock.ExpectExec("DELETE FROM sensor_health_history WHERE recorded_at < \\?").
-		WithArgs(cutoff).
+	formattedCutoff := cutoff.UTC().Format("2006-01-02 15:04:05")
+	mock.ExpectBegin()
+	mock.ExpectExec("INSERT INTO sensor_health_history \\(sensor_id, health_status, recorded_at\\)").
+		WithArgs(formattedCutoff, formattedCutoff).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("DELETE FROM sensor_health_history WHERE datetime\\(recorded_at\\) < datetime\\(\\?\\)").
+		WithArgs(formattedCutoff).
 		WillReturnError(errors.New("database error"))
+	mock.ExpectRollback()
 
 	err := repo.DeleteHealthHistoryOlderThan(context.Background(), cutoff)
 
@@ -964,4 +982,41 @@ func TestSensorRepository_UpdateSensorStatus_DBError(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "error updating sensor status")
 	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSensorRepository_DeleteHealthHistoryOlderThan_PreservesCutoffCheckpointForLongLivedState(t *testing.T) {
+	db := newInMemoryDB(t)
+	require.NoError(t, runMigrations(db, slog.Default()))
+
+	repo := NewSensorRepository(db, slog.Default())
+	ctx := context.Background()
+	cutoff := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+
+	err := repo.AddSensor(ctx, gen.Sensor{
+		Name:         "continuity-sensor",
+		SensorDriver: "sensor-hub-http-temperature",
+	})
+	require.NoError(t, err)
+
+	sensorID, err := repo.GetSensorIdByName(ctx, "continuity-sensor")
+	require.NoError(t, err)
+
+	const sqliteDateTime = "2006-01-02 15:04:05"
+
+	_, err = db.ExecContext(
+		ctx,
+		"INSERT INTO sensor_health_history (sensor_id, health_status, recorded_at) VALUES (?, ?, ?), (?, ?, ?)",
+		sensorID, gen.Bad, cutoff.Add(-48*time.Hour).Format(sqliteDateTime),
+		sensorID, gen.Good, cutoff.Add(-12*time.Hour).Format(sqliteDateTime),
+	)
+	require.NoError(t, err)
+
+	err = repo.DeleteHealthHistoryOlderThan(ctx, cutoff)
+	require.NoError(t, err)
+
+	history, err := repo.GetSensorHealthHistoryById(ctx, sensorID, 10)
+	require.NoError(t, err)
+	require.Len(t, history, 1)
+	assert.Equal(t, gen.Good, history[0].HealthStatus)
+	assert.Equal(t, cutoff, history[0].RecordedAt.UTC())
 }


### PR DESCRIPTION
## Summary
- preserve retained health history continuity by inserting cutoff checkpoint rows before pruning old history
- add migration 19 to remove consecutive duplicate health history rows while keeping real transitions
- add repository and migration coverage for cleanup continuity and duplicate-history backfill

## Testing
- cd sensor_hub && go test ./...
- cd sensor_hub && go test -tags integration -v -timeout 300s ./integration/

Fixes #143