### PR TITLE
Faster controllable-toggle first load + readings query/index audit

### DIFF
--- a/sensor_hub/api/readings_api.go
+++ b/sensor_hub/api/readings_api.go
@@ -67,16 +67,10 @@ func (s *Server) GetReadingsBetweenDates(c *gin.Context, params gen.GetReadingsB
 }
 
 func (s *Server) SubscribeCurrentReadings(c *gin.Context) {
-	ctx := c.Request.Context()
-	currentReadings, err := s.readingsService.ServiceGetLatest(ctx)
-
-	if err != nil {
-		slog.Error("error fetching latest readings", "error", err)
-		c.JSON(http.StatusInternalServerError, gin.H{"message": "Error fetching latest readings"})
-		return
-	}
-
+	// Register the connection first, then serve the snapshot from the in-memory store.
+	// This keeps the toggle's critical path off SQLite entirely, so a connecting client
+	// gets current state immediately instead of waiting on a contended query.
 	createPushWebSocket(c, "current-readings")
 
-	ws.BroadcastToTopic("current-readings", currentReadings)
+	ws.BroadcastToTopic("current-readings", ws.CurrentReadingsSnapshot())
 }

--- a/sensor_hub/cmd/serve.go
+++ b/sensor_hub/cmd/serve.go
@@ -121,6 +121,14 @@ func runServe(cmd *cobra.Command, args []string) error {
 	maintenanceRepo := database.NewMaintenanceRepository(db)
 
 	readingsService := service.NewReadingsService(readingsRepo, mtRepo, aggregationTiers, appProps.AppConfig.ReadingsAggregationEnabled, logger)
+
+	// Seed the in-memory current-readings store so a freshly started server serves
+	// correct toggle/sensor state on connect without a database query.
+	if latest, err := readingsService.ServiceGetLatest(ctx); err != nil {
+		logger.Warn("failed to seed current-readings store", "error", err)
+	} else {
+		ws.SeedReadings(latest)
+	}
 	propertiesService := service.NewPropertiesService(logger)
 	cleanupService := service.NewCleanupService(sensorRepo, readingsRepo, failedRepo, notificationRepo, alertRepo, maintenanceRepo, logger)
 

--- a/sensor_hub/db/migrations/000020_drop_redundant_readings_index.down.sql
+++ b/sensor_hub/db/migrations/000020_drop_redundant_readings_index.down.sql
@@ -1,0 +1,2 @@
+-- Restore the redundant single-column sensor_id index dropped by the up-migration.
+CREATE INDEX IF NOT EXISTS idx_readings_sensor_id ON readings (sensor_id);

--- a/sensor_hub/db/migrations/000020_drop_redundant_readings_index.up.sql
+++ b/sensor_hub/db/migrations/000020_drop_redundant_readings_index.up.sql
@@ -1,0 +1,11 @@
+-- Migration 000020: readings index hygiene
+--
+-- idx_readings_sensor_id (sensor_id) is the leftmost prefix of
+-- idx_readings_sensor_type_time (sensor_id, measurement_type_id, time DESC), so it
+-- adds no read value and only amplifies insert cost on the high-frequency ingest
+-- path. Drop it.
+--
+-- idx_readings_time_asc (time ASC) is intentionally kept: EXPLAIN QUERY PLAN on the
+-- live database confirmed the global retention delete
+-- (DELETE FROM readings WHERE time < ?) uses it.
+DROP INDEX IF EXISTS idx_readings_sensor_id;

--- a/sensor_hub/db/readings_index_migration_test.go
+++ b/sensor_hub/db/readings_index_migration_test.go
@@ -1,0 +1,45 @@
+package database
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func indexNames(t *testing.T, db *sql.DB, table string) []string {
+	t.Helper()
+	rows, err := db.Query("SELECT name FROM sqlite_master WHERE type='index' AND tbl_name = ?", table)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var names []string
+	for rows.Next() {
+		var n string
+		require.NoError(t, rows.Scan(&n))
+		names = append(names, n)
+	}
+	require.NoError(t, rows.Err())
+	return names
+}
+
+func TestMigration20_DropsRedundantSensorIndexKeepsRest(t *testing.T) {
+	db := newInMemoryDB(t)
+	require.NoError(t, newTestMigrator(t, db).Migrate(20))
+
+	indexes := indexNames(t, db, "readings")
+	assert.NotContains(t, indexes, "idx_readings_sensor_id", "redundant prefix index is dropped")
+	assert.Contains(t, indexes, "idx_readings_sensor_type_time", "composite index retained")
+	assert.Contains(t, indexes, "idx_readings_time_asc", "ASC time index retained (retention delete uses it)")
+	assert.Contains(t, indexes, "idx_readings_time", "DESC time index retained")
+}
+
+func TestMigration20_DownRestoresSensorIndex(t *testing.T) {
+	db := newInMemoryDB(t)
+	m := newTestMigrator(t, db)
+	require.NoError(t, m.Migrate(20))
+	require.NoError(t, m.Migrate(19))
+
+	assert.Contains(t, indexNames(t, db, "readings"), "idx_readings_sensor_id", "down migration restores the index")
+}

--- a/sensor_hub/db/readings_repository.go
+++ b/sensor_hub/db/readings_repository.go
@@ -3,6 +3,7 @@ package database
 import (
 	"context"
 	"database/sql"
+	"errors"
 	gen "example/sensorHub/gen"
 	"example/sensorHub/utils"
 	"fmt"
@@ -56,30 +57,62 @@ func (r *ReadingsRepositoryImpl) GetBetweenDates(ctx context.Context, startDate,
 	return r.getAggregatedBetweenDates(ctx, startDate, endDate, sensorName, measurementType, interval, aggFunc)
 }
 
-func (r *ReadingsRepositoryImpl) getRawBetweenDates(ctx context.Context, startDate, endDate, sensorName, measurementType string) ([]gen.Reading, error) {
-	query := fmt.Sprintf(`
+// seriesFilter resolves the optional sensor/measurement names to ids and returns an
+// id-based WHERE fragment (plus its bind args). Filtering on r.sensor_id /
+// r.measurement_type_id lets the (sensor_id, measurement_type_id, time DESC) composite
+// index serve the query, instead of a full-table scan filtered by joined names.
+// resolved is false when a provided name does not exist, signalling the caller to return
+// an empty result (matching the prior LOWER(name) behaviour). Resolution is
+// case-insensitive, as before.
+func (r *ReadingsRepositoryImpl) seriesFilter(ctx context.Context, sensorName, measurementType string) (clause string, args []any, resolved bool, err error) {
+	if sensorName != "" {
+		id, e := r.resolveSensorID(ctx, sensorName)
+		if errors.Is(e, sql.ErrNoRows) {
+			return "", nil, false, nil
+		}
+		if e != nil {
+			return "", nil, false, e
+		}
+		clause += " AND r.sensor_id = ?"
+		args = append(args, id)
+	}
+	if measurementType != "" {
+		id, e := r.resolveMeasurementTypeID(ctx, measurementType)
+		if errors.Is(e, sql.ErrNoRows) {
+			return "", nil, false, nil
+		}
+		if e != nil {
+			return "", nil, false, e
+		}
+		clause += " AND r.measurement_type_id = ?"
+		args = append(args, id)
+	}
+	return clause, args, true, nil
+}
+
+func rawBetweenQuery(seriesClause string) string {
+	return fmt.Sprintf(`
 		SELECT r.id, s.name, mt.name, r.numeric_value, r.text_state, COALESCE(smt.unit, mt.default_unit), r.time
 		FROM %s r
 		JOIN sensors s ON r.sensor_id = s.id
 		JOIN %s mt ON r.measurement_type_id = mt.id
 		LEFT JOIN %s smt ON smt.sensor_id = s.id AND smt.measurement_type_id = mt.id
-		WHERE r.time BETWEEN ? AND ?
-	`, TableReadings, TableMeasurementTypes, TableSensorMeasurementTypes)
+		WHERE r.time BETWEEN ? AND ?%s
+		ORDER BY r.time ASC
+	`, TableReadings, TableMeasurementTypes, TableSensorMeasurementTypes, seriesClause)
+}
 
-	args := []any{startDate, endDate}
-
-	if sensorName != "" {
-		query += " AND LOWER(s.name) = LOWER(?)"
-		args = append(args, sensorName)
+func (r *ReadingsRepositoryImpl) getRawBetweenDates(ctx context.Context, startDate, endDate, sensorName, measurementType string) ([]gen.Reading, error) {
+	clause, filterArgs, resolved, err := r.seriesFilter(ctx, sensorName, measurementType)
+	if err != nil {
+		return nil, fmt.Errorf("error resolving readings filter: %w", err)
 	}
-	if measurementType != "" {
-		query += " AND LOWER(mt.name) = LOWER(?)"
-		args = append(args, measurementType)
+	if !resolved {
+		return nil, nil
 	}
 
-	query += " ORDER BY r.time ASC"
-
-	rows, err := r.db.QueryContext(ctx, query, args...)
+	args := append([]any{startDate, endDate}, filterArgs...)
+	rows, err := r.db.QueryContext(ctx, rawBetweenQuery(clause), args...)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching readings between %s and %s: %w", startDate, endDate, err)
 	}
@@ -103,29 +136,16 @@ func (r *ReadingsRepositoryImpl) getAggregatedBetweenDates(ctx context.Context, 
 		sqlAgg = "COUNT(*)"
 	}
 
-	query := fmt.Sprintf(`
-		SELECT 0 AS id, s.name, mt.name, %s, NULL, COALESCE(smt.unit, mt.default_unit), %s AS bucket_time
-		FROM %s r
-		JOIN sensors s ON r.sensor_id = s.id
-		JOIN %s mt ON r.measurement_type_id = mt.id
-		LEFT JOIN %s smt ON smt.sensor_id = s.id AND smt.measurement_type_id = mt.id
-		WHERE r.time BETWEEN ? AND ?
-	`, sqlAgg, bucket, TableReadings, TableMeasurementTypes, TableSensorMeasurementTypes)
-
-	args := []any{startDate, endDate}
-
-	if sensorName != "" {
-		query += " AND LOWER(s.name) = LOWER(?)"
-		args = append(args, sensorName)
+	clause, filterArgs, resolved, err := r.seriesFilter(ctx, sensorName, measurementType)
+	if err != nil {
+		return nil, fmt.Errorf("error resolving readings filter: %w", err)
 	}
-	if measurementType != "" {
-		query += " AND LOWER(mt.name) = LOWER(?)"
-		args = append(args, measurementType)
+	if !resolved {
+		return nil, nil
 	}
 
-	query += fmt.Sprintf(" GROUP BY s.name, mt.name, bucket_time ORDER BY bucket_time ASC")
-
-	rows, err := r.db.QueryContext(ctx, query, args...)
+	args := append([]any{startDate, endDate}, filterArgs...)
+	rows, err := r.db.QueryContext(ctx, aggregatedBetweenQuery(sqlAgg, bucket, clause), args...)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching aggregated readings between %s and %s: %w", startDate, endDate, err)
 	}
@@ -134,35 +154,46 @@ func (r *ReadingsRepositoryImpl) getAggregatedBetweenDates(ctx context.Context, 
 	return scanReadings(rows)
 }
 
-func (r *ReadingsRepositoryImpl) getLastBetweenDates(ctx context.Context, startDate, endDate, sensorName, measurementType, bucket string) ([]gen.Reading, error) {
-	query := fmt.Sprintf(`
+func aggregatedBetweenQuery(sqlAgg, bucket, seriesClause string) string {
+	return fmt.Sprintf(`
+		SELECT 0 AS id, s.name, mt.name, %s, NULL, COALESCE(smt.unit, mt.default_unit), %s AS bucket_time
+		FROM %s r
+		JOIN sensors s ON r.sensor_id = s.id
+		JOIN %s mt ON r.measurement_type_id = mt.id
+		LEFT JOIN %s smt ON smt.sensor_id = s.id AND smt.measurement_type_id = mt.id
+		WHERE r.time BETWEEN ? AND ?%s
+		GROUP BY s.name, mt.name, bucket_time ORDER BY bucket_time ASC
+	`, sqlAgg, bucket, TableReadings, TableMeasurementTypes, TableSensorMeasurementTypes, seriesClause)
+}
+
+func lastBetweenQuery(bucket, seriesClause string) string {
+	return fmt.Sprintf(`
 		SELECT sub.id, sub.sensor_name, sub.measurement_type, sub.numeric_value, sub.text_state, sub.unit, sub.bucket_time
 		FROM (
 			SELECT r.id, s.name AS sensor_name, mt.name AS measurement_type,
 				r.numeric_value, r.text_state, COALESCE(smt.unit, mt.default_unit) AS unit,
 				%s AS bucket_time,
-				ROW_NUMBER() OVER (PARTITION BY s.name, mt.name, %s ORDER BY r.time DESC) AS rn
+				ROW_NUMBER() OVER (PARTITION BY r.sensor_id, r.measurement_type_id, %s ORDER BY r.time DESC) AS rn
 			FROM %s r
 			JOIN sensors s ON r.sensor_id = s.id
 			JOIN %s mt ON r.measurement_type_id = mt.id
 			LEFT JOIN %s smt ON smt.sensor_id = s.id AND smt.measurement_type_id = mt.id
-			WHERE r.time BETWEEN ? AND ?
-	`, bucket, bucket, TableReadings, TableMeasurementTypes, TableSensorMeasurementTypes)
+			WHERE r.time BETWEEN ? AND ?%s
+		) sub WHERE sub.rn = 1 ORDER BY sub.bucket_time ASC
+	`, bucket, bucket, TableReadings, TableMeasurementTypes, TableSensorMeasurementTypes, seriesClause)
+}
 
-	args := []any{startDate, endDate}
-
-	if sensorName != "" {
-		query += " AND LOWER(s.name) = LOWER(?)"
-		args = append(args, sensorName)
+func (r *ReadingsRepositoryImpl) getLastBetweenDates(ctx context.Context, startDate, endDate, sensorName, measurementType, bucket string) ([]gen.Reading, error) {
+	clause, filterArgs, resolved, err := r.seriesFilter(ctx, sensorName, measurementType)
+	if err != nil {
+		return nil, fmt.Errorf("error resolving readings filter: %w", err)
 	}
-	if measurementType != "" {
-		query += " AND LOWER(mt.name) = LOWER(?)"
-		args = append(args, measurementType)
+	if !resolved {
+		return nil, nil
 	}
 
-	query += ") sub WHERE sub.rn = 1 ORDER BY sub.bucket_time ASC"
-
-	rows, err := r.db.QueryContext(ctx, query, args...)
+	args := append([]any{startDate, endDate}, filterArgs...)
+	rows, err := r.db.QueryContext(ctx, lastBetweenQuery(bucket, clause), args...)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching last-value readings between %s and %s: %w", startDate, endDate, err)
 	}

--- a/sensor_hub/db/readings_repository_query_test.go
+++ b/sensor_hub/db/readings_repository_query_test.go
@@ -1,0 +1,133 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"log/slog"
+	"strings"
+	"testing"
+
+	gen "example/sensorHub/gen"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// migratedReadingsRepo returns a repository backed by a fully-migrated in-memory
+// database with one sensor present, so name->id resolution works in queries.
+func migratedReadingsRepo(t *testing.T) (*ReadingsRepositoryImpl, *sql.DB) {
+	t.Helper()
+	db := newInMemoryDB(t)
+	require.NoError(t, newTestMigrator(t, db).Migrate(19))
+
+	ctx := context.Background()
+	require.NoError(t, NewSensorRepository(db, slog.Default()).AddSensor(ctx, gen.Sensor{
+		Name:         "Office",
+		SensorDriver: "sensor-hub-http-temperature",
+	}))
+
+	repo := NewReadingsRepository(db, slog.Default()).(*ReadingsRepositoryImpl)
+	return repo, db
+}
+
+// queryPlan runs EXPLAIN QUERY PLAN and returns the concatenated detail lines.
+func queryPlan(t *testing.T, db *sql.DB, query string, args ...any) string {
+	t.Helper()
+	rows, err := db.Query("EXPLAIN QUERY PLAN "+query, args...)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var sb strings.Builder
+	for rows.Next() {
+		var id, parent, notused int
+		var detail string
+		require.NoError(t, rows.Scan(&id, &parent, &notused, &detail))
+		sb.WriteString(detail)
+		sb.WriteString("\n")
+	}
+	require.NoError(t, rows.Err())
+	return sb.String()
+}
+
+func TestRawBetweenQuery_UsesCompositeIndex(t *testing.T) {
+	repo, db := migratedReadingsRepo(t)
+	ctx := context.Background()
+
+	clause, filterArgs, resolved, err := repo.seriesFilter(ctx, "Office", "temperature")
+	require.NoError(t, err)
+	require.True(t, resolved)
+
+	args := append([]any{"2025-01-01 00:00:00", "2025-02-01 00:00:00"}, filterArgs...)
+	plan := queryPlan(t, db, rawBetweenQuery(clause), args...)
+
+	assert.Contains(t, plan, "idx_readings_sensor_type_time", "should use the composite index")
+	assert.NotContains(t, plan, "SCAN readings", "should not full-scan the readings table")
+}
+
+func TestAggregatedBetweenQuery_UsesCompositeIndex(t *testing.T) {
+	repo, db := migratedReadingsRepo(t)
+	ctx := context.Background()
+
+	clause, filterArgs, resolved, err := repo.seriesFilter(ctx, "Office", "temperature")
+	require.NoError(t, err)
+	require.True(t, resolved)
+
+	bucket, err := timeBucketExpression(AggregationPT1H)
+	require.NoError(t, err)
+
+	args := append([]any{"2025-01-01 00:00:00", "2025-02-01 00:00:00"}, filterArgs...)
+	plan := queryPlan(t, db, aggregatedBetweenQuery("ROUND(AVG(r.numeric_value), 2)", bucket, clause), args...)
+
+	assert.Contains(t, plan, "idx_readings_sensor_type_time", "should use the composite index")
+	assert.NotContains(t, plan, "SCAN readings", "should not full-scan the readings table")
+}
+
+func TestLastBetweenQuery_UsesCompositeIndex(t *testing.T) {
+	repo, db := migratedReadingsRepo(t)
+	ctx := context.Background()
+
+	clause, filterArgs, resolved, err := repo.seriesFilter(ctx, "Office", "temperature")
+	require.NoError(t, err)
+	require.True(t, resolved)
+
+	bucket, err := timeBucketExpression(AggregationPT1H)
+	require.NoError(t, err)
+
+	args := append([]any{"2025-01-01 00:00:00", "2025-02-01 00:00:00"}, filterArgs...)
+	plan := queryPlan(t, db, lastBetweenQuery(bucket, clause), args...)
+
+	assert.Contains(t, plan, "idx_readings_sensor_type_time", "should use the composite index")
+	assert.NotContains(t, plan, "SCAN readings", "should not full-scan the readings table")
+}
+
+func TestGetBetweenDates_Raw_FiltersBySensorCaseInsensitively(t *testing.T) {
+	repo, _ := migratedReadingsRepo(t) // seeds sensor "Office"
+	ctx := context.Background()
+	require.NoError(t, NewSensorRepository(db(repo), slog.Default()).AddSensor(ctx, gen.Sensor{
+		Name:         "Attic",
+		SensorDriver: "sensor-hub-http-temperature",
+	}))
+
+	v := 21.0
+	require.NoError(t, repo.Add(ctx, []gen.Reading{
+		{SensorName: "Office", MeasurementType: "temperature", NumericValue: &v, Time: "2025-01-15 12:00:00"},
+		{SensorName: "Attic", MeasurementType: "temperature", NumericValue: &v, Time: "2025-01-15 12:00:00"},
+	}))
+
+	got, err := repo.GetBetweenDates(ctx, "2025-01-01 00:00:00", "2025-02-01 00:00:00", "office", "temperature", AggregationRaw, "")
+	require.NoError(t, err)
+	require.Len(t, got, 1, "filters to the one matching sensor")
+	assert.Equal(t, "Office", got[0].SensorName, "case-insensitive name match")
+}
+
+func TestGetBetweenDates_Raw_UnknownSensorReturnsEmpty(t *testing.T) {
+	repo, _ := migratedReadingsRepo(t)
+	ctx := context.Background()
+
+	got, err := repo.GetBetweenDates(ctx, "2025-01-01 00:00:00", "2025-02-01 00:00:00", "does-not-exist", "temperature", AggregationRaw, "")
+	require.NoError(t, err, "unknown sensor is not an error")
+	assert.Empty(t, got, "unknown sensor yields no readings")
+}
+
+// db exposes the repository's underlying *sql.DB for test setup.
+func db(r *ReadingsRepositoryImpl) *sql.DB { return r.db }

--- a/sensor_hub/service/sensor_service.go
+++ b/sensor_hub/service/sensor_service.go
@@ -295,7 +295,7 @@ func (s *SensorService) ServiceCollectAndStoreAllSensorReadings(ctx context.Cont
 			}
 		}
 	}
-	ws.BroadcastToTopic("current-readings", allReadings)
+	ws.PublishReadings(allReadings)
 	return nil
 }
 
@@ -355,7 +355,7 @@ func (s *SensorService) ServiceCollectFromSensorByName(ctx context.Context, sens
 		span.SetAttributes(attribute.Int("readings.count", len(readings)))
 		s.ServiceUpdateSensorHealthById(ctx, sensor.Id, gen.Good, "successful reading")
 		s.logger.Debug("collected readings", "sensor", sensorName, "count", len(readings))
-		ws.BroadcastToTopic("current-readings", readings)
+		ws.PublishReadings(readings)
 
 		// Process alerts for each reading
 		for _, reading := range readings {
@@ -632,7 +632,7 @@ func (s *SensorService) ServiceProcessPushReadings(ctx context.Context, sensor g
 	}
 
 	// Broadcast
-	ws.BroadcastToTopic("current-readings", readings)
+	ws.PublishReadings(readings)
 
 	return nil
 }

--- a/sensor_hub/ws/readings_store.go
+++ b/sensor_hub/ws/readings_store.go
@@ -1,0 +1,76 @@
+package ws
+
+import (
+	"sync"
+
+	gen "example/sensorHub/gen"
+)
+
+// ReadingsStore holds the latest reading per (sensorName, measurementType) series,
+// last-write-wins. It is the authoritative source for the current-readings connect
+// snapshot, so a client connecting never needs a database query to learn current state.
+type ReadingsStore struct {
+	mu     sync.RWMutex
+	latest map[string]map[string]gen.Reading
+}
+
+func NewReadingsStore() *ReadingsStore {
+	return &ReadingsStore{latest: make(map[string]map[string]gen.Reading)}
+}
+
+// Update records each reading as the latest value for its series.
+func (s *ReadingsStore) Update(readings []gen.Reading) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, reading := range readings {
+		byType, ok := s.latest[reading.SensorName]
+		if !ok {
+			byType = make(map[string]gen.Reading)
+			s.latest[reading.SensorName] = byType
+		}
+		byType[reading.MeasurementType] = reading
+	}
+}
+
+// Snapshot returns the current latest reading for every known series.
+func (s *ReadingsStore) Snapshot() []gen.Reading {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]gen.Reading, 0)
+	for _, byType := range s.latest {
+		for _, reading := range byType {
+			out = append(out, reading)
+		}
+	}
+	return out
+}
+
+// currentReadingsTopic is the websocket topic carrying live reading updates and the
+// connect snapshot.
+const currentReadingsTopic = "current-readings"
+
+// DefaultReadingsStore backs the application-wide current-readings snapshot.
+var DefaultReadingsStore = NewReadingsStore()
+
+// PublishReadings is the single entry point for emitting readings: it updates the
+// in-memory store and broadcasts to the current-readings topic in one step, so the
+// snapshot served on connect can never drift from the live stream. Only actual
+// readings flow through here; non-reading messages (e.g. command status) broadcast
+// directly via BroadcastToTopic and must not touch the store.
+func PublishReadings(readings []gen.Reading) {
+	DefaultReadingsStore.Update(readings)
+	BroadcastToTopic(currentReadingsTopic, readings)
+}
+
+// CurrentReadingsSnapshot returns the latest readings held in memory, for serving
+// to a freshly-connected client without a database query.
+func CurrentReadingsSnapshot() []gen.Reading {
+	return DefaultReadingsStore.Snapshot()
+}
+
+// SeedReadings primes the store at startup (e.g. from the database) so a freshly
+// started server serves correct state before any new readings flow. It does not
+// broadcast, since there are no clients to notify yet.
+func SeedReadings(readings []gen.Reading) {
+	DefaultReadingsStore.Update(readings)
+}

--- a/sensor_hub/ws/readings_store_test.go
+++ b/sensor_hub/ws/readings_store_test.go
@@ -1,0 +1,102 @@
+package ws
+
+import (
+	"testing"
+	"time"
+
+	gen "example/sensorHub/gen"
+
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+)
+
+func numericReading(sensor, measurementType string, value float64, ts string) gen.Reading {
+	v := value
+	return gen.Reading{SensorName: sensor, MeasurementType: measurementType, NumericValue: &v, Time: ts}
+}
+
+func snapshotBySeries(readings []gen.Reading) map[string]gen.Reading {
+	out := make(map[string]gen.Reading, len(readings))
+	for _, r := range readings {
+		out[r.SensorName+"/"+r.MeasurementType] = r
+	}
+	return out
+}
+
+func TestReadingsStore_Snapshot_ReturnsLatestPerSeriesLastWriteWins(t *testing.T) {
+	store := NewReadingsStore()
+
+	store.Update([]gen.Reading{
+		numericReading("office-plug", "power", 10, "2025-01-01T00:00:00Z"),
+		numericReading("office-plug", "power", 20, "2025-01-01T00:01:00Z"), // newer for same series
+		numericReading("attic", "temperature", 5, "2025-01-01T00:00:00Z"),
+	})
+
+	snap := store.Snapshot()
+	assert.Len(t, snap, 2, "one entry per (sensor, measurement type) series")
+
+	bySeries := snapshotBySeries(snap)
+	assert.Equal(t, 20.0, *bySeries["office-plug/power"].NumericValue, "later write wins")
+	assert.Equal(t, 5.0, *bySeries["attic/temperature"].NumericValue)
+}
+
+// registerSubscriber wires a connection into DefaultHub subscribed to the given topic,
+// returning its send channel and a cleanup func. Mirrors the pattern in hub_test.go.
+func registerSubscriber(topic string) (chan any, func()) {
+	conn := &websocket.Conn{}
+	send := make(chan any, 16)
+	DefaultHub.mu.Lock()
+	DefaultHub.conns[conn] = &connInfo{conn: conn, send: send, topics: map[string]bool{topic: true}}
+	DefaultHub.mu.Unlock()
+	return send, func() {
+		DefaultHub.mu.Lock()
+		delete(DefaultHub.conns, conn)
+		DefaultHub.mu.Unlock()
+	}
+}
+
+func TestPublishReadings_UpdatesStoreAndBroadcasts(t *testing.T) {
+	send, cleanup := registerSubscriber("current-readings")
+	defer cleanup()
+
+	readings := []gen.Reading{numericReading("office-plug", "power", 42, "2025-01-01T00:00:00Z")}
+	PublishReadings(readings)
+
+	select {
+	case msg := <-send:
+		assert.Equal(t, readings, msg, "subscriber receives the published readings")
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("expected broadcast to current-readings subscriber")
+	}
+
+	bySeries := snapshotBySeries(CurrentReadingsSnapshot())
+	if assert.Contains(t, bySeries, "office-plug/power", "store reflects published reading") {
+		assert.Equal(t, 42.0, *bySeries["office-plug/power"].NumericValue)
+	}
+}
+
+func TestBroadcastToTopic_DoesNotUpdateReadingsStore(t *testing.T) {
+	// Command-status messages are broadcast straight to current-readings; they are not
+	// readings and must never appear in the snapshot store.
+	before := len(CurrentReadingsSnapshot())
+
+	BroadcastToTopic("current-readings", map[string]any{"type": "command_status", "id": 1})
+
+	assert.Equal(t, before, len(CurrentReadingsSnapshot()), "non-reading broadcast must not change the store")
+}
+
+func TestSeedReadings_PrimesStoreWithoutBroadcasting(t *testing.T) {
+	send, cleanup := registerSubscriber("current-readings")
+	defer cleanup()
+
+	SeedReadings([]gen.Reading{numericReading("attic-bulb", "state", 1, "2025-01-01T00:00:00Z")})
+
+	bySeries := snapshotBySeries(CurrentReadingsSnapshot())
+	assert.Contains(t, bySeries, "attic-bulb/state", "seed populates the store")
+
+	select {
+	case msg := <-send:
+		t.Fatalf("seeding must not broadcast, got %v", msg)
+	case <-time.After(50 * time.Millisecond):
+	}
+}


### PR DESCRIPTION
Implements the design in #214 across three commits, one per planned slice.

Controllable toggles took 1-2s to become usable on first load. Investigation found the WebSocket was not at fault - it pushes the state snapshot the instant the connection registers. The delay was the snapshot's full-table window query (`ServiceGetLatest`) contending with the dashboard's chart-query burst on single-threaded SQLite. This PR removes the toggle from that contention window and also makes the readings pipeline cheaper on both reads and writes.

## Commits

### 1. `feat(ws)`: serve current-readings snapshot from in-memory store — closes #215
- New authoritative in-memory `ReadingsStore` (latest reading per `sensor/measurement` series, last-write-wins).
- Single `PublishReadings` entry point updates the store **and** broadcasts in one step, so the cache and the live `current-readings` stream can't drift. The three reading-broadcast sites route through it; command-status broadcasts stay on plain `BroadcastToTopic` and never touch the store.
- Store is seeded once at startup from the DB.
- `SubscribeCurrentReadings` now registers the connection first, then serves the snapshot from memory — **no SQLite on the toggle's critical path**.

### 2. `perf(db)`: filter readings queries by id to use the composite index — closes #216
- The between-queries filtered by `LOWER(s.name)`/`LOWER(mt.name)` after the join, so `idx_readings_sensor_type_time (sensor_id, measurement_type_id, time DESC)` was unreachable and SQLite range-scanned every sensor's rows in the window.
- A shared `seriesFilter` helper resolves names to ids (case-insensitive, as before) and filters on `r.sensor_id`/`r.measurement_type_id`, across the raw, aggregated, and last-value paths; the last-value window now partitions by id too.
- `EXPLAIN QUERY PLAN` tests against a fully-migrated schema confirm each query uses the composite index and no longer full-scans `readings`. Unknown names still return an empty result, not an error.

### 3. `perf(db)`: drop redundant `idx_readings_sensor_id` (migration 000020) — closes #217
- `idx_readings_sensor_id` is the leftmost prefix of the composite index — no read value, pure insert overhead on the hot ingest path. Dropped.
- `idx_readings_time_asc` is **kept**: `EXPLAIN QUERY PLAN` on the live DB (recorded in #217) confirmed the global retention delete (`DELETE FROM readings WHERE time < ?`) uses it, so it is not redundant. The down-migration restores the dropped index.

## Why the two workstreams reinforce each other
Commit 2 makes chart **reads** cheaper; commit 3 makes ingest **writes** cheaper. Both shrink the SQLite contention window — the same root cause behind the toggle delay. Commit 1 removes the toggle from that window entirely.

## Testing
- TDD throughout (red → green per behavior). New unit tests: `ws` store/publish/seed; `db` `EXPLAIN QUERY PLAN` index-usage tests and behavior guards; migration up/down tests.
- Full unit suite passes; `go vet` clean.
- Integration suite passes after each slice: `cd sensor_hub && go test -tags integration -v -timeout 300s ./integration/`.

## Notes
- Live data measured on the Pi during design: ~250k readings, `office-plug` alone 161k (~65%).
- Out of scope (deferred): the WebSocket auth gate (`enabled: user != null` → `/auth/me`) and index audits of non-readings tables.

Closes #215, closes #216, closes #217.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
