### PR TITLE
Remove health history limit contract

### DIFF
--- a/packaging/defaults/application.properties
+++ b/packaging/defaults/application.properties
@@ -6,7 +6,6 @@ openapi.yaml.location=
 health.history.retention.days=180
 sensor.data.retention.days=365
 data.cleanup.interval.hours=24
-health.history.default.response.number=1000
 failed.login.retention.days=1
 auth.bcrypt.cost=12
 auth.session.ttl.minutes=43200

--- a/sensor_hub/api/mocks_test.go
+++ b/sensor_hub/api/mocks_test.go
@@ -250,8 +250,8 @@ func (m *MockSensorService) ServiceSetEnabledSensorByName(ctx context.Context, n
 	return args.Error(0)
 }
 
-func (m *MockSensorService) ServiceGetSensorHealthHistoryByName(ctx context.Context, name string, limit int) ([]gen.SensorHealthHistory, error) {
-	args := m.Called(ctx, name, limit)
+func (m *MockSensorService) ServiceGetSensorHealthHistoryByName(ctx context.Context, name string) ([]gen.SensorHealthHistory, error) {
+	args := m.Called(ctx, name)
 	return args.Get(0).([]gen.SensorHealthHistory), args.Error(1)
 }
 

--- a/sensor_hub/api/openapi.yaml
+++ b/sensor_hub/api/openapi.yaml
@@ -775,9 +775,8 @@ paths:
         - sensors
       summary: Get sensor health history
       description: >-
-        Return historical health checks for a sensor. A `limit` query
-        parameter may be provided to restrict the number of returned records
-        (default is defined by the server configuration).
+        Return all retained historical health checks for a sensor within the
+        configured retention window.
       operationId: getSensorHealthHistoryByName
       x-required-permission: view_sensors
       parameters:
@@ -786,12 +785,6 @@ paths:
           required: true
           schema:
             type: string
-        - name: limit
-          in: query
-          required: false
-          schema:
-            type: integer
-          description: Max number of history records to return (server default applies if omitted)
       responses:
         '200':
           description: Array of health history records

--- a/sensor_hub/api/sensor_api.go
+++ b/sensor_hub/api/sensor_api.go
@@ -342,20 +342,10 @@ func (s *Server) SubscribeSensorsByDriver(c *gin.Context, driver string) {
 	ws.BroadcastToTopic(topic, sensors)
 }
 
-// Limit defaults to the app config value when params.Limit is nil.
-func (s *Server) GetSensorHealthHistoryByName(c *gin.Context, name string, params gen.GetSensorHealthHistoryByNameParams) {
+func (s *Server) GetSensorHealthHistoryByName(c *gin.Context, name string) {
 	ctx := c.Request.Context()
 
-	limit := appProps.AppConfig.HealthHistoryDefaultResponseNumber
-	if params.Limit != nil {
-		if *params.Limit <= 0 {
-			c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid limit parameter"})
-			return
-		}
-		limit = *params.Limit
-	}
-
-	healthHistory, err := s.sensorService.ServiceGetSensorHealthHistoryByName(ctx, name, limit)
+	healthHistory, err := s.sensorService.ServiceGetSensorHealthHistoryByName(ctx, name)
 	if err != nil {
 		c.IndentedJSON(http.StatusInternalServerError, gin.H{"message": "Error retrieving sensor health history", "error": err.Error()})
 		return

--- a/sensor_hub/api/sensor_api_test.go
+++ b/sensor_hub/api/sensor_api_test.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"strconv"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -20,7 +19,7 @@ import (
 
 func init() {
 	appProps.AppConfig = &appProps.ApplicationConfiguration{
-		HealthHistoryDefaultResponseNumber: 10,
+		SensorDataRetentionDays: 30,
 	}
 }
 
@@ -409,19 +408,10 @@ func TestSensorExistsHandler(t *testing.T) {
 func TestGetSensorHealthHistoryByNameHandler(t *testing.T) {
 	router, api, s, mockService := setupSensorRouter()
 	api.GET("/sensors/:name/health", func(c *gin.Context) {
-		var params gen.GetSensorHealthHistoryByNameParams
-		if limitStr := c.Query("limit"); limitStr != "" {
-			limit, err := strconv.Atoi(limitStr)
-			if err != nil || limit <= 0 {
-				c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid limit parameter"})
-				return
-			}
-			params.Limit = &limit
-		}
-		s.GetSensorHealthHistoryByName(c, c.Param("name"), params)
+		s.GetSensorHealthHistoryByName(c, c.Param("name"))
 	})
 
-	mockService.On("ServiceGetSensorHealthHistoryByName", mock.Anything, "s1", 10).Return([]gen.SensorHealthHistory{}, nil)
+	mockService.On("ServiceGetSensorHealthHistoryByName", mock.Anything, "s1").Return([]gen.SensorHealthHistory{}, nil)
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/sensors/s1/health", nil)
@@ -698,44 +688,28 @@ func TestTotalReadingsPerSensorHandler_ServiceError(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
 
-func TestGetSensorHealthHistoryByNameHandler_InvalidLimit(t *testing.T) {
-	router, api, s, _ := setupSensorRouter()
+func TestGetSensorHealthHistoryByNameHandler_IgnoresLegacyLimitQuery(t *testing.T) {
+	router, api, s, mockService := setupSensorRouter()
 	api.GET("/sensors/:name/health", func(c *gin.Context) {
-		var params gen.GetSensorHealthHistoryByNameParams
-		if limitStr := c.Query("limit"); limitStr != "" {
-			limit, err := strconv.Atoi(limitStr)
-			if err != nil || limit <= 0 {
-				c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid limit parameter"})
-				return
-			}
-			params.Limit = &limit
-		}
-		s.GetSensorHealthHistoryByName(c, c.Param("name"), params)
+		s.GetSensorHealthHistoryByName(c, c.Param("name"))
 	})
+
+	mockService.On("ServiceGetSensorHealthHistoryByName", mock.Anything, "s1").Return([]gen.SensorHealthHistory{}, nil)
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/sensors/s1/health?limit=invalid", nil)
 	router.ServeHTTP(w, req)
 
-	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, http.StatusOK, w.Code)
 }
 
 func TestGetSensorHealthHistoryByNameHandler_ServiceError(t *testing.T) {
 	router, api, s, mockService := setupSensorRouter()
 	api.GET("/sensors/:name/health", func(c *gin.Context) {
-		var params gen.GetSensorHealthHistoryByNameParams
-		if limitStr := c.Query("limit"); limitStr != "" {
-			limit, err := strconv.Atoi(limitStr)
-			if err != nil || limit <= 0 {
-				c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "Invalid limit parameter"})
-				return
-			}
-			params.Limit = &limit
-		}
-		s.GetSensorHealthHistoryByName(c, c.Param("name"), params)
+		s.GetSensorHealthHistoryByName(c, c.Param("name"))
 	})
 
-	mockService.On("ServiceGetSensorHealthHistoryByName", mock.Anything, "s1", 10).Return([]gen.SensorHealthHistory{}, errors.New("db error"))
+	mockService.On("ServiceGetSensorHealthHistoryByName", mock.Anything, "s1").Return([]gen.SensorHealthHistory{}, errors.New("db error"))
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/sensors/s1/health", nil)

--- a/sensor_hub/application_properties/application_configuration.go
+++ b/sensor_hub/application_properties/application_configuration.go
@@ -6,15 +6,14 @@ import (
 )
 
 type ApplicationConfiguration struct {
-	SensorCollectionInterval           int    `prop:"sensor.collection.interval" default:"300" file:"application" validate:"positive"`
-	SensorDiscoverySkip                bool   `prop:"sensor.discovery.skip" default:"true" file:"application"`
-	OpenAPILocation                    string `prop:"openapi.yaml.location" default:"./docker_tests/openapi.yaml" file:"application"`
-	HealthHistoryRetentionDays         int    `prop:"health.history.retention.days" default:"30" file:"application" validate:"non_negative"`
-	SensorDataRetentionDays            int    `prop:"sensor.data.retention.days" default:"90" file:"application" validate:"non_negative"`
-	FailedLoginRetentionDays           int    `prop:"failed.login.retention.days" default:"2" file:"application" validate:"non_negative"`
-	AlertHistoryRetentionDays          int    `prop:"alert.history.retention.days" default:"90" file:"application" validate:"non_negative"`
-	DataCleanupIntervalHours           int    `prop:"data.cleanup.interval.hours" default:"1" file:"application" validate:"positive"`
-	HealthHistoryDefaultResponseNumber int    `prop:"health.history.default.response.number" default:"1000" file:"application" validate:"positive"`
+	SensorCollectionInterval   int    `prop:"sensor.collection.interval" default:"300" file:"application" validate:"positive"`
+	SensorDiscoverySkip        bool   `prop:"sensor.discovery.skip" default:"true" file:"application"`
+	OpenAPILocation            string `prop:"openapi.yaml.location" default:"./docker_tests/openapi.yaml" file:"application"`
+	HealthHistoryRetentionDays int    `prop:"health.history.retention.days" default:"30" file:"application" validate:"non_negative"`
+	SensorDataRetentionDays    int    `prop:"sensor.data.retention.days" default:"90" file:"application" validate:"non_negative"`
+	FailedLoginRetentionDays   int    `prop:"failed.login.retention.days" default:"2" file:"application" validate:"non_negative"`
+	AlertHistoryRetentionDays  int    `prop:"alert.history.retention.days" default:"90" file:"application" validate:"non_negative"`
+	DataCleanupIntervalHours   int    `prop:"data.cleanup.interval.hours" default:"1" file:"application" validate:"positive"`
 
 	SMTPUser string `prop:"smtp.user" default:"" file:"smtp"`
 

--- a/sensor_hub/application_properties/application_properties_test.go
+++ b/sensor_hub/application_properties/application_properties_test.go
@@ -13,27 +13,26 @@ import (
 // validAppPropsMap returns a complete valid application properties map
 func validAppPropsMap() map[string]string {
 	return map[string]string{
-		"sensor.collection.interval":             "300",
-		"sensor.discovery.skip":                  "true",
-		"openapi.yaml.location":                  "/path/to/openapi.yaml",
-		"health.history.retention.days":          "180",
-		"sensor.data.retention.days":             "365",
-		"data.cleanup.interval.hours":            "24",
-		"health.history.default.response.number": "1000",
-		"failed.login.retention.days":            "2",
-		"auth.bcrypt.cost":                       "12",
-		"auth.session.ttl.minutes":               "43200",
-		"auth.session.cookie.name":               "sensor_hub_session",
-		"auth.login.backoff.window.minutes":      "15",
-		"auth.login.backoff.threshold":           "5",
-		"auth.login.backoff.base.seconds":        "2",
-		"auth.login.backoff.max.seconds":         "300",
-		"oauth.credentials.file.path":            "configuration/credentials.json",
-		"oauth.token.file.path":                  "configuration/token.json",
-		"oauth.token.refresh.interval.minutes":   "30",
-		"mqtt.broker.enabled":                    "true",
-		"mqtt.broker.port":                       "1883",
-		"actuator.command.timeout_seconds":       "10",
+		"sensor.collection.interval":           "300",
+		"sensor.discovery.skip":                "true",
+		"openapi.yaml.location":                "/path/to/openapi.yaml",
+		"health.history.retention.days":        "180",
+		"sensor.data.retention.days":           "365",
+		"data.cleanup.interval.hours":          "24",
+		"failed.login.retention.days":          "2",
+		"auth.bcrypt.cost":                     "12",
+		"auth.session.ttl.minutes":             "43200",
+		"auth.session.cookie.name":             "sensor_hub_session",
+		"auth.login.backoff.window.minutes":    "15",
+		"auth.login.backoff.threshold":         "5",
+		"auth.login.backoff.base.seconds":      "2",
+		"auth.login.backoff.max.seconds":       "300",
+		"oauth.credentials.file.path":          "configuration/credentials.json",
+		"oauth.token.file.path":                "configuration/token.json",
+		"oauth.token.refresh.interval.minutes": "30",
+		"mqtt.broker.enabled":                  "true",
+		"mqtt.broker.port":                     "1883",
+		"actuator.command.timeout_seconds":     "10",
 	}
 }
 
@@ -64,7 +63,6 @@ func TestLoadConfigurationFromMaps_Success(t *testing.T) {
 	assert.Equal(t, 180, cfg.HealthHistoryRetentionDays)
 	assert.Equal(t, 365, cfg.SensorDataRetentionDays)
 	assert.Equal(t, 24, cfg.DataCleanupIntervalHours)
-	assert.Equal(t, 1000, cfg.HealthHistoryDefaultResponseNumber)
 	assert.Equal(t, 2, cfg.FailedLoginRetentionDays)
 	assert.Equal(t, 12, cfg.AuthBcryptCost)
 	assert.Equal(t, 43200, cfg.AuthSessionTTLMinutes)
@@ -136,14 +134,14 @@ func TestLoadConfigurationFromMaps_InvalidDataCleanupIntervalHours(t *testing.T)
 	assert.Nil(t, cfg)
 }
 
-func TestLoadConfigurationFromMaps_InvalidHealthHistoryDefaultResponseNumber(t *testing.T) {
+func TestLoadConfigurationFromMaps_LegacyHealthHistoryDefaultResponseNumberIgnored(t *testing.T) {
 	appProps := validAppPropsMap()
 	appProps["health.history.default.response.number"] = "nope"
 
 	cfg, err := LoadConfigurationFromMaps(appProps, validSmtpPropsMap(), validDbPropsMap())
 
-	assert.Error(t, err)
-	assert.Nil(t, cfg)
+	assert.NoError(t, err)
+	assert.NotNil(t, cfg)
 }
 
 func TestLoadConfigurationFromMaps_InvalidFailedLoginRetentionDays(t *testing.T) {
@@ -268,24 +266,23 @@ func TestLoadConfigurationFromMaps_ZeroCleanupInterval(t *testing.T) {
 
 func TestConvertConfigurationToMaps_Success(t *testing.T) {
 	cfg := &ApplicationConfiguration{
-		SensorCollectionInterval:           300,
-		SensorDiscoverySkip:                true,
-		OpenAPILocation:                    "/path/to/openapi.yaml",
-		HealthHistoryRetentionDays:         180,
-		SensorDataRetentionDays:            365,
-		DataCleanupIntervalHours:           24,
-		HealthHistoryDefaultResponseNumber: 1000,
-		FailedLoginRetentionDays:           2,
-		AuthBcryptCost:                     12,
-		AuthSessionTTLMinutes:              43200,
-		AuthSessionCookieName:              "my_session",
-		AuthLoginBackoffWindowMinutes:      15,
-		AuthLoginBackoffThreshold:          5,
-		AuthLoginBackoffBaseSeconds:        2,
-		AuthLoginBackoffMaxSeconds:         300,
-		SMTPUser:                           "user@test.com",
-		DatabasePath:                       "test/path.db",
-		ActuatorCommandTimeoutSeconds:      12,
+		SensorCollectionInterval:      300,
+		SensorDiscoverySkip:           true,
+		OpenAPILocation:               "/path/to/openapi.yaml",
+		HealthHistoryRetentionDays:    180,
+		SensorDataRetentionDays:       365,
+		DataCleanupIntervalHours:      24,
+		FailedLoginRetentionDays:      2,
+		AuthBcryptCost:                12,
+		AuthSessionTTLMinutes:         43200,
+		AuthSessionCookieName:         "my_session",
+		AuthLoginBackoffWindowMinutes: 15,
+		AuthLoginBackoffThreshold:     5,
+		AuthLoginBackoffBaseSeconds:   2,
+		AuthLoginBackoffMaxSeconds:    300,
+		SMTPUser:                      "user@test.com",
+		DatabasePath:                  "test/path.db",
+		ActuatorCommandTimeoutSeconds: 12,
 	}
 
 	appProps, smtpProps, dbProps := ConvertConfigurationToMaps(cfg)
@@ -296,7 +293,6 @@ func TestConvertConfigurationToMaps_Success(t *testing.T) {
 	assert.Equal(t, "180", appProps["health.history.retention.days"])
 	assert.Equal(t, "365", appProps["sensor.data.retention.days"])
 	assert.Equal(t, "24", appProps["data.cleanup.interval.hours"])
-	assert.Equal(t, "1000", appProps["health.history.default.response.number"])
 	assert.Equal(t, "2", appProps["failed.login.retention.days"])
 	assert.Equal(t, "12", appProps["auth.bcrypt.cost"])
 	assert.Equal(t, "43200", appProps["auth.session.ttl.minutes"])
@@ -305,6 +301,9 @@ func TestConvertConfigurationToMaps_Success(t *testing.T) {
 	assert.Equal(t, "5", appProps["auth.login.backoff.threshold"])
 	assert.Equal(t, "2", appProps["auth.login.backoff.base.seconds"])
 	assert.Equal(t, "300", appProps["auth.login.backoff.max.seconds"])
+
+	_, hasLegacyHealthHistoryLimit := appProps["health.history.default.response.number"]
+	assert.False(t, hasLegacyHealthHistoryLimit)
 
 	assert.Equal(t, "user@test.com", smtpProps["smtp.user"])
 
@@ -325,25 +324,24 @@ func TestConvertConfigurationToMaps_ZeroValues(t *testing.T) {
 
 func TestConvertConfigurationToMaps_RoundTrip(t *testing.T) {
 	original := &ApplicationConfiguration{
-		SensorCollectionInterval:           600,
-		SensorDiscoverySkip:                false,
-		OpenAPILocation:                    "/api/spec.yaml",
-		HealthHistoryRetentionDays:         90,
-		SensorDataRetentionDays:            180,
-		DataCleanupIntervalHours:           12,
-		HealthHistoryDefaultResponseNumber: 1000,
-		FailedLoginRetentionDays:           7,
-		AuthBcryptCost:                     14,
-		AuthSessionTTLMinutes:              60,
-		AuthSessionCookieName:              "test_session",
-		AuthLoginBackoffWindowMinutes:      30,
-		AuthLoginBackoffThreshold:          10,
-		AuthLoginBackoffBaseSeconds:        5,
-		AuthLoginBackoffMaxSeconds:         600,
-		SMTPUser:                           "smtp@test.com",
-		DatabasePath:                       "test/roundtrip.db",
-		MQTTBrokerPort:                     1883,
-		ActuatorCommandTimeoutSeconds:      25,
+		SensorCollectionInterval:      600,
+		SensorDiscoverySkip:           false,
+		OpenAPILocation:               "/api/spec.yaml",
+		HealthHistoryRetentionDays:    90,
+		SensorDataRetentionDays:       180,
+		DataCleanupIntervalHours:      12,
+		FailedLoginRetentionDays:      7,
+		AuthBcryptCost:                14,
+		AuthSessionTTLMinutes:         60,
+		AuthSessionCookieName:         "test_session",
+		AuthLoginBackoffWindowMinutes: 30,
+		AuthLoginBackoffThreshold:     10,
+		AuthLoginBackoffBaseSeconds:   5,
+		AuthLoginBackoffMaxSeconds:    600,
+		SMTPUser:                      "smtp@test.com",
+		DatabasePath:                  "test/roundtrip.db",
+		MQTTBrokerPort:                1883,
+		ActuatorCommandTimeoutSeconds: 25,
 	}
 
 	appProps, smtpProps, dbProps := ConvertConfigurationToMaps(original)
@@ -576,24 +574,23 @@ func TestSaveConfigurationToFiles_Success(t *testing.T) {
 	defer func() { AppConfig = origConfig }()
 
 	AppConfig = &ApplicationConfiguration{
-		SensorCollectionInterval:           120,
-		SensorDiscoverySkip:                false,
-		OpenAPILocation:                    "/test/openapi.yaml",
-		HealthHistoryRetentionDays:         90,
-		SensorDataRetentionDays:            180,
-		DataCleanupIntervalHours:           12,
-		HealthHistoryDefaultResponseNumber: 1000,
-		FailedLoginRetentionDays:           3,
-		AuthBcryptCost:                     10,
-		AuthSessionTTLMinutes:              60,
-		AuthSessionCookieName:              "test_cookie",
-		AuthLoginBackoffWindowMinutes:      10,
-		AuthLoginBackoffThreshold:          3,
-		AuthLoginBackoffBaseSeconds:        1,
-		AuthLoginBackoffMaxSeconds:         60,
-		SMTPUser:                           "test@smtp.com",
-		DatabasePath:                       "test/save.db",
-		ActuatorCommandTimeoutSeconds:      9,
+		SensorCollectionInterval:      120,
+		SensorDiscoverySkip:           false,
+		OpenAPILocation:               "/test/openapi.yaml",
+		HealthHistoryRetentionDays:    90,
+		SensorDataRetentionDays:       180,
+		DataCleanupIntervalHours:      12,
+		FailedLoginRetentionDays:      3,
+		AuthBcryptCost:                10,
+		AuthSessionTTLMinutes:         60,
+		AuthSessionCookieName:         "test_cookie",
+		AuthLoginBackoffWindowMinutes: 10,
+		AuthLoginBackoffThreshold:     3,
+		AuthLoginBackoffBaseSeconds:   1,
+		AuthLoginBackoffMaxSeconds:    60,
+		SMTPUser:                      "test@smtp.com",
+		DatabasePath:                  "test/save.db",
+		ActuatorCommandTimeoutSeconds: 9,
 	}
 
 	err = SaveConfigurationToFiles()
@@ -743,26 +740,25 @@ func TestLoadConfigurationFromMaps_InvalidOAuthTokenRefreshInterval(t *testing.T
 
 func TestConvertConfigurationToMaps_OAuthConfig(t *testing.T) {
 	cfg := &ApplicationConfiguration{
-		SensorCollectionInterval:           300,
-		SensorDiscoverySkip:                true,
-		OpenAPILocation:                    "/path/to/openapi.yaml",
-		HealthHistoryRetentionDays:         180,
-		SensorDataRetentionDays:            365,
-		DataCleanupIntervalHours:           24,
-		HealthHistoryDefaultResponseNumber: 1000,
-		FailedLoginRetentionDays:           2,
-		AuthBcryptCost:                     12,
-		AuthSessionTTLMinutes:              43200,
-		AuthSessionCookieName:              "sensor_hub_session",
-		AuthLoginBackoffWindowMinutes:      15,
-		AuthLoginBackoffThreshold:          5,
-		AuthLoginBackoffBaseSeconds:        2,
-		AuthLoginBackoffMaxSeconds:         300,
-		OAuthCredentialsFilePath:           "/my/creds.json",
-		OAuthTokenFilePath:                 "/my/token.json",
-		OAuthTokenRefreshIntervalMinutes:   60,
-		SMTPUser:                           "user@example.com",
-		DatabasePath:                       "test/oauth.db",
+		SensorCollectionInterval:         300,
+		SensorDiscoverySkip:              true,
+		OpenAPILocation:                  "/path/to/openapi.yaml",
+		HealthHistoryRetentionDays:       180,
+		SensorDataRetentionDays:          365,
+		DataCleanupIntervalHours:         24,
+		FailedLoginRetentionDays:         2,
+		AuthBcryptCost:                   12,
+		AuthSessionTTLMinutes:            43200,
+		AuthSessionCookieName:            "sensor_hub_session",
+		AuthLoginBackoffWindowMinutes:    15,
+		AuthLoginBackoffThreshold:        5,
+		AuthLoginBackoffBaseSeconds:      2,
+		AuthLoginBackoffMaxSeconds:       300,
+		OAuthCredentialsFilePath:         "/my/creds.json",
+		OAuthTokenFilePath:               "/my/token.json",
+		OAuthTokenRefreshIntervalMinutes: 60,
+		SMTPUser:                         "user@example.com",
+		DatabasePath:                     "test/oauth.db",
 	}
 
 	appProps, _, _ := ConvertConfigurationToMaps(cfg)

--- a/sensor_hub/cmd/sensors.go
+++ b/sensor_hub/cmd/sensors.go
@@ -159,16 +159,8 @@ var sensorsHealthCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		params := &gen.GetSensorHealthHistoryByNameParams{}
-		if limit, _ := cmd.Flags().GetInt("limit"); limit > 0 {
-			params.Limit = &limit
-		}
-		return consumeJSON(client.GetSensorHealthHistoryByName(ctx, args[0], params))
+		return consumeJSON(client.GetSensorHealthHistoryByName(ctx, args[0]))
 	},
-}
-
-func init() {
-	sensorsHealthCmd.Flags().Int("limit", 0, "Maximum number of health records to return")
 }
 
 var sensorsStatsCmd = &cobra.Command{

--- a/sensor_hub/configuration/application.properties
+++ b/sensor_hub/configuration/application.properties
@@ -6,7 +6,6 @@ sensor.data.retention.days=365
 failed.login.retention.days=1
 alert.history.retention.days=90
 data.cleanup.interval.hours=24
-health.history.default.response.number=1000
 auth.bcrypt.cost=12
 auth.session.ttl.minutes=43200
 auth.session.cookie.name=sensor_hub_session

--- a/sensor_hub/db/sensor_health_history_migration_test.go
+++ b/sensor_hub/db/sensor_health_history_migration_test.go
@@ -53,7 +53,7 @@ func TestHealthHistoryMigration_RemovesConsecutiveDuplicates(t *testing.T) {
 
 	require.NoError(t, m.Up())
 
-	history, err := repo.GetSensorHealthHistoryById(ctx, sensorID, 10)
+	history, err := repo.GetSensorHealthHistoryById(ctx, sensorID, t1)
 	require.NoError(t, err)
 	require.Len(t, history, 3)
 

--- a/sensor_hub/db/sensor_repository.go
+++ b/sensor_hub/db/sensor_repository.go
@@ -136,9 +136,9 @@ func (s *SensorRepository) DeleteHealthHistoryOlderThan(ctx context.Context, cut
 	return nil
 }
 
-func (s *SensorRepository) GetSensorHealthHistoryById(ctx context.Context, sensorId int, limit int) ([]gen.SensorHealthHistory, error) {
-	query := fmt.Sprintf("SELECT id, sensor_id, health_status, recorded_at FROM %s WHERE sensor_id = ? ORDER BY recorded_at DESC LIMIT ?", TableSensorHealthHistory)
-	rows, err := s.db.QueryContext(ctx, query, sensorId, limit)
+func (s *SensorRepository) GetSensorHealthHistoryById(ctx context.Context, sensorId int, since time.Time) ([]gen.SensorHealthHistory, error) {
+	query := fmt.Sprintf("SELECT id, sensor_id, health_status, recorded_at FROM %s WHERE sensor_id = ? AND datetime(recorded_at) >= datetime(?) ORDER BY recorded_at DESC", TableSensorHealthHistory)
+	rows, err := s.db.QueryContext(ctx, query, sensorId, since.UTC().Format("2006-01-02 15:04:05"))
 	if err != nil {
 		return nil, fmt.Errorf("error querying sensor health history: %w", err)
 	}

--- a/sensor_hub/db/sensor_repository_interface.go
+++ b/sensor_hub/db/sensor_repository_interface.go
@@ -23,7 +23,7 @@ type SensorRepositoryInterface[T any] interface {
 	SensorExistsByExternalId(ctx context.Context, externalId string) (bool, error)
 	UpdateSensorHealthById(ctx context.Context, sensorId int, healthStatus gen.SensorHealthStatus, healthReason string) error
 	UpdateSensorStatus(ctx context.Context, sensorId int, status string) error
-	GetSensorHealthHistoryById(ctx context.Context, sensorId int, limit int) ([]gen.SensorHealthHistory, error)
+	GetSensorHealthHistoryById(ctx context.Context, sensorId int, since time.Time) ([]gen.SensorHealthHistory, error)
 	DeleteHealthHistoryOlderThan(ctx context.Context, cutoffDate time.Time) error
 	GetSensorsWithRetention(ctx context.Context) ([]gen.Sensor, error)
 }

--- a/sensor_hub/db/sensor_repository_test.go
+++ b/sensor_hub/db/sensor_repository_test.go
@@ -640,13 +640,15 @@ func TestSensorRepository_GetSensorHealthHistoryById_Success(t *testing.T) {
 	repo := NewSensorRepository(db, slog.Default())
 
 	now := time.Now()
-	mock.ExpectQuery("SELECT id, sensor_id, health_status, recorded_at FROM sensor_health_history WHERE sensor_id = \\? ORDER BY recorded_at DESC LIMIT \\?").
-		WithArgs(1, 10).
+	since := now.Add(-24 * time.Hour)
+	formattedSince := since.UTC().Format("2006-01-02 15:04:05")
+	mock.ExpectQuery("SELECT id, sensor_id, health_status, recorded_at FROM sensor_health_history WHERE sensor_id = \\? AND datetime\\(recorded_at\\) >= datetime\\(\\?\\) ORDER BY recorded_at DESC").
+		WithArgs(1, formattedSince).
 		WillReturnRows(sqlmock.NewRows(sensorHealthHistoryColumns).
 			AddRow(1, "1", "good", now).
 			AddRow(2, "1", "bad", now.Add(-time.Hour)))
 
-	history, err := repo.GetSensorHealthHistoryById(context.Background(), 1, 10)
+	history, err := repo.GetSensorHealthHistoryById(context.Background(), 1, since)
 
 	assert.NoError(t, err)
 	assert.Len(t, history, 2)
@@ -659,11 +661,13 @@ func TestSensorRepository_GetSensorHealthHistoryById_Empty(t *testing.T) {
 	db, mock := newMockDB(t)
 	repo := NewSensorRepository(db, slog.Default())
 
-	mock.ExpectQuery("SELECT id, sensor_id, health_status, recorded_at FROM sensor_health_history WHERE sensor_id = \\? ORDER BY recorded_at DESC LIMIT \\?").
-		WithArgs(1, 10).
+	since := time.Now().Add(-24 * time.Hour)
+	formattedSince := since.UTC().Format("2006-01-02 15:04:05")
+	mock.ExpectQuery("SELECT id, sensor_id, health_status, recorded_at FROM sensor_health_history WHERE sensor_id = \\? AND datetime\\(recorded_at\\) >= datetime\\(\\?\\) ORDER BY recorded_at DESC").
+		WithArgs(1, formattedSince).
 		WillReturnRows(sqlmock.NewRows(sensorHealthHistoryColumns))
 
-	history, err := repo.GetSensorHealthHistoryById(context.Background(), 1, 10)
+	history, err := repo.GetSensorHealthHistoryById(context.Background(), 1, since)
 
 	assert.NoError(t, err)
 	assert.Empty(t, history)
@@ -674,11 +678,13 @@ func TestSensorRepository_GetSensorHealthHistoryById_DBError(t *testing.T) {
 	db, mock := newMockDB(t)
 	repo := NewSensorRepository(db, slog.Default())
 
-	mock.ExpectQuery("SELECT id, sensor_id, health_status, recorded_at FROM sensor_health_history WHERE sensor_id = \\? ORDER BY recorded_at DESC LIMIT \\?").
-		WithArgs(1, 10).
+	since := time.Now().Add(-24 * time.Hour)
+	formattedSince := since.UTC().Format("2006-01-02 15:04:05")
+	mock.ExpectQuery("SELECT id, sensor_id, health_status, recorded_at FROM sensor_health_history WHERE sensor_id = \\? AND datetime\\(recorded_at\\) >= datetime\\(\\?\\) ORDER BY recorded_at DESC").
+		WithArgs(1, formattedSince).
 		WillReturnError(errors.New("database error"))
 
-	history, err := repo.GetSensorHealthHistoryById(context.Background(), 1, 10)
+	history, err := repo.GetSensorHealthHistoryById(context.Background(), 1, since)
 
 	assert.Error(t, err)
 	assert.Nil(t, history)
@@ -1014,7 +1020,7 @@ func TestSensorRepository_DeleteHealthHistoryOlderThan_PreservesCutoffCheckpoint
 	err = repo.DeleteHealthHistoryOlderThan(ctx, cutoff)
 	require.NoError(t, err)
 
-	history, err := repo.GetSensorHealthHistoryById(ctx, sensorID, 10)
+	history, err := repo.GetSensorHealthHistoryById(ctx, sensorID, cutoff)
 	require.NoError(t, err)
 	require.Len(t, history, 1)
 	assert.Equal(t, gen.Good, history[0].HealthStatus)

--- a/sensor_hub/gen/client.gen.go
+++ b/sensor_hub/gen/client.gen.go
@@ -348,7 +348,7 @@ type ClientInterface interface {
 	EnableSensor(ctx context.Context, sensorName string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetSensorHealthHistoryByName request
-	GetSensorHealthHistoryByName(ctx context.Context, name string, params *GetSensorHealthHistoryByNameParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	GetSensorHealthHistoryByName(ctx context.Context, name string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetTotalReadingsPerSensor request
 	GetTotalReadingsPerSensor(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1500,8 +1500,8 @@ func (c *Client) EnableSensor(ctx context.Context, sensorName string, reqEditors
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetSensorHealthHistoryByName(ctx context.Context, name string, params *GetSensorHealthHistoryByNameParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetSensorHealthHistoryByNameRequest(c.Server, name, params)
+func (c *Client) GetSensorHealthHistoryByName(ctx context.Context, name string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetSensorHealthHistoryByNameRequest(c.Server, name)
 	if err != nil {
 		return nil, err
 	}
@@ -4465,7 +4465,7 @@ func NewEnableSensorRequest(server string, sensorName string) (*http.Request, er
 }
 
 // NewGetSensorHealthHistoryByNameRequest generates requests for GetSensorHealthHistoryByName
-func NewGetSensorHealthHistoryByNameRequest(server string, name string, params *GetSensorHealthHistoryByNameParams) (*http.Request, error) {
+func NewGetSensorHealthHistoryByNameRequest(server string, name string) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -4488,28 +4488,6 @@ func NewGetSensorHealthHistoryByNameRequest(server string, name string, params *
 	queryURL, err := serverURL.Parse(operationPath)
 	if err != nil {
 		return nil, err
-	}
-
-	if params != nil {
-		queryValues := queryURL.Query()
-
-		if params.Limit != nil {
-
-			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "limit", *params.Limit, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "integer", Format: ""}); err != nil {
-				return nil, err
-			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-				return nil, err
-			} else {
-				for k, v := range parsed {
-					for _, v2 := range v {
-						queryValues.Add(k, v2)
-					}
-				}
-			}
-
-		}
-
-		queryURL.RawQuery = queryValues.Encode()
 	}
 
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
@@ -5373,7 +5351,7 @@ type ClientWithResponsesInterface interface {
 	EnableSensorWithResponse(ctx context.Context, sensorName string, reqEditors ...RequestEditorFn) (*EnableSensorResp, error)
 
 	// GetSensorHealthHistoryByNameWithResponse request
-	GetSensorHealthHistoryByNameWithResponse(ctx context.Context, name string, params *GetSensorHealthHistoryByNameParams, reqEditors ...RequestEditorFn) (*GetSensorHealthHistoryByNameResp, error)
+	GetSensorHealthHistoryByNameWithResponse(ctx context.Context, name string, reqEditors ...RequestEditorFn) (*GetSensorHealthHistoryByNameResp, error)
 
 	// GetTotalReadingsPerSensorWithResponse request
 	GetTotalReadingsPerSensorWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetTotalReadingsPerSensorResp, error)
@@ -8322,8 +8300,8 @@ func (c *ClientWithResponses) EnableSensorWithResponse(ctx context.Context, sens
 }
 
 // GetSensorHealthHistoryByNameWithResponse request returning *GetSensorHealthHistoryByNameResp
-func (c *ClientWithResponses) GetSensorHealthHistoryByNameWithResponse(ctx context.Context, name string, params *GetSensorHealthHistoryByNameParams, reqEditors ...RequestEditorFn) (*GetSensorHealthHistoryByNameResp, error) {
-	rsp, err := c.GetSensorHealthHistoryByName(ctx, name, params, reqEditors...)
+func (c *ClientWithResponses) GetSensorHealthHistoryByNameWithResponse(ctx context.Context, name string, reqEditors ...RequestEditorFn) (*GetSensorHealthHistoryByNameResp, error) {
+	rsp, err := c.GetSensorHealthHistoryByName(ctx, name, reqEditors...)
 	if err != nil {
 		return nil, err
 	}

--- a/sensor_hub/gen/server.gen.go
+++ b/sensor_hub/gen/server.gen.go
@@ -237,7 +237,7 @@ type ServerInterface interface {
 	EnableSensor(c *gin.Context, sensorName string)
 	// Get sensor health history
 	// (GET /sensors/health/{name})
-	GetSensorHealthHistoryByName(c *gin.Context, name string, params GetSensorHealthHistoryByNameParams)
+	GetSensorHealthHistoryByName(c *gin.Context, name string)
 	// Get total readings per sensor
 	// (GET /sensors/stats/total-readings)
 	GetTotalReadingsPerSensor(c *gin.Context)
@@ -2225,17 +2225,6 @@ func (siw *ServerInterfaceWrapper) GetSensorHealthHistoryByName(c *gin.Context) 
 
 	c.Set(ApiKeyAuthScopes, []string{})
 
-	// Parameter object where we will unmarshal all parameters from the context
-	var params GetSensorHealthHistoryByNameParams
-
-	// ------------- Optional query parameter "limit" -------------
-
-	err = runtime.BindQueryParameterWithOptions("form", true, false, "limit", c.Request.URL.Query(), &params.Limit, runtime.BindQueryParameterOptions{Type: "integer", Format: ""})
-	if err != nil {
-		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter limit: %w", err), http.StatusBadRequest)
-		return
-	}
-
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
 		if c.IsAborted() {
@@ -2243,7 +2232,7 @@ func (siw *ServerInterfaceWrapper) GetSensorHealthHistoryByName(c *gin.Context) 
 		}
 	}
 
-	siw.Handler.GetSensorHealthHistoryByName(c, name, params)
+	siw.Handler.GetSensorHealthHistoryByName(c, name)
 }
 
 // GetTotalReadingsPerSensor operation middleware

--- a/sensor_hub/gen/types.gen.go
+++ b/sensor_hub/gen/types.gen.go
@@ -1129,12 +1129,6 @@ type AssignPermissionJSONBody struct {
 	PermissionId int `json:"permission_id"`
 }
 
-// GetSensorHealthHistoryByNameParams defines parameters for GetSensorHealthHistoryByName.
-type GetSensorHealthHistoryByNameParams struct {
-	// Limit Max number of history records to return (server default applies if omitted)
-	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
-}
-
 // GetSensorsByStatusParamsStatus defines parameters for GetSensorsByStatus.
 type GetSensorsByStatusParamsStatus string
 

--- a/sensor_hub/mqtt/connection_manager_test.go
+++ b/sensor_hub/mqtt/connection_manager_test.go
@@ -84,8 +84,8 @@ func (m *MockSensorService) ServiceValidateSensorConfig(ctx context.Context, sen
 func (m *MockSensorService) ServiceSetEnabledSensorByName(ctx context.Context, name string, enabled bool) error {
 	return m.Called(ctx, name, enabled).Error(0)
 }
-func (m *MockSensorService) ServiceGetSensorHealthHistoryByName(ctx context.Context, name string, limit int) ([]gen.SensorHealthHistory, error) {
-	args := m.Called(ctx, name, limit)
+func (m *MockSensorService) ServiceGetSensorHealthHistoryByName(ctx context.Context, name string) ([]gen.SensorHealthHistory, error) {
+	args := m.Called(ctx, name)
 	return args.Get(0).([]gen.SensorHealthHistory), args.Error(1)
 }
 func (m *MockSensorService) ServiceGetTotalReadingsForEachSensor(ctx context.Context) (map[string]int, error) {

--- a/sensor_hub/service/properties_service_test.go
+++ b/sensor_hub/service/properties_service_test.go
@@ -21,18 +21,17 @@ func setupPropertiesServiceTestConfig() func() {
 
 	// Set up minimal test config with actual field names
 	appProps.AppConfig = &appProps.ApplicationConfiguration{
-		SensorCollectionInterval:           30,
-		AuthSessionTTLMinutes:              60,
-		AuthBcryptCost:                     4,
-		HealthHistoryRetentionDays:         30,
-		SensorDataRetentionDays:            90,
-		DataCleanupIntervalHours:           24,
-		HealthHistoryDefaultResponseNumber: 1000,
-		FailedLoginRetentionDays:           2,
-		SMTPUser:                           "testuser",
-		DatabasePath:                       "data/sensor_hub.db",
-		MQTTBrokerPort:                     1883,
-		ActuatorCommandTimeoutSeconds:      10,
+		SensorCollectionInterval:      30,
+		AuthSessionTTLMinutes:         60,
+		AuthBcryptCost:                4,
+		HealthHistoryRetentionDays:    30,
+		SensorDataRetentionDays:       90,
+		DataCleanupIntervalHours:      24,
+		FailedLoginRetentionDays:      2,
+		SMTPUser:                      "testuser",
+		DatabasePath:                  "data/sensor_hub.db",
+		MQTTBrokerPort:                1883,
+		ActuatorCommandTimeoutSeconds: 10,
 	}
 
 	return func() {

--- a/sensor_hub/service/sensor_service.go
+++ b/sensor_hub/service/sensor_service.go
@@ -501,13 +501,19 @@ func (s *SensorService) ServiceGetTotalReadingsForEachSensor(ctx context.Context
 	return totalReadings, nil
 }
 
-func (s *SensorService) ServiceGetSensorHealthHistoryByName(ctx context.Context, name string, limit int) ([]gen.SensorHealthHistory, error) {
+func (s *SensorService) ServiceGetSensorHealthHistoryByName(ctx context.Context, name string) ([]gen.SensorHealthHistory, error) {
 	sensorId, err := s.ServiceGetSensorIdByName(ctx, name)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving sensor ID for sensor %s: %w", name, err)
 	}
 
-	history, err := s.sensorRepo.GetSensorHealthHistoryById(ctx, sensorId, limit)
+	retentionDays := 0
+	if appProps.AppConfig != nil {
+		retentionDays = appProps.AppConfig.HealthHistoryRetentionDays
+	}
+	since := time.Now().AddDate(0, 0, -retentionDays)
+
+	history, err := s.sensorRepo.GetSensorHealthHistoryById(ctx, sensorId, since)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving health history for sensor %s: %w", name, err)
 	}

--- a/sensor_hub/service/sensor_service_interface.go
+++ b/sensor_hub/service/sensor_service_interface.go
@@ -26,7 +26,7 @@ type SensorServiceInterface interface {
 	ServiceValidateSensorConfig(ctx context.Context, sensor gen.Sensor) error
 	ServiceUpdateSensorHealthById(ctx context.Context, sensorId int, healthStatus gen.SensorHealthStatus, healthReason string)
 	ServiceSetEnabledSensorByName(ctx context.Context, name string, enabled bool) error
-	ServiceGetSensorHealthHistoryByName(ctx context.Context, name string, limit int) ([]gen.SensorHealthHistory, error)
+	ServiceGetSensorHealthHistoryByName(ctx context.Context, name string) ([]gen.SensorHealthHistory, error)
 	ServiceGetTotalReadingsForEachSensor(ctx context.Context) (map[string]int, error)
 	ServiceGetSensorsByStatus(ctx context.Context, status string) ([]gen.Sensor, error)
 	ServiceApproveSensor(ctx context.Context, sensorId int) error

--- a/sensor_hub/service/sensor_service_test.go
+++ b/sensor_hub/service/sensor_service_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"example/sensorHub/alerting"
+	appProps "example/sensorHub/application_properties"
 	database "example/sensorHub/db"
 	_ "example/sensorHub/drivers" // trigger init() to register drivers
 	gen "example/sensorHub/gen"
@@ -686,17 +687,30 @@ func TestSensorService_ServiceGetTotalReadingsForEachSensor_Error(t *testing.T) 
 
 func TestSensorService_ServiceGetSensorHealthHistoryByName_Success(t *testing.T) {
 	service, sensorRepo, _, _, _ := setupSensorService()
+	originalConfig := appProps.AppConfig
+	appProps.AppConfig = &appProps.ApplicationConfiguration{HealthHistoryRetentionDays: 30}
+	defer func() {
+		appProps.AppConfig = originalConfig
+	}()
 
 	history := []gen.SensorHealthHistory{
 		{SensorId: "1", HealthStatus: gen.Good},
 	}
+	var observedSince time.Time
 	sensorRepo.On("GetSensorIdByName", mock.Anything, "TestSensor").Return(1, nil)
-	sensorRepo.On("GetSensorHealthHistoryById", mock.Anything, 1, 10).Return(history, nil)
+	sensorRepo.On("GetSensorHealthHistoryById", mock.Anything, 1, mock.MatchedBy(func(since time.Time) bool {
+		observedSince = since
+		return true
+	})).Return(history, nil)
 
-	result, err := service.ServiceGetSensorHealthHistoryByName(context.Background(), "TestSensor", 10)
+	before := time.Now()
+	result, err := service.ServiceGetSensorHealthHistoryByName(context.Background(), "TestSensor")
+	after := time.Now()
 
 	assert.NoError(t, err)
 	assert.Len(t, result, 1)
+	assert.False(t, observedSince.Before(before.AddDate(0, 0, -30)))
+	assert.False(t, observedSince.After(after.AddDate(0, 0, -30)))
 }
 
 func TestSensorService_ServiceGetSensorHealthHistoryByName_SensorNotFound(t *testing.T) {
@@ -704,7 +718,7 @@ func TestSensorService_ServiceGetSensorHealthHistoryByName_SensorNotFound(t *tes
 
 	sensorRepo.On("GetSensorIdByName", mock.Anything, "NonExistent").Return(0, errors.New("not found"))
 
-	_, err := service.ServiceGetSensorHealthHistoryByName(context.Background(), "NonExistent", 10)
+	_, err := service.ServiceGetSensorHealthHistoryByName(context.Background(), "NonExistent")
 
 	assert.Error(t, err)
 }

--- a/sensor_hub/service/test_mocks_test.go
+++ b/sensor_hub/service/test_mocks_test.go
@@ -282,8 +282,8 @@ func (m *MockSensorRepository) UpdateSensorHealthById(ctx context.Context, senso
 	return args.Error(0)
 }
 
-func (m *MockSensorRepository) GetSensorHealthHistoryById(ctx context.Context, sensorId int, limit int) ([]gen.SensorHealthHistory, error) {
-	args := m.Called(ctx, sensorId, limit)
+func (m *MockSensorRepository) GetSensorHealthHistoryById(ctx context.Context, sensorId int, since time.Time) ([]gen.SensorHealthHistory, error) {
+	args := m.Called(ctx, sensorId, since)
 	return args.Get(0).([]gen.SensorHealthHistory), args.Error(1)
 }
 

--- a/sensor_hub/skills/claude.md
+++ b/sensor_hub/skills/claude.md
@@ -221,7 +221,7 @@ The `update` command requires a JSON file with the full dashboard structure.
 | `weather-forecast`   | —                                                                                                                          | External weather forecast card               |
 | `sensor-health-pie`  | —                                                                                                                          | Sensor health status pie chart               |
 | `sensor-type-pie`    | —                                                                                                                          | Sensor driver distribution pie chart         |
-| `health-timeline`    | `sensorId` (number)                                                                                                        | Sensor health status history chart           |
+| `health-timeline`    | `sensorId` (number)                                                                                                        | Retained-window health status timeline for a sensor |
 | `reading-stats`      | —                                                                                                                          | Total readings per sensor data grid          |
 | `notifications-feed` | —                                                                                                                          | Recent notifications feed                    |
 | `markdown-note`      | `content` (string)                                                                                                         | User-defined markdown text block             |
@@ -231,7 +231,7 @@ The `update` command requires a JSON file with the full dashboard structure.
 | `comparison-chart`   | `measurementType` (measurement-type), `sensorIds` (number[]), `timeRange` (time-range, default "24h"), `refreshInterval` (number, default 30), `aggregationFunction` (aggregation-function-select, dynamic — shows only functions supported by the selected measurement type; empty = auto) | Multi-sensor overlay line chart        |
 | `group-summary`      | `measurementType` (measurement-type)                                                                                       | Average reading for a measurement type across all sensors |
 | `alert-summary`      | —                                                                                                                          | Compact list of configured alert rules       |
-| `uptime`             | `sensorId` (number)                                                                                                        | Uptime percentage for a sensor               |
+| `uptime`             | `sensorId` (number)                                                                                                        | Time-weighted uptime over the retained health window |
 | `heatmap`            | `sensorId` (number), `measurementType` (measurement-type), `scaleMin` (number, default 10), `scaleMax` (number, default 30) | Colour-coded 30-day heatmap                 |
 | `sensor-detail`      | `sensorId` (number)                                                                                                        | Latest readings grid for a sensor            |
 | `sensor-toggle`      | `sensorId` (controllable binary sensor), `property` (binary capability property, default `state`)                         | Large optimistic on/off switch for a controllable sensor |

--- a/sensor_hub/skills/claude.md
+++ b/sensor_hub/skills/claude.md
@@ -46,7 +46,6 @@ sensor-hub sensors delete "Living Room"              # Delete by name
 sensor-hub sensors enable "Living Room"              # Enable sensor
 sensor-hub sensors disable "Living Room"             # Disable sensor
 sensor-hub sensors health "Living Room"              # Health history
-sensor-hub sensors health "Living Room" --limit 10   # With limit
 sensor-hub sensors stats                             # Total readings per sensor
 sensor-hub sensors collect                           # Collect all
 sensor-hub sensors collect "Living Room"             # Collect specific
@@ -222,7 +221,7 @@ The `update` command requires a JSON file with the full dashboard structure.
 | `weather-forecast`   | —                                                                                                                          | External weather forecast card               |
 | `sensor-health-pie`  | —                                                                                                                          | Sensor health status pie chart               |
 | `sensor-type-pie`    | —                                                                                                                          | Sensor driver distribution pie chart         |
-| `health-timeline`    | `sensorId` (number), `limit` (number, default 1000)                                                                        | Sensor health status history chart           |
+| `health-timeline`    | `sensorId` (number)                                                                                                        | Sensor health status history chart           |
 | `reading-stats`      | —                                                                                                                          | Total readings per sensor data grid          |
 | `notifications-feed` | —                                                                                                                          | Recent notifications feed                    |
 | `markdown-note`      | `content` (string)                                                                                                         | User-defined markdown text block             |
@@ -232,7 +231,7 @@ The `update` command requires a JSON file with the full dashboard structure.
 | `comparison-chart`   | `measurementType` (measurement-type), `sensorIds` (number[]), `timeRange` (time-range, default "24h"), `refreshInterval` (number, default 30), `aggregationFunction` (aggregation-function-select, dynamic — shows only functions supported by the selected measurement type; empty = auto) | Multi-sensor overlay line chart        |
 | `group-summary`      | `measurementType` (measurement-type)                                                                                       | Average reading for a measurement type across all sensors |
 | `alert-summary`      | —                                                                                                                          | Compact list of configured alert rules       |
-| `uptime`             | `sensorId` (number), `limit` (number, default 1000)                                                                        | Uptime percentage for a sensor               |
+| `uptime`             | `sensorId` (number)                                                                                                        | Uptime percentage for a sensor               |
 | `heatmap`            | `sensorId` (number), `measurementType` (measurement-type), `scaleMin` (number, default 10), `scaleMax` (number, default 30) | Colour-coded 30-day heatmap                 |
 | `sensor-detail`      | `sensorId` (number)                                                                                                        | Latest readings grid for a sensor            |
 | `sensor-toggle`      | `sensorId` (controllable binary sensor), `property` (binary capability property, default `state`)                         | Large optimistic on/off switch for a controllable sensor |
@@ -244,7 +243,7 @@ The `update` command requires a JSON file with the full dashboard structure.
 - `timeRange` is a relative time preset: `"5m"`, `"15m"`, `"30m"`, `"1h"`, `"6h"`, `"24h"`, `"3d"`, `"7d"`, `"30d"`, or `"custom"`. When `"custom"`, also set `customStart` and `customEnd` as ISO date strings. Defaults to `"24h"` if omitted.
 - Legacy `startDate` / `endDate` ISO date strings still work for backward compatibility but prefer `timeRange`
 - `refreshInterval` is the polling interval in seconds for chart data updates; defaults to 30 if omitted
-- `limit` controls how many history records to fetch; defaults to 1000 if omitted
+- Health history widgets use the full retained history window configured by `health.history.retention.days`
 - Legacy type `temperature-chart` is an alias for `readings-chart` and still works
 
 #### Example: dashboard with two widgets

--- a/sensor_hub/skills/copilot.md
+++ b/sensor_hub/skills/copilot.md
@@ -221,7 +221,7 @@ The `update` command requires a JSON file with the full dashboard structure.
 | `weather-forecast`   | —                                                                                                                          | External weather forecast card               |
 | `sensor-health-pie`  | —                                                                                                                          | Sensor health status pie chart               |
 | `sensor-type-pie`    | —                                                                                                                          | Sensor driver distribution pie chart         |
-| `health-timeline`    | `sensorId` (number)                                                                                                        | Sensor health status history chart           |
+| `health-timeline`    | `sensorId` (number)                                                                                                        | Retained-window health status timeline for a sensor |
 | `reading-stats`      | —                                                                                                                          | Total readings per sensor data grid          |
 | `notifications-feed` | —                                                                                                                          | Recent notifications feed                    |
 | `markdown-note`      | `content` (string)                                                                                                         | User-defined markdown text block             |
@@ -231,7 +231,7 @@ The `update` command requires a JSON file with the full dashboard structure.
 | `comparison-chart`   | `measurementType` (measurement-type), `sensorIds` (number[]), `timeRange` (time-range, default "24h"), `refreshInterval` (number, default 30), `aggregationFunction` (aggregation-function-select, dynamic — shows only functions supported by the selected measurement type; empty = auto) | Multi-sensor overlay line chart        |
 | `group-summary`      | `measurementType` (measurement-type)                                                                                       | Average reading for a measurement type across all sensors |
 | `alert-summary`      | —                                                                                                                          | Compact list of configured alert rules       |
-| `uptime`             | `sensorId` (number)                                                                                                        | Uptime percentage for a sensor               |
+| `uptime`             | `sensorId` (number)                                                                                                        | Time-weighted uptime over the retained health window |
 | `heatmap`            | `sensorId` (number), `measurementType` (measurement-type), `scaleMin` (number, default 10), `scaleMax` (number, default 30) | Colour-coded 30-day heatmap                 |
 | `sensor-detail`      | `sensorId` (number)                                                                                                        | Latest readings grid for a sensor            |
 | `sensor-toggle`      | `sensorId` (controllable binary sensor), `property` (binary capability property, default `state`)                         | Large optimistic on/off switch for a controllable sensor |

--- a/sensor_hub/skills/copilot.md
+++ b/sensor_hub/skills/copilot.md
@@ -46,7 +46,6 @@ sensor-hub sensors delete "Living Room"              # Delete by name
 sensor-hub sensors enable "Living Room"              # Enable sensor
 sensor-hub sensors disable "Living Room"             # Disable sensor
 sensor-hub sensors health "Living Room"              # Health history
-sensor-hub sensors health "Living Room" --limit 10   # With limit
 sensor-hub sensors stats                             # Total readings per sensor
 sensor-hub sensors collect                           # Collect all
 sensor-hub sensors collect "Living Room"             # Collect specific
@@ -222,7 +221,7 @@ The `update` command requires a JSON file with the full dashboard structure.
 | `weather-forecast`   | —                                                                                                                          | External weather forecast card               |
 | `sensor-health-pie`  | —                                                                                                                          | Sensor health status pie chart               |
 | `sensor-type-pie`    | —                                                                                                                          | Sensor driver distribution pie chart         |
-| `health-timeline`    | `sensorId` (number), `limit` (number, default 1000)                                                                        | Sensor health status history chart           |
+| `health-timeline`    | `sensorId` (number)                                                                                                        | Sensor health status history chart           |
 | `reading-stats`      | —                                                                                                                          | Total readings per sensor data grid          |
 | `notifications-feed` | —                                                                                                                          | Recent notifications feed                    |
 | `markdown-note`      | `content` (string)                                                                                                         | User-defined markdown text block             |
@@ -232,7 +231,7 @@ The `update` command requires a JSON file with the full dashboard structure.
 | `comparison-chart`   | `measurementType` (measurement-type), `sensorIds` (number[]), `timeRange` (time-range, default "24h"), `refreshInterval` (number, default 30), `aggregationFunction` (aggregation-function-select, dynamic — shows only functions supported by the selected measurement type; empty = auto) | Multi-sensor overlay line chart        |
 | `group-summary`      | `measurementType` (measurement-type)                                                                                       | Average reading for a measurement type across all sensors |
 | `alert-summary`      | —                                                                                                                          | Compact list of configured alert rules       |
-| `uptime`             | `sensorId` (number), `limit` (number, default 1000)                                                                        | Uptime percentage for a sensor               |
+| `uptime`             | `sensorId` (number)                                                                                                        | Uptime percentage for a sensor               |
 | `heatmap`            | `sensorId` (number), `measurementType` (measurement-type), `scaleMin` (number, default 10), `scaleMax` (number, default 30) | Colour-coded 30-day heatmap                 |
 | `sensor-detail`      | `sensorId` (number)                                                                                                        | Latest readings grid for a sensor            |
 | `sensor-toggle`      | `sensorId` (controllable binary sensor), `property` (binary capability property, default `state`)                         | Large optimistic on/off switch for a controllable sensor |
@@ -244,7 +243,7 @@ The `update` command requires a JSON file with the full dashboard structure.
 - `timeRange` is a relative time preset: `"5m"`, `"15m"`, `"30m"`, `"1h"`, `"6h"`, `"24h"`, `"3d"`, `"7d"`, `"30d"`, or `"custom"`. When `"custom"`, also set `customStart` and `customEnd` as ISO date strings. Defaults to `"24h"` if omitted.
 - Legacy `startDate` / `endDate` ISO date strings still work for backward compatibility but prefer `timeRange`
 - `refreshInterval` is the polling interval in seconds for chart data updates; defaults to 30 if omitted
-- `limit` controls how many history records to fetch; defaults to 1000 if omitted
+- Health history widgets use the full retained history window configured by `health.history.retention.days`
 - Legacy type `temperature-chart` is an alias for `readings-chart` and still works
 
 #### Example: dashboard with two widgets

--- a/sensor_hub/ui/sensor_hub_ui/src/components/SensorHealthHistory.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/components/SensorHealthHistory.tsx
@@ -4,7 +4,7 @@ import {useEffect, useState} from "react";
 import {DataGrid, type GridColDef} from "@mui/x-data-grid";
 import LayoutCard from "../tools/LayoutCard.tsx";
 import {TypographyH2} from "../tools/Typography.tsx";
-import {Alert, Button, Snackbar, TextField} from "@mui/material";
+import {Alert, Button, Snackbar} from "@mui/material";
 import RefreshIcon from '@mui/icons-material/Refresh';
 import { useIsMobile } from "../hooks/useMobile";
 
@@ -13,9 +13,7 @@ interface SensorHealthHistoryProps {
 }
 
 function SensorHealthHistory({sensor}: SensorHealthHistoryProps) {
-  const [limit, setLimit] = useState(100);
-  const [limitInput, setLimitInput] = useState("100");
-  const [healthHistory, refresh] = useSensorHealthHistory(sensor.name, limit);
+  const [healthHistory, refresh] = useSensorHealthHistory(sensor.name);
   const [isLoading, setIsLoading] = useState(true);
   const [snackbarOpen, setSnackbarOpen] = useState(false);
   const isMobile = useIsMobile();
@@ -76,18 +74,9 @@ function SensorHealthHistory({sensor}: SensorHealthHistoryProps) {
           marginTop: 16,
           gap: 16
         }}>
-          <TextField
-            label="Limit History Entries"
-            type="number"
-            defaultValue={5000}
-            onChange={(e) => setLimitInput(e.target.value)}
-            sx={{ mt: 2, width: isMobile ? "100%" : 200 }}
-            fullWidth={isMobile}
-          />
           <Button
             onClick={() => {
               setIsLoading(true);
-              setLimit(parseInt(limitInput));
               refresh().then(() => {
                 setIsLoading(false);
                 setSnackbarOpen(true);
@@ -100,6 +89,7 @@ function SensorHealthHistory({sensor}: SensorHealthHistoryProps) {
               mt: 2,
               alignSelf: 'center',
               height: "56px",
+              width: isMobile ? "100%" : undefined,
             }}
           >
             Refresh

--- a/sensor_hub/ui/sensor_hub_ui/src/components/SensorHealthHistoryChart.test.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/components/SensorHealthHistoryChart.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Sensor, SensorHealthHistory } from '../gen/aliases';
+import SensorHealthHistoryChart from './SensorHealthHistoryChart';
+
+const { useSensorHealthHistoryMock } = vi.hoisted(() => ({
+  useSensorHealthHistoryMock: vi.fn(),
+}));
+
+const properties: Record<string, string> = {};
+
+vi.mock('../hooks/useSensorHealthHistory.ts', () => ({
+  default: useSensorHealthHistoryMock,
+}));
+
+vi.mock('../hooks/useProperties.ts', () => ({
+  useProperties: () => properties,
+}));
+
+vi.mock('../hooks/useMobile', () => ({
+  useIsMobile: () => false,
+}));
+
+vi.mock('../theme/chartColours', () => ({
+  useChartColours: () => ({
+    grid: '#ccc',
+    health: ['#0f0', '#f00', '#999'],
+  }),
+}));
+
+vi.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AreaChart: ({ data, children }: { data: Array<{ recorded_at: string }>; children: React.ReactNode }) => (
+    <div
+      data-testid="area-chart"
+      data-point-count={String(data.length)}
+      data-last-recorded-at={data[data.length - 1]?.recorded_at ?? ''}
+    >
+      {children}
+    </div>
+  ),
+  CartesianGrid: () => null,
+  Legend: () => null,
+  Line: () => null,
+  Tooltip: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  Area: () => null,
+  ReferenceArea: () => null,
+}));
+
+function makeSensor(overrides: Partial<Sensor> = {}): Sensor {
+  return {
+    id: 1,
+    name: 'hallway',
+    external_id: 'hallway',
+    sensor_driver: 'zigbee2mqtt',
+    config: {},
+    metadata: {},
+    health_status: 'good',
+    health_reason: 'ok',
+    enabled: true,
+    status: 'active',
+    retention_hours: null,
+    ...overrides,
+  };
+}
+
+function makeHistory(overrides: Partial<SensorHealthHistory> = {}): SensorHealthHistory {
+  return {
+    id: 1,
+    sensor_id: '1',
+    health_status: 'good',
+    recorded_at: '2026-05-09T10:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('SensorHealthHistoryChart', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-09T12:00:00Z'));
+    Object.keys(properties).forEach((key) => delete properties[key]);
+    useSensorHealthHistoryMock.mockReset();
+  });
+
+  it('extends the latest health state to now before rendering the step chart', () => {
+    useSensorHealthHistoryMock.mockReturnValue([[makeHistory()], vi.fn()]);
+
+    render(<SensorHealthHistoryChart sensor={makeSensor()} />);
+
+    expect(screen.getByTestId('area-chart')).toHaveAttribute('data-point-count', '2');
+    expect(screen.getByTestId('area-chart')).toHaveAttribute('data-last-recorded-at', '2026-05-09T12:00:00.000Z');
+  });
+
+  it('shows retained-window context and duration summary above the chart', () => {
+    properties['health.history.retention.days'] = '1';
+    useSensorHealthHistoryMock.mockReturnValue([[
+      makeHistory({
+        recorded_at: '2026-05-09T10:00:00Z',
+        health_status: 'good',
+      }),
+      makeHistory({
+        id: 2,
+        recorded_at: '2026-05-09T11:00:00Z',
+        health_status: 'bad',
+      }),
+    ], vi.fn()]);
+
+    render(<SensorHealthHistoryChart sensor={makeSensor()} />);
+
+    expect(screen.getByText('Window 24h')).toBeInTheDocument();
+    expect(screen.getByText('Current bad')).toBeInTheDocument();
+    expect(screen.getByText('Last change 1h ago')).toBeInTheDocument();
+    expect(screen.getByText('Good 1h · Bad 1h · Unknown 22h')).toBeInTheDocument();
+  });
+});

--- a/sensor_hub/ui/sensor_hub_ui/src/components/SensorHealthHistoryChart.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/components/SensorHealthHistoryChart.tsx
@@ -27,14 +27,13 @@ function TransitionDot(props: any) {
 
 interface SensorHealthHistoryChartProps {
   sensor: Sensor,
-  limit?: number,
 }
 
-function SensorHealthHistoryChart({sensor, limit}: SensorHealthHistoryChartProps) {
+function SensorHealthHistoryChart({sensor}: SensorHealthHistoryChartProps) {
   const chartColours = useChartColours();
   const isMobile = useIsMobile();
 
-  const [healthHistoryData] = useSensorHealthHistory(sensor.name, limit ?? 1000);
+  const [healthHistoryData] = useSensorHealthHistory(sensor.name);
 
   const mappedData = useMemo(() => {
     if (!Array.isArray(healthHistoryData)) return [];
@@ -160,4 +159,3 @@ const graphContainerStyle: CSSProperties = {
 
 
 export default SensorHealthHistoryChart;
-

--- a/sensor_hub/ui/sensor_hub_ui/src/components/SensorHealthHistoryChart.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/components/SensorHealthHistoryChart.tsx
@@ -1,5 +1,5 @@
 import useSensorHealthHistory from "../hooks/useSensorHealthHistory.ts";
-import type {Sensor, SensorHealthHistory} from "../gen/aliases";
+import type {Sensor} from "../gen/aliases";
 import {type CSSProperties, useMemo} from "react";
 import {
   CartesianGrid,
@@ -15,6 +15,8 @@ import {
 } from "recharts";
 import { useIsMobile } from "../hooks/useMobile";
 import { useChartColours } from "../theme/chartColours";
+import { buildHealthWindowModel, formatDurationShort, formatWindowLabel } from "../health/healthWindow";
+import { useProperties } from "../hooks/useProperties.ts";
 
 // Custom dot that only renders at transition points for lines with valid values
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -32,17 +34,31 @@ interface SensorHealthHistoryChartProps {
 function SensorHealthHistoryChart({sensor}: SensorHealthHistoryChartProps) {
   const chartColours = useChartColours();
   const isMobile = useIsMobile();
+  const properties = useProperties();
 
   const [healthHistoryData] = useSensorHealthHistory(sensor.name);
 
-  const mappedData = useMemo(() => {
-    if (!Array.isArray(healthHistoryData)) return [];
-
+  const model = useMemo(() => {
+    if (!Array.isArray(healthHistoryData) || healthHistoryData.length === 0) return null;
+    const now = new Date();
     const sortedByRecordedAt = [...healthHistoryData].sort((a, b) => {
       const dateA = new Date(a.recorded_at).getTime();
       const dateB = new Date(b.recorded_at).getTime();
       return dateA - dateB;
     });
+    const configuredRetentionDays = Number.parseInt(properties['health.history.retention.days'] ?? '', 10);
+    const windowStart = Number.isFinite(configuredRetentionDays) && configuredRetentionDays > 0
+      ? new Date(now.getTime() - configuredRetentionDays * 24 * 60 * 60 * 1000)
+      : new Date(sortedByRecordedAt[0].recorded_at);
+
+    return buildHealthWindowModel(sortedByRecordedAt, {
+      windowStart,
+      now,
+    });
+  }, [healthHistoryData, properties]);
+
+  const mappedData = useMemo(() => {
+    if (!model) return [];
 
     const mapStatusToValue = (s: string | undefined | null) => {
       if (!s) return 0;
@@ -53,11 +69,11 @@ function SensorHealthHistoryChart({sensor}: SensorHealthHistoryChartProps) {
       return 0;
     };
 
-    return sortedByRecordedAt.map((h: SensorHealthHistory, index: number) => {
+    return model.points.map((h, index) => {
       const recorded = h.recorded_at;
       const status = h.health_status;
       const value = mapStatusToValue(status);
-      const prevValue = index > 0 ? mapStatusToValue(sortedByRecordedAt[index - 1].health_status) : null;
+      const prevValue = index > 0 ? mapStatusToValue(model.points[index - 1].health_status) : null;
       const isTransition = prevValue === null || prevValue !== value;
       return {
         ...h,
@@ -70,7 +86,7 @@ function SensorHealthHistoryChart({sensor}: SensorHealthHistoryChartProps) {
         unknownVal: value === 0 ? 0 : null,
       };
     });
-  }, [healthHistoryData]);
+  }, [model]);
 
   const valueToLabel = (v: number) => {
     if (v === 2) return "good";
@@ -78,12 +94,28 @@ function SensorHealthHistoryChart({sensor}: SensorHealthHistoryChartProps) {
     return "unknown";
   };
 
+  const lastChangeLabel = useMemo(() => {
+    if (!model?.lastTransitionAt) return null;
+    const elapsedMs = Math.max(0, Date.now() - new Date(model.lastTransitionAt).getTime());
+    return `${formatDurationShort(elapsedMs)} ago`;
+  }, [model]);
+
   return (
     <div data-testid="sensor-health-history-chart" style={graphContainerStyle}>
+      {model && (
+        <div style={summaryStyle}>
+          <span>Window {formatWindowLabel(model.windowDurationMs)}</span>
+          <span>Current {model.currentStatus}</span>
+          {lastChangeLabel && <span>Last change {lastChangeLabel}</span>}
+          <span>
+            Good {formatDurationShort(model.durationsMs.good)} · Bad {formatDurationShort(model.durationsMs.bad)} · Unknown {formatDurationShort(model.durationsMs.unknown)}
+          </span>
+        </div>
+      )}
       {!Array.isArray(mappedData) || mappedData.length === 0 ? (
         <></>
       ) : (
-        <div style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }}>
+        <div style={chartAreaStyle}>
           <ResponsiveContainer width="100%" height="100%">
             <AreaChart data={mappedData} >
               <CartesianGrid stroke={chartColours.grid} strokeDasharray="3 3" />
@@ -151,6 +183,23 @@ function SensorHealthHistoryChart({sensor}: SensorHealthHistoryChartProps) {
 }
 
 const graphContainerStyle: CSSProperties = {
+  width: "100%",
+  flex: 1,
+  minHeight: 0,
+  display: "flex",
+  flexDirection: "column",
+  gap: 8,
+};
+
+const summaryStyle: CSSProperties = {
+  display: "flex",
+  flexWrap: "wrap",
+  gap: 12,
+  fontSize: 12,
+  color: "var(--mui-palette-text-secondary, rgba(0, 0, 0, 0.6))",
+};
+
+const chartAreaStyle: CSSProperties = {
   width: "100%",
   flex: 1,
   minHeight: 0,

--- a/sensor_hub/ui/sensor_hub_ui/src/components/SensorHealthHistoryChartCard.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/components/SensorHealthHistoryChartCard.tsx
@@ -1,9 +1,5 @@
-import { useState, type CSSProperties } from 'react';
-import {
-  Box, Dialog, DialogTitle, DialogContent, DialogActions,
-  Button, TextField, IconButton,
-} from '@mui/material';
-import SettingsIcon from '@mui/icons-material/Settings';
+import { type CSSProperties } from 'react';
+import { Box } from '@mui/material';
 import LayoutCard from '../tools/LayoutCard';
 import { TypographyH2 } from '../tools/Typography';
 import SensorHealthHistoryChart from './SensorHealthHistoryChart';
@@ -21,48 +17,12 @@ interface SensorHealthHistoryChartCardProps {
 }
 
 export default function SensorHealthHistoryChartCard({ sensor }: SensorHealthHistoryChartCardProps) {
-  const [limit, setLimit] = useState(1000);
-  const [settingsOpen, setSettingsOpen] = useState(false);
-  const [draftLimit, setDraftLimit] = useState('1000');
-
-  const handleOpen = () => {
-    setDraftLimit(limit.toString());
-    setSettingsOpen(true);
-  };
-
-  const handleSave = () => {
-    const parsed = parseInt(draftLimit);
-    setLimit(Number.isFinite(parsed) && parsed > 0 ? parsed : 1000);
-    setSettingsOpen(false);
-  };
-
   return (
     <LayoutCard variant="secondary" changes={graphContainerStyle}>
       <Box display="flex" alignItems="center" justifyContent="space-between" width="100%">
         <TypographyH2>Sensor Health History</TypographyH2>
-        <IconButton onClick={handleOpen} size="small" title="Settings">
-          <SettingsIcon />
-        </IconButton>
       </Box>
-      <SensorHealthHistoryChart sensor={sensor} limit={limit} />
-
-      <Dialog open={settingsOpen} onClose={() => setSettingsOpen(false)} maxWidth="xs" fullWidth>
-        <DialogTitle>Health Timeline Settings</DialogTitle>
-        <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-          <TextField
-            label="History Limit"
-            type="number"
-            fullWidth
-            sx={{ mt: 1 }}
-            value={draftLimit}
-            onChange={(e) => setDraftLimit(e.target.value)}
-          />
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setSettingsOpen(false)}>Cancel</Button>
-          <Button variant="contained" onClick={handleSave}>Apply</Button>
-        </DialogActions>
-      </Dialog>
+      <SensorHealthHistoryChart sensor={sensor} />
     </LayoutCard>
   );
 }

--- a/sensor_hub/ui/sensor_hub_ui/src/components/SensorHealthHistoryControls.test.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/components/SensorHealthHistoryControls.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Sensor } from '../gen/aliases';
+import SensorHealthHistory from './SensorHealthHistory';
+import SensorHealthHistoryChartCard from './SensorHealthHistoryChartCard';
+
+const { refreshMock, useSensorHealthHistoryMock } = vi.hoisted(() => ({
+  refreshMock: vi.fn(),
+  useSensorHealthHistoryMock: vi.fn(),
+}));
+
+vi.mock('../hooks/useSensorHealthHistory.ts', () => ({
+  default: useSensorHealthHistoryMock,
+}));
+
+vi.mock('../hooks/useMobile', () => ({
+  useIsMobile: () => false,
+}));
+
+vi.mock('@mui/x-data-grid', () => ({
+  DataGrid: () => <div data-testid="data-grid" />,
+}));
+
+vi.mock('./SensorHealthHistoryChart', () => ({
+  default: () => <div data-testid="sensor-health-history-chart" />,
+}));
+
+function makeSensor(overrides: Partial<Sensor> = {}): Sensor {
+  return {
+    id: 1,
+    name: 'garage-door',
+    external_id: 'garage-door',
+    sensor_driver: 'zigbee2mqtt',
+    config: {},
+    metadata: {},
+    health_status: 'good',
+    health_reason: 'ok',
+    enabled: true,
+    status: 'active',
+    retention_hours: null,
+    ...overrides,
+  };
+}
+
+describe('sensor health history controls', () => {
+  beforeEach(() => {
+    refreshMock.mockReset();
+    useSensorHealthHistoryMock.mockReset();
+    useSensorHealthHistoryMock.mockReturnValue([[], refreshMock]);
+  });
+
+  it('does not render a limit input on the sensor health history table card', () => {
+    render(<SensorHealthHistory sensor={makeSensor()} />);
+
+    expect(screen.getByRole('button', { name: 'Refresh' })).toBeInTheDocument();
+    expect(screen.queryByLabelText('Limit History Entries')).not.toBeInTheDocument();
+    expect(screen.queryByText('Limit History Entries')).not.toBeInTheDocument();
+  });
+
+  it('does not render settings for history limits on the chart card', () => {
+    render(<SensorHealthHistoryChartCard sensor={makeSensor()} />);
+
+    expect(screen.getByText('Sensor Health History')).toBeInTheDocument();
+    expect(screen.queryByTitle('Settings')).not.toBeInTheDocument();
+    expect(screen.queryByText('Health Timeline Settings')).not.toBeInTheDocument();
+  });
+});

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/healthHistoryConfig.test.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/healthHistoryConfig.test.ts
@@ -1,0 +1,17 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { getWidget } from './WidgetRegistry';
+import { registerAllWidgets } from './widgets';
+
+beforeAll(() => {
+  registerAllWidgets();
+});
+
+describe('health history widget configuration', () => {
+  it('keeps the health timeline widget focused on sensor selection only', () => {
+    expect(getWidget('health-timeline')?.configFields?.map((field) => field.key)).toEqual(['sensorId']);
+  });
+
+  it('keeps the uptime widget focused on sensor selection only', () => {
+    expect(getWidget('uptime')?.configFields?.map((field) => field.key)).toEqual(['sensorId']);
+  });
+});

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/HealthTimelineWidget.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/HealthTimelineWidget.tsx
@@ -10,7 +10,6 @@ export default function HealthTimelineWidget({ config }: WidgetProps) {
     const reportUpdate = useReportWidgetUpdate();
     const sensorId = config.sensorId as number | undefined;
     const sensor = sensorId ? sensors.find((s) => s.id === sensorId) : sensors[0];
-    const limit = typeof config.limit === 'number' && config.limit > 0 ? config.limit : 1000;
 
     useEffect(() => { reportUpdate(new Date()); }, [reportUpdate]);
 
@@ -18,5 +17,5 @@ export default function HealthTimelineWidget({ config }: WidgetProps) {
         return <Typography color="text.secondary" sx={{ p: 2 }}>Select a sensor in widget settings</Typography>;
     }
 
-    return <SensorHealthHistoryChart sensor={sensor} limit={limit} />;
+    return <SensorHealthHistoryChart sensor={sensor} />;
 }

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/UptimeWidget.test.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/UptimeWidget.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Sensor, SensorHealthHistory } from '../../gen/aliases';
+import UptimeWidget from './UptimeWidget';
+
+const { reportUpdateMock, useSensorHealthHistoryMock } = vi.hoisted(() => ({
+  reportUpdateMock: vi.fn(),
+  useSensorHealthHistoryMock: vi.fn(),
+}));
+
+const sensors: Sensor[] = [];
+const properties: Record<string, string> = {};
+
+vi.mock('../../hooks/useSensorContext', () => ({
+  useSensorContext: () => ({
+    sensors,
+  }),
+}));
+
+vi.mock('../../hooks/useSensorHealthHistory', () => ({
+  default: useSensorHealthHistoryMock,
+}));
+
+vi.mock('../../hooks/useProperties', () => ({
+  useProperties: () => properties,
+}));
+
+vi.mock('../WidgetUpdateContext', () => ({
+  useReportWidgetUpdate: () => reportUpdateMock,
+}));
+
+function makeSensor(overrides: Partial<Sensor> = {}): Sensor {
+  return {
+    id: 7,
+    name: 'boiler',
+    external_id: 'boiler',
+    sensor_driver: 'zigbee2mqtt',
+    config: {},
+    metadata: {},
+    health_status: 'good',
+    health_reason: 'ok',
+    enabled: true,
+    status: 'active',
+    retention_hours: null,
+    ...overrides,
+  };
+}
+
+function makeHistory(overrides: Partial<SensorHealthHistory> = {}): SensorHealthHistory {
+  return {
+    id: 1,
+    sensor_id: '7',
+    health_status: 'good',
+    recorded_at: '2026-05-09T10:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('UptimeWidget', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-09T13:00:00Z'));
+    sensors.splice(0, sensors.length, makeSensor());
+    Object.keys(properties).forEach((key) => delete properties[key]);
+    reportUpdateMock.mockReset();
+    useSensorHealthHistoryMock.mockReset();
+  });
+
+  it('shows a time-weighted uptime percentage instead of transition-count uptime', () => {
+    useSensorHealthHistoryMock.mockReturnValue([[
+      makeHistory({
+        recorded_at: '2026-05-09T10:00:00Z',
+        health_status: 'good',
+      }),
+      makeHistory({
+        id: 2,
+        recorded_at: '2026-05-09T11:00:00Z',
+        health_status: 'bad',
+      }),
+    ], vi.fn()]);
+
+    render(<UptimeWidget id="widget-1" isEditing={false} config={{ sensorId: 7 }} />);
+
+    expect(screen.getByText('33.3%')).toBeInTheDocument();
+  });
+
+  it('uses the retained window and shows the good/bad/unknown time breakdown when available', () => {
+    properties['health.history.retention.days'] = '1';
+    useSensorHealthHistoryMock.mockReturnValue([[
+      makeHistory({
+        recorded_at: '2026-05-09T10:00:00Z',
+        health_status: 'good',
+      }),
+      makeHistory({
+        id: 2,
+        recorded_at: '2026-05-09T11:00:00Z',
+        health_status: 'bad',
+      }),
+    ], vi.fn()]);
+
+    render(<UptimeWidget id="widget-1" isEditing={false} config={{ sensorId: 7 }} />);
+
+    expect(screen.getByText('4.2%')).toBeInTheDocument();
+    expect(screen.getByText('Good for 1h of last 24h')).toBeInTheDocument();
+    expect(screen.getByText('Bad 2h · Unknown 21h')).toBeInTheDocument();
+  });
+});

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/UptimeWidget.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/UptimeWidget.tsx
@@ -1,13 +1,16 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import type { WidgetProps } from '../types';
 import { Box, LinearProgress, Typography } from '@mui/material';
 import { useSensorContext } from '../../hooks/useSensorContext';
 import useSensorHealthHistory from '../../hooks/useSensorHealthHistory';
 import { useReportWidgetUpdate } from '../WidgetUpdateContext';
+import { buildHealthWindowModel, formatDurationShort, formatWindowLabel } from '../../health/healthWindow';
+import { useProperties } from '../../hooks/useProperties';
 
 export default function UptimeWidget({ config }: WidgetProps) {
     const { sensors } = useSensorContext();
     const reportUpdate = useReportWidgetUpdate();
+    const properties = useProperties();
     const sensorId = config.sensorId as number | undefined;
     const sensor = sensorId ? sensors.find((s) => s.id === sensorId) : undefined;
     const sensorName = sensor?.name ?? '';
@@ -18,6 +21,29 @@ export default function UptimeWidget({ config }: WidgetProps) {
         if (history.length > 0) reportUpdate(new Date());
     }, [history, reportUpdate]);
 
+    const model = useMemo(() => {
+        if (history.length === 0) return null;
+        const now = new Date();
+        const configuredRetentionDays = Number.parseInt(properties['health.history.retention.days'] ?? '', 10);
+        const windowStart = Number.isFinite(configuredRetentionDays) && configuredRetentionDays > 0
+            ? new Date(now.getTime() - configuredRetentionDays * 24 * 60 * 60 * 1000)
+            : new Date(history.reduce((earliest, entry) => {
+                return new Date(entry.recorded_at).getTime() < new Date(earliest).getTime() ? entry.recorded_at : earliest;
+            }, history[0].recorded_at));
+        return buildHealthWindowModel(history, {
+            windowStart,
+            now,
+        });
+    }, [history, properties]);
+
+    const uptime = model ? model.goodRatio * 100 : 0;
+
+    const getColor = (pct: number): 'success' | 'warning' | 'error' => {
+        if (pct > 90) return 'success';
+        if (pct >= 70) return 'warning';
+        return 'error';
+    };
+
     if (!sensor) {
         return (
             <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}>
@@ -26,20 +52,10 @@ export default function UptimeWidget({ config }: WidgetProps) {
         );
     }
 
-    const total = history.length;
-    const good = history.filter((h) => h.health_status === 'good').length;
-    const uptime = total > 0 ? (good / total) * 100 : 0;
-
-    const getColor = (pct: number): 'success' | 'warning' | 'error' => {
-        if (pct > 90) return 'success';
-        if (pct >= 70) return 'warning';
-        return 'error';
-    };
-
     return (
         <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', height: '100%', p: 2, gap: 2 }}>
             <Typography variant="h3" sx={{ fontWeight: 'bold' }}>
-                {total > 0 ? `${uptime.toFixed(1)}%` : '—'}
+                {model ? `${uptime.toFixed(1)}%` : '—'}
             </Typography>
             <Box sx={{ width: '80%' }}>
                 <LinearProgress
@@ -49,6 +65,16 @@ export default function UptimeWidget({ config }: WidgetProps) {
                     sx={{ height: 10, borderRadius: 5 }}
                 />
             </Box>
+            {model && (
+                <>
+                    <Typography variant="body2" color="text.secondary" align="center">
+                        Good for {formatDurationShort(model.durationsMs.good)} of last {formatWindowLabel(model.windowDurationMs)}
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary" align="center">
+                        Bad {formatDurationShort(model.durationsMs.bad)} · Unknown {formatDurationShort(model.durationsMs.unknown)}
+                    </Typography>
+                </>
+            )}
             <Typography variant="subtitle2" color="text.secondary">{sensor.name}</Typography>
         </Box>
     );

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/UptimeWidget.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/UptimeWidget.tsx
@@ -11,9 +11,8 @@ export default function UptimeWidget({ config }: WidgetProps) {
     const sensorId = config.sensorId as number | undefined;
     const sensor = sensorId ? sensors.find((s) => s.id === sensorId) : undefined;
     const sensorName = sensor?.name ?? '';
-    const limit = typeof config.limit === 'number' && config.limit > 0 ? config.limit : 1000;
 
-    const [history] = useSensorHealthHistory(sensorName, limit);
+    const [history] = useSensorHealthHistory(sensorName);
 
     useEffect(() => {
         if (history.length > 0) reportUpdate(new Date());

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/index.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/index.ts
@@ -93,7 +93,6 @@ export function registerAllWidgets(): void {
         minH: 3,
         configFields: [
             { key: 'sensorId', label: 'Sensor', type: 'sensor-select' },
-            { key: 'limit', label: 'History Limit', type: 'number', defaultValue: 1000 },
         ],
     });
 
@@ -235,7 +234,6 @@ export function registerAllWidgets(): void {
         minH: 2,
         configFields: [
             { key: 'sensorId', label: 'Sensor', type: 'sensor-select' },
-            { key: 'limit', label: 'History Limit', type: 'number', defaultValue: 1000 },
         ],
     });
 

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/index.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/index.ts
@@ -85,7 +85,7 @@ export function registerAllWidgets(): void {
     registerWidget({
         type: 'health-timeline',
         label: 'Health Timeline',
-        description: 'Sensor health status history chart',
+        description: 'Retained-window health status timeline for a sensor',
         component: HealthTimelineWidget,
         defaultConfig: {},
         defaultLayout: { w: 6, h: 4 },
@@ -226,7 +226,7 @@ export function registerAllWidgets(): void {
     registerWidget({
         type: 'uptime',
         label: 'Sensor Uptime',
-        description: 'Uptime percentage for a sensor',
+        description: 'Time-weighted uptime over the retained health window',
         component: UptimeWidget,
         defaultConfig: {},
         defaultLayout: { w: 3, h: 3 },

--- a/sensor_hub/ui/sensor_hub_ui/src/gen/schema.d.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/gen/schema.d.ts
@@ -307,7 +307,7 @@ export interface paths {
         };
         /**
          * Get sensor health history
-         * @description Return historical health checks for a sensor. A `limit` query parameter may be provided to restrict the number of returned records (default is defined by the server configuration).
+         * @description Return all retained historical health checks for a sensor within the configured retention window.
          */
         get: operations["getSensorHealthHistoryByName"];
         put?: never;
@@ -3040,10 +3040,7 @@ export interface operations {
     };
     getSensorHealthHistoryByName: {
         parameters: {
-            query?: {
-                /** @description Max number of history records to return (server default applies if omitted) */
-                limit?: number;
-            };
+            query?: never;
             header?: never;
             path: {
                 name: string;

--- a/sensor_hub/ui/sensor_hub_ui/src/health/healthWindow.test.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/health/healthWindow.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import type { SensorHealthHistory } from '../gen/aliases';
+import { buildHealthWindowModel } from './healthWindow';
+
+function makeHistory(overrides: Partial<SensorHealthHistory> = {}): SensorHealthHistory {
+  return {
+    id: 1,
+    sensor_id: 'sensor-1',
+    health_status: 'good',
+    recorded_at: '2026-05-09T10:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('buildHealthWindowModel', () => {
+  it('extends the latest known health state to now for timeline rendering', () => {
+    const model = buildHealthWindowModel(
+      [
+        makeHistory({
+          recorded_at: '2026-05-09T10:00:00Z',
+          health_status: 'good',
+        }),
+      ],
+      {
+        windowStart: new Date('2026-05-09T10:00:00Z'),
+        now: new Date('2026-05-09T12:00:00Z'),
+      },
+    );
+
+    expect(model.points).toHaveLength(2);
+    expect(model.points[0]).toMatchObject({
+      recorded_at: '2026-05-09T10:00:00Z',
+      health_status: 'good',
+      synthetic: false,
+    });
+    expect(model.points[1]).toMatchObject({
+      recorded_at: '2026-05-09T12:00:00.000Z',
+      health_status: 'good',
+      synthetic: true,
+    });
+  });
+
+  it('computes time-weighted status durations across the retained window', () => {
+    const model = buildHealthWindowModel(
+      [
+        makeHistory({
+          recorded_at: '2026-05-09T10:00:00Z',
+          health_status: 'good',
+        }),
+        makeHistory({
+          id: 2,
+          recorded_at: '2026-05-09T11:00:00Z',
+          health_status: 'bad',
+        }),
+      ],
+      {
+        windowStart: new Date('2026-05-09T10:00:00Z'),
+        now: new Date('2026-05-09T13:00:00Z'),
+      },
+    );
+
+    expect(model.currentStatus).toBe('bad');
+    expect(model.lastTransitionAt).toBe('2026-05-09T11:00:00Z');
+    expect(model.durationsMs).toEqual({
+      good: 60 * 60 * 1000,
+      bad: 2 * 60 * 60 * 1000,
+      unknown: 0,
+    });
+    expect(model.windowDurationMs).toBe(3 * 60 * 60 * 1000);
+    expect(model.goodRatio).toBeCloseTo(1 / 3);
+  });
+
+  it('treats the retained-window gap before the first record as unknown time', () => {
+    const model = buildHealthWindowModel(
+      [
+        makeHistory({
+          recorded_at: '2026-05-09T10:00:00Z',
+          health_status: 'good',
+        }),
+      ],
+      {
+        windowStart: new Date('2026-05-09T09:00:00Z'),
+        now: new Date('2026-05-09T13:00:00Z'),
+      },
+    );
+
+    expect(model.points[0]).toMatchObject({
+      recorded_at: '2026-05-09T09:00:00.000Z',
+      health_status: 'unknown',
+      synthetic: true,
+    });
+    expect(model.durationsMs).toEqual({
+      good: 3 * 60 * 60 * 1000,
+      bad: 0,
+      unknown: 60 * 60 * 1000,
+    });
+    expect(model.windowDurationMs).toBe(4 * 60 * 60 * 1000);
+    expect(model.goodRatio).toBeCloseTo(0.75);
+  });
+});

--- a/sensor_hub/ui/sensor_hub_ui/src/health/healthWindow.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/health/healthWindow.ts
@@ -1,0 +1,102 @@
+import type { SensorHealthHistory, SensorHealthStatus } from '../gen/aliases';
+
+export interface HealthWindowPoint {
+  recorded_at: string;
+  health_status: SensorHealthStatus;
+  synthetic: boolean;
+}
+
+export interface HealthWindowModel {
+  points: HealthWindowPoint[];
+  currentStatus: SensorHealthStatus | null;
+  lastTransitionAt: string | null;
+  durationsMs: Record<SensorHealthStatus, number>;
+  windowDurationMs: number;
+  goodRatio: number;
+}
+
+export function formatDurationShort(durationMs: number): string {
+  const totalMinutes = Math.max(0, Math.round(durationMs / (60 * 1000)));
+  const totalHours = Math.floor(totalMinutes / 60);
+  const days = Math.floor(totalHours / 24);
+  const hours = totalHours % 24;
+  const minutes = totalMinutes % 60;
+
+  if (days > 0) return hours > 0 ? `${days}d ${hours}h` : `${days}d`;
+  if (totalHours > 0) return minutes > 0 ? `${totalHours}h ${minutes}m` : `${totalHours}h`;
+  return `${Math.max(1, totalMinutes)}m`;
+}
+
+export function formatWindowLabel(windowDurationMs: number): string {
+  const totalHours = Math.round(windowDurationMs / (60 * 60 * 1000));
+  if (totalHours % 24 === 0) {
+    const days = totalHours / 24;
+    return days === 1 ? '24h' : `${days}d`;
+  }
+  return formatDurationShort(windowDurationMs);
+}
+
+interface BuildHealthWindowModelOptions {
+  windowStart: Date;
+  now: Date;
+}
+
+export function buildHealthWindowModel(
+  history: SensorHealthHistory[],
+  options: BuildHealthWindowModelOptions,
+): HealthWindowModel {
+  const points = [...history]
+    .sort((left, right) => new Date(left.recorded_at).getTime() - new Date(right.recorded_at).getTime())
+    .map((entry) => ({
+      recorded_at: entry.recorded_at,
+      health_status: entry.health_status,
+      synthetic: false,
+    }));
+
+  if (points.length === 0) {
+    return {
+      points: [],
+      currentStatus: null,
+      lastTransitionAt: null,
+      durationsMs: { good: 0, bad: 0, unknown: 0 },
+      windowDurationMs: Math.max(0, options.now.getTime() - options.windowStart.getTime()),
+      goodRatio: 0,
+    };
+  }
+
+  if (new Date(points[0].recorded_at).getTime() > options.windowStart.getTime()) {
+    points.unshift({
+      recorded_at: options.windowStart.toISOString(),
+      health_status: 'unknown',
+      synthetic: true,
+    });
+  }
+
+  const lastPoint = points[points.length - 1];
+  if (new Date(lastPoint.recorded_at).getTime() < options.now.getTime()) {
+    points.push({
+      recorded_at: options.now.toISOString(),
+      health_status: lastPoint.health_status,
+      synthetic: true,
+    });
+  }
+
+  const durationsMs: Record<SensorHealthStatus, number> = { good: 0, bad: 0, unknown: 0 };
+  for (let i = 0; i < points.length - 1; i += 1) {
+    const current = points[i];
+    const next = points[i + 1];
+    const segmentDuration = Math.max(0, new Date(next.recorded_at).getTime() - new Date(current.recorded_at).getTime());
+    durationsMs[current.health_status] += segmentDuration;
+  }
+
+  const windowDurationMs = Math.max(0, options.now.getTime() - options.windowStart.getTime());
+
+  return {
+    points,
+    currentStatus: points[points.length - 1]?.health_status ?? null,
+    lastTransitionAt: points.length > 1 ? points[points.length - 2].recorded_at : points[0].recorded_at,
+    durationsMs,
+    windowDurationMs,
+    goodRatio: windowDurationMs > 0 ? durationsMs.good / windowDurationMs : 0,
+  };
+}

--- a/sensor_hub/ui/sensor_hub_ui/src/hooks/useSensorHealthHistory.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/hooks/useSensorHealthHistory.ts
@@ -4,23 +4,19 @@ import { apiClient } from "../gen/client";
 import { useAuth } from '../providers/AuthContext.tsx';
 import { logger } from '../tools/logger';
 
-function useSensorHealthHistory(sensorName: string, limit?: number): [SensorHealthHistory[], () => Promise<void>] {
+function useSensorHealthHistory(sensorName: string): [SensorHealthHistory[], () => Promise<void>] {
   const [healthHistory, setHealthHistory] = useState<SensorHealthHistory[]>([]);
-
-  if (!limit) {
-    limit = 5000;
-  }
 
   const fetchHistory = useCallback(async () => {
     try {
       const { data } = await apiClient.GET('/sensors/health/{name}', {
-        params: { path: { name: sensorName }, query: limit ? { limit } : undefined },
+        params: { path: { name: sensorName } },
       });
       setHealthHistory(data ?? []);
     } catch (err) {
       logger.error("Failed to load sensor health history", err);
     }
-  }, [sensorName, limit]);
+  }, [sensorName]);
 
   const { user } = useAuth();
 


### PR DESCRIPTION
## Summary\n- remove the health-history limit contract from the backend API, CLI, config, and generated artifacts\n- update the sensor page plus Health Timeline and Uptime widgets to always use the retained history window\n- refresh tests and docs for the new retention-window behavior\n\nCloses #144\nRefs #22