### PR TITLE
Fix user deletion with dependent records

### DIFF
--- a/sensor_hub/db/user_repository.go
+++ b/sensor_hub/db/user_repository.go
@@ -220,8 +220,14 @@ func (r *SqlUserRepository) DeleteUserById(ctx context.Context, userId int) erro
 	if _, err = tx.ExecContext(ctx, "DELETE FROM user_roles WHERE user_id = ?", userId); err != nil {
 		return fmt.Errorf("error deleting user roles: %w", err)
 	}
+	if _, err = tx.ExecContext(ctx, "DELETE FROM api_keys WHERE user_id = ?", userId); err != nil {
+		return fmt.Errorf("error deleting api keys for user: %w", err)
+	}
 	if _, err = tx.ExecContext(ctx, "DELETE FROM sessions WHERE user_id = ?", userId); err != nil {
 		return fmt.Errorf("error deleting sessions for user: %w", err)
+	}
+	if _, err = tx.ExecContext(ctx, "DELETE FROM sensor_command_history WHERE user_id = ?", userId); err != nil {
+		return fmt.Errorf("error deleting sensor command history for user: %w", err)
 	}
 	if _, err = tx.ExecContext(ctx, "DELETE FROM users WHERE id = ?", userId); err != nil {
 		return fmt.Errorf("error deleting user: %w", err)

--- a/sensor_hub/db/user_repository_test.go
+++ b/sensor_hub/db/user_repository_test.go
@@ -644,7 +644,13 @@ func TestUserRepository_DeleteUserById_Success(t *testing.T) {
 	mock.ExpectExec("DELETE FROM user_roles WHERE user_id = \\?").
 		WithArgs(1).
 		WillReturnResult(sqlmock.NewResult(0, 2))
+	mock.ExpectExec("DELETE FROM api_keys WHERE user_id = \\?").
+		WithArgs(1).
+		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec("DELETE FROM sessions WHERE user_id = \\?").
+		WithArgs(1).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("DELETE FROM sensor_command_history WHERE user_id = \\?").
 		WithArgs(1).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec("DELETE FROM users WHERE id = \\?").
@@ -683,6 +689,9 @@ func TestUserRepository_DeleteUserById_RollbackOnSessionsError(t *testing.T) {
 	mock.ExpectExec("DELETE FROM user_roles WHERE user_id = \\?").
 		WithArgs(1).
 		WillReturnResult(sqlmock.NewResult(0, 2))
+	mock.ExpectExec("DELETE FROM api_keys WHERE user_id = \\?").
+		WithArgs(1).
+		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec("DELETE FROM sessions WHERE user_id = \\?").
 		WithArgs(1).
 		WillReturnError(errors.New("database error"))

--- a/sensor_hub/integration/users_test.go
+++ b/sensor_hub/integration/users_test.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"testing"
 
-	"example/sensorHub/testharness"
 	gen "example/sensorHub/gen"
+	"example/sensorHub/testharness"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -72,4 +72,72 @@ func TestUsers_Delete(t *testing.T) {
 
 	status = client.DeleteUser(created.ID)
 	assert.Equal(t, http.StatusOK, status)
+}
+
+func TestUsers_DeleteRemovesOwnedApiKeys(t *testing.T) {
+	user := gen.CreateUserRequest{
+		Username: "user-with-api-key",
+		Password: "deletepass123",
+		Email:    ptrStr("user-with-api-key@test.com"),
+		Roles:    &[]string{"user"},
+	}
+	resp, status := client.CreateUser(user)
+	require.Equal(t, http.StatusCreated, status)
+
+	var created struct {
+		ID int `json:"id"`
+	}
+	require.NoError(t, json.Unmarshal(resp, &created))
+	require.True(t, created.ID > 0)
+
+	userClient := testharness.NewClient(t, env.ServerURL)
+	require.Equal(t, http.StatusOK, userClient.Login(user.Username, user.Password))
+	require.Equal(t, http.StatusOK, userClient.ChangePassword("deletepass456"))
+
+	_, status = userClient.CreateApiKey("delete-test-key")
+	require.Equal(t, http.StatusCreated, status)
+
+	status = client.DeleteUser(created.ID)
+	assert.Equal(t, http.StatusOK, status)
+
+	var apiKeyCount int
+	require.NoError(t, env.DB.QueryRow(`SELECT COUNT(*) FROM api_keys WHERE user_id = ?`, created.ID).Scan(&apiKeyCount))
+	assert.Zero(t, apiKeyCount)
+}
+
+func TestUsers_DeleteRemovesSensorCommandHistory(t *testing.T) {
+	fixture := setupCommandFixture(t, "delete-history-plug")
+	defer fixture.stop()
+
+	user := gen.CreateUserRequest{
+		Username: "user-with-command-history",
+		Password: "deletepass123",
+		Email:    ptrStr("user-with-command-history@test.com"),
+		Roles:    &[]string{"user"},
+	}
+	resp, status := client.CreateUser(user)
+	require.Equal(t, http.StatusCreated, status)
+
+	var created struct {
+		ID int `json:"id"`
+	}
+	require.NoError(t, json.Unmarshal(resp, &created))
+	require.True(t, created.ID > 0)
+
+	userClient := testharness.NewClient(t, env.ServerURL)
+	require.Equal(t, http.StatusOK, userClient.Login(user.Username, user.Password))
+	require.Equal(t, http.StatusOK, userClient.ChangePassword("deletepass456"))
+
+	command, status := userClient.SendSensorCommand(fixture.sensor.Id, "state", "ON")
+	require.Equal(t, http.StatusAccepted, status)
+
+	var historyCount int
+	require.NoError(t, env.DB.QueryRow(`SELECT COUNT(*) FROM sensor_command_history WHERE id = ?`, command.Id).Scan(&historyCount))
+	require.Equal(t, 1, historyCount)
+
+	status = client.DeleteUser(created.ID)
+	assert.Equal(t, http.StatusOK, status)
+
+	require.NoError(t, env.DB.QueryRow(`SELECT COUNT(*) FROM sensor_command_history WHERE id = ?`, command.Id).Scan(&historyCount))
+	assert.Zero(t, historyCount)
 }


### PR DESCRIPTION
## Summary
- delete API keys before deleting users
- delete sensor command history before deleting users
- add integration regressions for both deletion paths

## Testing
- `cd sensor_hub && go test ./...`
- `cd sensor_hub && go test -tags integration -v -timeout 300s ./integration/`

Closes #150
