### PR TITLE
Controllable-first dashboard loading: client-side priority request scheduler

### DIFF
--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/AlertSummaryWidget.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/AlertSummaryWidget.tsx
@@ -3,6 +3,7 @@ import type { AlertRule } from '../../gen/aliases';
 import { useState, useEffect } from 'react';
 import { Box, Typography, List, ListItem, ListItemText, Chip } from '@mui/material';
 import { apiClient } from '../../gen/client';
+import { requestScheduler } from '../../scheduler/requestScheduler';
 import { useReportWidgetUpdate } from '../WidgetUpdateContext';
 
 export default function AlertSummaryWidget(_props: WidgetProps) {
@@ -11,7 +12,7 @@ export default function AlertSummaryWidget(_props: WidgetProps) {
     const reportUpdate = useReportWidgetUpdate();
 
     useEffect(() => {
-        apiClient.GET('/alerts').then(({ data }) => {
+        requestScheduler.schedule('normal', () => apiClient.GET('/alerts')).then(({ data }) => {
             setRules((data as AlertRule[] | null) ?? []);
             setLoaded(true);
             reportUpdate(new Date());

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/HeatmapWidget.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/HeatmapWidget.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { Box, Typography } from '@mui/material';
 import { useSensorContext } from '../../hooks/useSensorContext';
 import { apiClient } from '../../gen/client';
+import { requestScheduler } from '../../scheduler/requestScheduler';
 import { useIsDark } from '../../theme/useIsDark';
 import { parseUTCTime } from '../../tools/Utils';
 import NeedsConfiguration from '../NeedsConfiguration';
@@ -78,7 +79,7 @@ export default function HeatmapWidget({ config }: WidgetProps) {
         const now = new Date();
         const start = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
 
-        apiClient.GET('/readings/between', { params: { query: { start: start.toISOString().slice(0, 10), end: now.toISOString().slice(0, 10), measurement_type: measurementType } } }).then(({ data: response }) => {
+        requestScheduler.schedule('normal', () => apiClient.GET('/readings/between', { params: { query: { start: start.toISOString().slice(0, 10), end: now.toISOString().slice(0, 10), measurement_type: measurementType } } })).then(({ data: response }) => {
             const sensorReadings = (response?.readings ?? []).filter((r) => r.sensor_name === sensor.name);
             const grouped: Record<string, number[]> = {};
 

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/MinMaxAvgWidget.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/MinMaxAvgWidget.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect } from 'react';
 import { Box, Paper, Typography } from '@mui/material';
 import { useSensorContext } from '../../hooks/useSensorContext';
 import { apiClient } from '../../gen/client';
+import { requestScheduler } from '../../scheduler/requestScheduler';
 import { useChartColours } from '../../theme/chartColours';
 import NeedsConfiguration from '../NeedsConfiguration';
 import { resolveTimeRange } from '../timeRange';
@@ -25,7 +26,7 @@ export default function MinMaxAvgWidget({ config }: WidgetProps) {
     useEffect(() => {
         if (!sensor) return;
 
-        apiClient.GET('/readings/between', { params: { query: { start: startIso, end: endIso, measurement_type: measurementType } } }).then(({ data: response }) => {
+        requestScheduler.schedule('normal', () => apiClient.GET('/readings/between', { params: { query: { start: startIso, end: endIso, measurement_type: measurementType } } })).then(({ data: response }) => {
             const sensorReadings = (response?.readings ?? []).filter((r) => r.sensor_name === sensor.name);
             if (sensorReadings.length === 0) {
                 setStats(null);

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/SensorToggleWidget.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/SensorToggleWidget.tsx
@@ -4,6 +4,7 @@ import { alpha, useTheme } from '@mui/material/styles';
 import type { WidgetProps } from '../types';
 import type { Capability, CommandStatusMessage } from '../../gen/aliases';
 import { apiClient } from '../../gen/client';
+import { requestScheduler } from '../../scheduler/requestScheduler';
 import { useCurrentReadings } from '../../hooks/useCurrentReadings';
 import { useSensorContext } from '../../hooks/useSensorContext';
 import { useAuth } from '../../providers/AuthContext';
@@ -177,10 +178,12 @@ export default function SensorToggleWidget({ config }: WidgetProps) {
     setOptimisticValue(nextValue);
     reportUpdate(new Date());
 
-    const { data, error } = await apiClient.POST('/sensors/{id}/command', {
+    // Send the command immediately and pause low-priority background polls for its duration,
+    // so the command (and its confirmation) aren't queued behind the read-only chart flood.
+    const { data, error } = await requestScheduler.runWithPreemption(() => apiClient.POST('/sensors/{id}/command', {
       params: { path: { id: sensor.id } },
       body: { property, value: nextValue },
-    });
+    }));
 
     if (error) {
       setOptimisticValue(previousValue);

--- a/sensor_hub/ui/sensor_hub_ui/src/environment/Environment.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/environment/Environment.ts
@@ -1,3 +1,10 @@
 export const API_BASE = import.meta.env.VITE_API_BASE || '/api';
 export const WEBSOCKET_BASE = import.meta.env.VITE_WEBSOCKET_BASE || '/api';
 
+/**
+ * Maximum number of read-only REST requests the client will have in flight to the backend at once.
+ * Caps the dashboard's on-load request burst so controllable widgets (and their commands) aren't
+ * starved by heavy chart queries on slow deployments. Tunable per deployment via VITE_READONLY_REQUEST_CONCURRENCY.
+ */
+export const READONLY_REQUEST_CONCURRENCY = Number(import.meta.env.VITE_READONLY_REQUEST_CONCURRENCY) || 4;
+

--- a/sensor_hub/ui/sensor_hub_ui/src/hooks/useReadingsData.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/hooks/useReadingsData.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState, useMemo } from "react";
 import type { ChartEntry, Sensor, Reading } from "../gen/aliases";
 import type { DateTime } from "luxon";
 import { apiClient } from "../gen/client";
+import { requestScheduler, type RequestPriority } from "../scheduler/requestScheduler";
 import { logger } from '../tools/logger';
 
 interface ResolvedRange {
@@ -77,14 +78,15 @@ export function useReadingsData({
       fetchStartIso: string,
       fetchEndIso: string,
       force = false,
+      priority: RequestPriority = 'normal',
     ) => {
       const currentRequestId = ++requestIdRef.current;
       const currentSensors = sensorsRef.current;
       const currentSensorsKey = currentSensors.map((s) => s.name).join("|");
       try {
-        const response = await apiClient.GET('/readings/between', {
+        const response = await requestScheduler.schedule(priority, () => apiClient.GET('/readings/between', {
           params: { query: { start: fetchStartIso, end: fetchEndIso, type: measurementType, aggregation_function: aggregationFunction as never } },
-        });
+        }));
         const data: Reading[] = response.data?.readings ?? [];
 
         if (requestIdRef.current !== currentRequestId || !isMountedRef.current) return;
@@ -135,14 +137,15 @@ export function useReadingsData({
       }
     };
 
-    void fetchAndMaybeUpdate(initStart, initEnd, true);
+    void fetchAndMaybeUpdate(initStart, initEnd, true, 'normal');
 
     const intervalId = window.setInterval(() => {
       // Re-resolve time range on each tick so relative presets slide forward
       const tick = resolveTimeRangeRef.current?.();
       const freshStart = tick?.startDate?.toUTC().toISO() ?? initStart;
       const freshEnd = tick?.endDate?.toUTC().toISO() ?? initEnd;
-      void fetchAndMaybeUpdate(freshStart, freshEnd);
+      // Background polls are low priority so they yield to initial loads and commands.
+      void fetchAndMaybeUpdate(freshStart, freshEnd, false, 'low');
     }, pollIntervalMs);
 
     return () => {

--- a/sensor_hub/ui/sensor_hub_ui/src/scheduler/requestScheduler.test.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/scheduler/requestScheduler.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRequestScheduler, type RequestScheduler } from './requestScheduler';
+
+/** A promise whose resolution we control, plus a record of whether `fn` has started running. */
+function deferred<T = void>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+/** Flush pending microtasks so admitted `start()` callbacks invoke their `fn`. */
+const flush = () => Promise.resolve().then(() => Promise.resolve());
+
+describe('requestScheduler', () => {
+  let scheduler: RequestScheduler;
+
+  beforeEach(() => {
+    scheduler = createRequestScheduler({ maxConcurrency: 2 });
+  });
+
+  it('never runs more than maxConcurrency tasks at once', async () => {
+    const gates = Array.from({ length: 5 }, () => deferred());
+    let running = 0;
+    let peak = 0;
+
+    const results = gates.map((gate) =>
+      scheduler.schedule('normal', async () => {
+        running++;
+        peak = Math.max(peak, running);
+        await gate.promise;
+        running--;
+      }),
+    );
+
+    await flush();
+    expect(scheduler.getInFlight()).toBe(2);
+    expect(running).toBe(2);
+
+    // Release one slot; exactly one more should be admitted.
+    gates[0].resolve();
+    await flush();
+    expect(scheduler.getInFlight()).toBe(2);
+
+    gates.forEach((g) => g.resolve());
+    await Promise.all(results);
+    expect(peak).toBe(2);
+    expect(scheduler.getInFlight()).toBe(0);
+  });
+
+  it('admits higher priority waiters before lower, FIFO within a tier', async () => {
+    const order: string[] = [];
+    const block = deferred();
+
+    // Occupy both slots so everything else queues.
+    scheduler.schedule('normal', () => block.promise);
+    scheduler.schedule('normal', () => block.promise);
+    await flush();
+    expect(scheduler.getInFlight()).toBe(2);
+
+    // Enqueue a mix while saturated.
+    const mk = (label: string) => () => {
+      order.push(label);
+      return Promise.resolve();
+    };
+    scheduler.schedule('low', mk('low-1'));
+    scheduler.schedule('normal', mk('normal-1'));
+    scheduler.schedule('high', mk('high-1'));
+    scheduler.schedule('normal', mk('normal-2'));
+    scheduler.schedule('high', mk('high-2'));
+
+    // Drain: release the two blockers, then let the queue flow.
+    block.resolve();
+    for (let i = 0; i < 10; i++) await flush();
+
+    expect(order).toEqual(['high-1', 'high-2', 'normal-1', 'normal-2', 'low-1']);
+  });
+
+  it('propagates resolution and rejection of the wrapped fn', async () => {
+    await expect(scheduler.schedule('normal', () => Promise.resolve(42))).resolves.toBe(42);
+    await expect(scheduler.schedule('normal', () => Promise.reject(new Error('boom')))).rejects.toThrow('boom');
+  });
+
+  it('admits more work immediately when maxConcurrency is raised', async () => {
+    const block = deferred();
+    for (let i = 0; i < 4; i++) scheduler.schedule('normal', () => block.promise);
+    await flush();
+    expect(scheduler.getInFlight()).toBe(2);
+
+    scheduler.setMaxConcurrency(4);
+    await flush();
+    expect(scheduler.getInFlight()).toBe(4);
+
+    block.resolve();
+  });
+
+  describe('preemption', () => {
+    it('pauses new low-priority admits while a command is in flight, then resumes', async () => {
+      const idle = createRequestScheduler({ maxConcurrency: 2 });
+      const command = deferred();
+      let lowRan = false;
+
+      const cmd = idle.runWithPreemption(() => command.promise);
+      expect(idle.isPreempted()).toBe(true);
+
+      idle.schedule('low', () => {
+        lowRan = true;
+        return Promise.resolve();
+      });
+      await flush();
+      // Slots are free, but the low task is held back by the engaged latch.
+      expect(lowRan).toBe(false);
+      expect(idle.getQueuedCount('low')).toBe(1);
+
+      // normal tasks are NOT affected by preemption.
+      let normalRan = false;
+      idle.schedule('normal', () => {
+        normalRan = true;
+        return Promise.resolve();
+      });
+      await flush();
+      expect(normalRan).toBe(true);
+
+      command.resolve();
+      await cmd;
+      await flush();
+      expect(idle.isPreempted()).toBe(false);
+      expect(lowRan).toBe(true);
+    });
+
+    it('auto-releases the latch after the timeout so polls are never starved', async () => {
+      vi.useFakeTimers();
+      try {
+        const s = createRequestScheduler({ maxConcurrency: 2 });
+        const neverResolves = deferred();
+        s.runWithPreemption(() => neverResolves.promise, { timeoutMs: 1000 });
+        expect(s.isPreempted()).toBe(true);
+
+        let lowRan = false;
+        s.schedule('low', () => {
+          lowRan = true;
+          return Promise.resolve();
+        });
+        await Promise.resolve();
+        expect(lowRan).toBe(false);
+
+        vi.advanceTimersByTime(1000);
+        expect(s.isPreempted()).toBe(false);
+        await Promise.resolve().then(() => Promise.resolve());
+        expect(lowRan).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('runs the preemptive task immediately even when the cap is saturated', async () => {
+      const block = deferred();
+      scheduler.schedule('normal', () => block.promise);
+      scheduler.schedule('normal', () => block.promise);
+      await flush();
+      expect(scheduler.getInFlight()).toBe(2);
+
+      let commandRan = false;
+      const cmd = scheduler.runWithPreemption(() => {
+        commandRan = true;
+        return Promise.resolve('ok');
+      });
+      await flush();
+      expect(commandRan).toBe(true);
+      await expect(cmd).resolves.toBe('ok');
+
+      block.resolve();
+    });
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});

--- a/sensor_hub/ui/sensor_hub_ui/src/scheduler/requestScheduler.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/scheduler/requestScheduler.ts
@@ -1,0 +1,123 @@
+import { READONLY_REQUEST_CONCURRENCY } from '../environment/Environment';
+
+/**
+ * Priority tiers for scheduled read-only requests.
+ * - `high`   — controllable-related work (reserved for future use); admitted before everything else.
+ * - `normal` — visible read-only widgets fetching on mount.
+ * - `low`    — background polling; additionally paused while a command is in flight (see preemption).
+ */
+export type RequestPriority = 'high' | 'normal' | 'low';
+
+const TIERS: RequestPriority[] = ['high', 'normal', 'low'];
+
+/** Default safety timeout after which an engaged preempt latch auto-releases, so polls can never be starved. */
+const DEFAULT_PREEMPT_TIMEOUT_MS = 5000;
+
+interface Waiter {
+  start: () => void;
+}
+
+export interface RequestScheduler {
+  /**
+   * Run `fn` through the scheduler at the given priority. At most `maxConcurrency` scheduled tasks run at once;
+   * when a slot frees the highest-priority waiter runs next (FIFO within a tier). Resolves/rejects with `fn`'s result.
+   */
+  schedule<T>(priority: RequestPriority, fn: () => Promise<T>): Promise<T>;
+  /**
+   * Run `fn` immediately (bypassing the concurrency cap — intended for a single lightweight command) while pausing
+   * admission of new `low`-priority tasks. The pause is released when `fn` settles, or after `timeoutMs` as a backstop.
+   */
+  runWithPreemption<T>(fn: () => Promise<T>, options?: { timeoutMs?: number }): Promise<T>;
+  setMaxConcurrency(n: number): void;
+  getMaxConcurrency(): number;
+  /** Number of scheduled tasks currently running. Excludes preemptive (command) tasks, which bypass the cap. */
+  getInFlight(): number;
+  getQueuedCount(priority: RequestPriority): number;
+  /** True while at least one preempt latch is engaged (new `low` tasks are paused). */
+  isPreempted(): boolean;
+}
+
+export function createRequestScheduler(options?: { maxConcurrency?: number }): RequestScheduler {
+  let maxConcurrency = Math.max(1, options?.maxConcurrency ?? READONLY_REQUEST_CONCURRENCY);
+  let inFlight = 0;
+  let preemptCount = 0;
+  const queues: Record<RequestPriority, Waiter[]> = { high: [], normal: [], low: [] };
+
+  function takeNextWaiter(): Waiter | undefined {
+    for (const tier of TIERS) {
+      if (tier === 'low' && preemptCount > 0) continue;
+      const waiter = queues[tier].shift();
+      if (waiter) return waiter;
+    }
+    return undefined;
+  }
+
+  function pump(): void {
+    while (inFlight < maxConcurrency) {
+      const waiter = takeNextWaiter();
+      if (!waiter) break;
+      inFlight++;
+      waiter.start();
+    }
+  }
+
+  function schedule<T>(priority: RequestPriority, fn: () => Promise<T>): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      queues[priority].push({
+        start: () => {
+          Promise.resolve()
+            .then(fn)
+            .then(resolve, reject)
+            .finally(() => {
+              inFlight--;
+              pump();
+            });
+        },
+      });
+      pump();
+    });
+  }
+
+  function runWithPreemption<T>(fn: () => Promise<T>, opts?: { timeoutMs?: number }): Promise<T> {
+    preemptCount++;
+    let released = false;
+    const timer = setTimeout(release, opts?.timeoutMs ?? DEFAULT_PREEMPT_TIMEOUT_MS);
+
+    function release(): void {
+      if (released) return;
+      released = true;
+      clearTimeout(timer);
+      preemptCount--;
+      pump();
+    }
+
+    // Invoke fn synchronously so the command is sent immediately (bypassing the cap).
+    let result: Promise<T>;
+    try {
+      result = Promise.resolve(fn());
+    } catch (err) {
+      release();
+      return Promise.reject(err);
+    }
+    // Release the latch when the command settles, on a side branch so the returned promise's
+    // resolution timing matches a bare fn() call (callers may rely on microtask ordering).
+    result.then(release, release);
+    return result;
+  }
+
+  return {
+    schedule,
+    runWithPreemption,
+    setMaxConcurrency(n: number) {
+      maxConcurrency = Math.max(1, n);
+      pump();
+    },
+    getMaxConcurrency: () => maxConcurrency,
+    getInFlight: () => inFlight,
+    getQueuedCount: (priority: RequestPriority) => queues[priority].length,
+    isPreempted: () => preemptCount > 0,
+  };
+}
+
+/** App-wide singleton. All read-only widget fetches and toggle commands go through this. */
+export const requestScheduler = createRequestScheduler();


### PR DESCRIPTION
## Summary

Makes controllable dashboard widgets (the `sensor-toggle` switch) settle and respond quickly even on a busy dashboard, by metering the read-only REST flood that was saturating the Raspberry Pi + SQLite backend on load.

Implements the full PRD in #209 — slices #210, #211, #212 — in one branch.

### Why

Measured against the live Pi (via the `sensor-hub` CLI): a light request went from **~23ms idle to 1.3-2.6s** while a dashboard's worth of chart queries hammered the backend (a 55-115x hit), recovering instantly when load cleared. The controllable toggle rides shared WebSockets + a command POST, so it gets fast not by jumping a queue but by us throttling the read-only flood so the Pi keeps headroom.

### What changed

- **New `src/scheduler/requestScheduler.ts`** — a priority-aware concurrency limiter (priority semaphore):
  - `schedule(priority, fn)` admits at most `N` tasks concurrently (`N` = `READONLY_REQUEST_CONCURRENCY`, default **4**, tunable via `VITE_READONLY_REQUEST_CONCURRENCY`); highest-priority waiter runs next, FIFO within a tier (`high` > `normal` > `low`).
  - `runWithPreemption(fn)` for commands: runs `fn` immediately (bypassing the cap) and pauses admission of new `low`-priority tasks for its duration, **bounded** by a safety timeout so polls can't be starved.
- **`useReadingsData`** (every chart): initial fetch at `normal`, 30s poll at `low`. Stale-response guard (`requestIdRef`) and unmount cleanup preserved.
- **`MinMaxAvgWidget`, `HeatmapWidget`, `AlertSummaryWidget`**: one-shot fetches routed at `normal`.
- **`SensorToggleWidget`**: command POST via `runWithPreemption` — sent immediately, pauses background polls while in flight. Optimistic UI and `command_status` reconciliation unchanged.

### Tests

- New `requestScheduler.test.ts`: concurrency never exceeds the cap, priority ordering + FIFO within tier, resolution/rejection propagation, raising the cap admits queued work, and preemption (pauses new `low` admits, resumes on settle, auto-releases after timeout, runs the command immediately when saturated).
- Full UI suite: **39 passed**. `npm run build` (tsc + vite) passes.

## Scope / non-goals

Frontend-only. No backend changes, no WebSocket-connection hoisting, no request coalescing — captured as follow-ups in #209.

## ⚠️ Pre-existing toolchain note (not introduced here)

`npm run lint` currently fails on `main` regardless of this change: `eslint@10.4.1` (locked) rejects a legacy `plugins` array emitted by a shared config (`eslint-plugin-react-hooks@7.1.1` / `eslint-plugin-react-refresh`). This PR touches no ESLint config or dependencies. New code was verified clean under a working `@eslint/js` + `typescript-eslint` ruleset. Happy to fix the lint toolchain in a separate PR (it needs a dependency-version decision).

## Closes

Closes #210, #211, #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)
