### PR TITLE
Fix steady-state health history recovery

### DIFF
--- a/sensor_hub/api/sensor_api_test.go
+++ b/sensor_hub/api/sensor_api_test.go
@@ -418,6 +418,11 @@ func TestGetSensorHealthHistoryByNameHandler(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
+	var history []gen.SensorHealthHistory
+	err := json.Unmarshal(w.Body.Bytes(), &history)
+	assert.NoError(t, err)
+	assert.NotNil(t, history)
+	assert.Empty(t, history)
 }
 
 func TestAddSensorHandler_InvalidJSON(t *testing.T) {

--- a/sensor_hub/db/sensor_repository.go
+++ b/sensor_hub/db/sensor_repository.go
@@ -154,8 +154,29 @@ func (s *SensorRepository) DeleteHealthHistoryOlderThan(ctx context.Context, cut
 }
 
 func (s *SensorRepository) GetSensorHealthHistoryById(ctx context.Context, sensorId int, since time.Time) ([]gen.SensorHealthHistory, error) {
-	query := fmt.Sprintf("SELECT id, sensor_id, health_status, recorded_at FROM %s WHERE sensor_id = ? AND datetime(recorded_at) >= datetime(?) ORDER BY recorded_at DESC", TableSensorHealthHistory)
-	rows, err := s.db.QueryContext(ctx, query, sensorId, since.UTC().Format("2006-01-02 15:04:05"))
+	query := fmt.Sprintf(`
+		WITH latest_before AS (
+			SELECT id, sensor_id, health_status, recorded_at
+			FROM %s
+			WHERE sensor_id = ? AND datetime(recorded_at) < datetime(?)
+			ORDER BY datetime(recorded_at) DESC, id DESC
+			LIMIT 1
+		),
+		within_window AS (
+			SELECT id, sensor_id, health_status, recorded_at
+			FROM %s
+			WHERE sensor_id = ? AND datetime(recorded_at) >= datetime(?)
+		)
+		SELECT id, sensor_id, health_status, recorded_at
+		FROM (
+			SELECT id, sensor_id, health_status, recorded_at FROM within_window
+			UNION ALL
+			SELECT id, sensor_id, health_status, recorded_at FROM latest_before
+		)
+		ORDER BY datetime(recorded_at) DESC, id DESC
+	`, TableSensorHealthHistory, TableSensorHealthHistory)
+	formattedSince := since.UTC().Format("2006-01-02 15:04:05")
+	rows, err := s.db.QueryContext(ctx, query, sensorId, formattedSince, sensorId, formattedSince)
 	if err != nil {
 		return nil, fmt.Errorf("error querying sensor health history: %w", err)
 	}

--- a/sensor_hub/db/sensor_repository.go
+++ b/sensor_hub/db/sensor_repository.go
@@ -123,6 +123,23 @@ func (s *SensorRepository) DeleteHealthHistoryOlderThan(ctx context.Context, cut
 		return fmt.Errorf("error inserting retained health history checkpoints: %w", err)
 	}
 
+	insertCurrentStateQuery := fmt.Sprintf(`
+		INSERT INTO %s (sensor_id, health_status, recorded_at)
+		SELECT s.id, s.health_status, ?
+		FROM sensors s
+		WHERE s.health_status IS NOT NULL
+		  AND NOT EXISTS (
+			SELECT 1
+			FROM %s h
+			WHERE h.sensor_id = s.id
+			  AND datetime(h.recorded_at) >= datetime(?)
+		  )
+	`, TableSensorHealthHistory, TableSensorHealthHistory)
+	if _, err := tx.ExecContext(ctx, insertCurrentStateQuery, cutoff, cutoff); err != nil {
+		tx.Rollback()
+		return fmt.Errorf("error backfilling retained health history checkpoints: %w", err)
+	}
+
 	deleteQuery := fmt.Sprintf("DELETE FROM %s WHERE datetime(recorded_at) < datetime(?)", TableSensorHealthHistory)
 	if _, err := tx.ExecContext(ctx, deleteQuery, cutoff); err != nil {
 		tx.Rollback()
@@ -144,7 +161,7 @@ func (s *SensorRepository) GetSensorHealthHistoryById(ctx context.Context, senso
 	}
 	defer rows.Close()
 
-	var history []gen.SensorHealthHistory
+	history := make([]gen.SensorHealthHistory, 0)
 	for rows.Next() {
 		var record gen.SensorHealthHistory
 		var recordedAt SQLiteTime

--- a/sensor_hub/db/sensor_repository_test.go
+++ b/sensor_hub/db/sensor_repository_test.go
@@ -642,8 +642,8 @@ func TestSensorRepository_GetSensorHealthHistoryById_Success(t *testing.T) {
 	now := time.Now()
 	since := now.Add(-24 * time.Hour)
 	formattedSince := since.UTC().Format("2006-01-02 15:04:05")
-	mock.ExpectQuery("SELECT id, sensor_id, health_status, recorded_at FROM sensor_health_history WHERE sensor_id = \\? AND datetime\\(recorded_at\\) >= datetime\\(\\?\\) ORDER BY recorded_at DESC").
-		WithArgs(1, formattedSince).
+	mock.ExpectQuery("WITH latest_before AS").
+		WithArgs(1, formattedSince, 1, formattedSince).
 		WillReturnRows(sqlmock.NewRows(sensorHealthHistoryColumns).
 			AddRow(1, "1", "good", now).
 			AddRow(2, "1", "bad", now.Add(-time.Hour)))
@@ -663,8 +663,8 @@ func TestSensorRepository_GetSensorHealthHistoryById_Empty(t *testing.T) {
 
 	since := time.Now().Add(-24 * time.Hour)
 	formattedSince := since.UTC().Format("2006-01-02 15:04:05")
-	mock.ExpectQuery("SELECT id, sensor_id, health_status, recorded_at FROM sensor_health_history WHERE sensor_id = \\? AND datetime\\(recorded_at\\) >= datetime\\(\\?\\) ORDER BY recorded_at DESC").
-		WithArgs(1, formattedSince).
+	mock.ExpectQuery("WITH latest_before AS").
+		WithArgs(1, formattedSince, 1, formattedSince).
 		WillReturnRows(sqlmock.NewRows(sensorHealthHistoryColumns))
 
 	history, err := repo.GetSensorHealthHistoryById(context.Background(), 1, since)
@@ -681,8 +681,8 @@ func TestSensorRepository_GetSensorHealthHistoryById_DBError(t *testing.T) {
 
 	since := time.Now().Add(-24 * time.Hour)
 	formattedSince := since.UTC().Format("2006-01-02 15:04:05")
-	mock.ExpectQuery("SELECT id, sensor_id, health_status, recorded_at FROM sensor_health_history WHERE sensor_id = \\? AND datetime\\(recorded_at\\) >= datetime\\(\\?\\) ORDER BY recorded_at DESC").
-		WithArgs(1, formattedSince).
+	mock.ExpectQuery("WITH latest_before AS").
+		WithArgs(1, formattedSince, 1, formattedSince).
 		WillReturnError(errors.New("database error"))
 
 	history, err := repo.GetSensorHealthHistoryById(context.Background(), 1, since)
@@ -1071,4 +1071,82 @@ func TestSensorRepository_DeleteHealthHistoryOlderThan_BackfillsCutoffCheckpoint
 	require.Len(t, history, 1)
 	assert.Equal(t, gen.Good, history[0].HealthStatus)
 	assert.Equal(t, cutoff, history[0].RecordedAt.UTC())
+}
+
+func TestSensorRepository_GetSensorHealthHistoryById_IncludesLatestCheckpointBeforeSince(t *testing.T) {
+	db := newInMemoryDB(t)
+	require.NoError(t, runMigrations(db, slog.Default()))
+
+	repo := NewSensorRepository(db, slog.Default())
+	ctx := context.Background()
+	checkpointTime := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+
+	err := repo.AddSensor(ctx, gen.Sensor{
+		Name:         "checkpoint-sensor",
+		SensorDriver: "sensor-hub-http-temperature",
+	})
+	require.NoError(t, err)
+
+	sensorID, err := repo.GetSensorIdByName(ctx, "checkpoint-sensor")
+	require.NoError(t, err)
+
+	const sqliteDateTime = "2006-01-02 15:04:05"
+	_, err = db.ExecContext(
+		ctx,
+		"INSERT INTO sensor_health_history (sensor_id, health_status, recorded_at) VALUES (?, ?, ?)",
+		sensorID,
+		gen.Good,
+		checkpointTime.Format(sqliteDateTime),
+	)
+	require.NoError(t, err)
+
+	history, err := repo.GetSensorHealthHistoryById(ctx, sensorID, checkpointTime.Add(time.Minute))
+	require.NoError(t, err)
+	require.Len(t, history, 1)
+	assert.Equal(t, gen.Good, history[0].HealthStatus)
+	assert.Equal(t, checkpointTime, history[0].RecordedAt.UTC())
+}
+
+func TestSensorRepository_GetSensorHealthHistoryById_IncludesBaselineAndLaterTransitions(t *testing.T) {
+	db := newInMemoryDB(t)
+	require.NoError(t, runMigrations(db, slog.Default()))
+
+	repo := NewSensorRepository(db, slog.Default())
+	ctx := context.Background()
+	baselineTime := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	transitionTime := baselineTime.Add(2 * time.Hour)
+
+	err := repo.AddSensor(ctx, gen.Sensor{
+		Name:         "transition-sensor",
+		SensorDriver: "sensor-hub-http-temperature",
+	})
+	require.NoError(t, err)
+
+	sensorID, err := repo.GetSensorIdByName(ctx, "transition-sensor")
+	require.NoError(t, err)
+
+	const sqliteDateTime = "2006-01-02 15:04:05"
+	_, err = db.ExecContext(
+		ctx,
+		"INSERT INTO sensor_health_history (sensor_id, health_status, recorded_at) VALUES (?, ?, ?), (?, ?, ?)",
+		sensorID,
+		gen.Good,
+		baselineTime.Format(sqliteDateTime),
+		sensorID,
+		gen.Bad,
+		transitionTime.Format(sqliteDateTime),
+	)
+	require.NoError(t, err)
+
+	history, err := repo.GetSensorHealthHistoryById(ctx, sensorID, baselineTime.Add(time.Minute))
+	require.NoError(t, err)
+	require.Len(t, history, 2)
+	assert.Equal(t, []gen.SensorHealthStatus{gen.Bad, gen.Good}, []gen.SensorHealthStatus{
+		history[0].HealthStatus,
+		history[1].HealthStatus,
+	})
+	assert.Equal(t, []time.Time{transitionTime, baselineTime}, []time.Time{
+		history[0].RecordedAt.UTC(),
+		history[1].RecordedAt.UTC(),
+	})
 }

--- a/sensor_hub/db/sensor_repository_test.go
+++ b/sensor_hub/db/sensor_repository_test.go
@@ -670,6 +670,7 @@ func TestSensorRepository_GetSensorHealthHistoryById_Empty(t *testing.T) {
 	history, err := repo.GetSensorHealthHistoryById(context.Background(), 1, since)
 
 	assert.NoError(t, err)
+	assert.NotNil(t, history)
 	assert.Empty(t, history)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
@@ -706,6 +707,9 @@ func TestSensorRepository_DeleteHealthHistoryOlderThan_Success(t *testing.T) {
 	mock.ExpectExec("INSERT INTO sensor_health_history \\(sensor_id, health_status, recorded_at\\)").
 		WithArgs(formattedCutoff, formattedCutoff).
 		WillReturnResult(sqlmock.NewResult(0, 2))
+	mock.ExpectExec("INSERT INTO sensor_health_history \\(sensor_id, health_status, recorded_at\\)").
+		WithArgs(formattedCutoff, formattedCutoff).
+		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec("DELETE FROM sensor_health_history WHERE datetime\\(recorded_at\\) < datetime\\(\\?\\)").
 		WithArgs(formattedCutoff).
 		WillReturnResult(sqlmock.NewResult(0, 5))
@@ -724,6 +728,9 @@ func TestSensorRepository_DeleteHealthHistoryOlderThan_NothingToDelete(t *testin
 	cutoff := time.Now().Add(-24 * time.Hour)
 	formattedCutoff := cutoff.UTC().Format("2006-01-02 15:04:05")
 	mock.ExpectBegin()
+	mock.ExpectExec("INSERT INTO sensor_health_history \\(sensor_id, health_status, recorded_at\\)").
+		WithArgs(formattedCutoff, formattedCutoff).
+		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec("INSERT INTO sensor_health_history \\(sensor_id, health_status, recorded_at\\)").
 		WithArgs(formattedCutoff, formattedCutoff).
 		WillReturnResult(sqlmock.NewResult(0, 0))
@@ -748,6 +755,9 @@ func TestSensorRepository_DeleteHealthHistoryOlderThan_DBError(t *testing.T) {
 	mock.ExpectExec("INSERT INTO sensor_health_history \\(sensor_id, health_status, recorded_at\\)").
 		WithArgs(formattedCutoff, formattedCutoff).
 		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("INSERT INTO sensor_health_history \\(sensor_id, health_status, recorded_at\\)").
+		WithArgs(formattedCutoff, formattedCutoff).
+		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec("DELETE FROM sensor_health_history WHERE datetime\\(recorded_at\\) < datetime\\(\\?\\)").
 		WithArgs(formattedCutoff).
 		WillReturnError(errors.New("database error"))
@@ -1014,6 +1024,42 @@ func TestSensorRepository_DeleteHealthHistoryOlderThan_PreservesCutoffCheckpoint
 		"INSERT INTO sensor_health_history (sensor_id, health_status, recorded_at) VALUES (?, ?, ?), (?, ?, ?)",
 		sensorID, gen.Bad, cutoff.Add(-48*time.Hour).Format(sqliteDateTime),
 		sensorID, gen.Good, cutoff.Add(-12*time.Hour).Format(sqliteDateTime),
+	)
+	require.NoError(t, err)
+
+	err = repo.DeleteHealthHistoryOlderThan(ctx, cutoff)
+	require.NoError(t, err)
+
+	history, err := repo.GetSensorHealthHistoryById(ctx, sensorID, cutoff)
+	require.NoError(t, err)
+	require.Len(t, history, 1)
+	assert.Equal(t, gen.Good, history[0].HealthStatus)
+	assert.Equal(t, cutoff, history[0].RecordedAt.UTC())
+}
+
+func TestSensorRepository_DeleteHealthHistoryOlderThan_BackfillsCutoffCheckpointFromCurrentSensorState(t *testing.T) {
+	db := newInMemoryDB(t)
+	require.NoError(t, runMigrations(db, slog.Default()))
+
+	repo := NewSensorRepository(db, slog.Default())
+	ctx := context.Background()
+	cutoff := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+
+	err := repo.AddSensor(ctx, gen.Sensor{
+		Name:         "steady-sensor",
+		SensorDriver: "sensor-hub-http-temperature",
+	})
+	require.NoError(t, err)
+
+	sensorID, err := repo.GetSensorIdByName(ctx, "steady-sensor")
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(
+		ctx,
+		"UPDATE sensors SET health_status = ?, health_reason = ? WHERE id = ?",
+		gen.Good,
+		"successful reading",
+		sensorID,
 	)
 	require.NoError(t, err)
 

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/UptimeWidget.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/UptimeWidget.tsx
@@ -36,7 +36,7 @@ export default function UptimeWidget({ config }: WidgetProps) {
         });
     }, [history, properties]);
 
-    const uptime = model ? model.goodRatio * 100 : 0;
+    const uptime = model ? Math.min(100, Math.max(0, model.goodRatio * 100)) : 0;
 
     const getColor = (pct: number): 'success' | 'warning' | 'error' => {
         if (pct > 90) return 'success';

--- a/sensor_hub/ui/sensor_hub_ui/src/health/healthWindow.test.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/health/healthWindow.test.ts
@@ -97,4 +97,39 @@ describe('buildHealthWindowModel', () => {
     expect(model.windowDurationMs).toBe(4 * 60 * 60 * 1000);
     expect(model.goodRatio).toBeCloseTo(0.75);
   });
+
+  it('clamps a pre-window baseline checkpoint to the requested window start', () => {
+    const model = buildHealthWindowModel(
+      [
+        makeHistory({
+          recorded_at: '2026-05-09T08:59:00Z',
+          health_status: 'good',
+        }),
+      ],
+      {
+        windowStart: new Date('2026-05-09T09:00:00Z'),
+        now: new Date('2026-05-09T13:00:00Z'),
+      },
+    );
+
+    expect(model.points).toEqual([
+      {
+        recorded_at: '2026-05-09T09:00:00.000Z',
+        health_status: 'good',
+        synthetic: true,
+      },
+      {
+        recorded_at: '2026-05-09T13:00:00.000Z',
+        health_status: 'good',
+        synthetic: true,
+      },
+    ]);
+    expect(model.durationsMs).toEqual({
+      good: 4 * 60 * 60 * 1000,
+      bad: 0,
+      unknown: 0,
+    });
+    expect(model.windowDurationMs).toBe(4 * 60 * 60 * 1000);
+    expect(model.goodRatio).toBe(1);
+  });
 });

--- a/sensor_hub/ui/sensor_hub_ui/src/health/healthWindow.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/health/healthWindow.ts
@@ -45,13 +45,15 @@ export function buildHealthWindowModel(
   history: SensorHealthHistory[],
   options: BuildHealthWindowModelOptions,
 ): HealthWindowModel {
-  const points = [...history]
+  let points = [...history]
     .sort((left, right) => new Date(left.recorded_at).getTime() - new Date(right.recorded_at).getTime())
     .map((entry) => ({
       recorded_at: entry.recorded_at,
       health_status: entry.health_status,
       synthetic: false,
     }));
+  const windowStartMs = options.windowStart.getTime();
+  const windowStartIso = options.windowStart.toISOString();
 
   if (points.length === 0) {
     return {
@@ -64,9 +66,32 @@ export function buildHealthWindowModel(
     };
   }
 
-  if (new Date(points[0].recorded_at).getTime() > options.windowStart.getTime()) {
+  const firstOnOrAfterWindowStart = points.findIndex((point) => new Date(point.recorded_at).getTime() >= windowStartMs);
+  if (firstOnOrAfterWindowStart === -1) {
+    const latestBeforeWindow = points[points.length - 1];
+    points = [{
+      recorded_at: windowStartIso,
+      health_status: latestBeforeWindow.health_status,
+      synthetic: true,
+    }];
+  } else if (firstOnOrAfterWindowStart > 0) {
+    const firstPointInWindow = points[firstOnOrAfterWindowStart];
+    if (new Date(firstPointInWindow.recorded_at).getTime() === windowStartMs) {
+      points = points.slice(firstOnOrAfterWindowStart);
+    } else {
+      const latestBeforeWindow = points[firstOnOrAfterWindowStart - 1];
+      points = [
+        {
+          recorded_at: windowStartIso,
+          health_status: latestBeforeWindow.health_status,
+          synthetic: true,
+        },
+        ...points.slice(firstOnOrAfterWindowStart),
+      ];
+    }
+  } else if (new Date(points[0].recorded_at).getTime() > windowStartMs) {
     points.unshift({
-      recorded_at: options.windowStart.toISOString(),
+      recorded_at: windowStartIso,
       health_status: 'unknown',
       synthetic: true,
     });


### PR DESCRIPTION
## Summary
- backfill a cutoff-boundary health-history checkpoint from the current sensor state when cleanup finds no retained rows
- include the latest checkpoint before the requested health-history window so cleanup-seeded boundary rows remain visible as time advances
- clamp pre-window baseline checkpoints to the requested UI window start so uptime cannot exceed 100 percent
- return array-shaped empty health-history results so the API never serializes null
- add regression coverage for the API contract, retained-history recovery, boundary checkpoint reads, and uptime window clamping

## Testing
- cd sensor_hub && go test ./...
- cd sensor_hub && go test -tags integration -v -timeout 300s ./integration/
- cd sensor_hub/ui/sensor_hub_ui && npm test -- --run src/health/healthWindow.test.ts
- cd sensor_hub/ui/sensor_hub_ui && npm run build

Fixes #148
