### PR TITLE
Animated loading states for dashboard widgets (the "Incoming" family)

### DIFF
--- a/sensor_hub/ui/sensor_hub_ui/src/components/CurrentTemperatures.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/components/CurrentTemperatures.tsx
@@ -6,6 +6,7 @@ import { useIsMobile } from "../hooks/useMobile";
 import { useSensorContext } from "../hooks/useSensorContext";
 import EmptyState from "./EmptyState";
 import ThermostatOutlinedIcon from "@mui/icons-material/ThermostatOutlined";
+import { CascadeRowsLoader } from "../dashboard/widget-loaders";
 
 interface CurrentTemperaturesProps {
   cardHeight?: string | number;
@@ -68,7 +69,9 @@ function CurrentTemperatures({ cardHeight, showTitle = true, onDataUpdate }: Cur
           width: "100%"
         }}
       >
-        {loaded && rows.length === 0 ? (
+        {!loaded ? (
+          <CascadeRowsLoader />
+        ) : rows.length === 0 ? (
           <EmptyState
             icon={<ThermostatOutlinedIcon sx={{ fontSize: 48 }} />}
             title="No live temperature data"
@@ -95,7 +98,6 @@ function CurrentTemperatures({ cardHeight, showTitle = true, onDataUpdate }: Cur
               '& .MuiDataGrid-cell': { fontSize: isMobile ? '0.9rem' : '1rem' },
               '& .MuiDataGrid-columnHeaders': { fontWeight: 'bold' },
             }}
-            loading={!loaded}
           />
         )}
       </div>

--- a/sensor_hub/ui/sensor_hub_ui/src/components/NotificationsCard.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/components/NotificationsCard.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
-import { Box, Typography, Button, Chip, IconButton, Menu, MenuItem, CircularProgress, Card, CardContent, Divider, Tabs, Tab } from '@mui/material';
+import { Box, Typography, Button, Chip, IconButton, Menu, MenuItem, Card, CardContent, Divider, Tabs, Tab } from '@mui/material';
+import { CascadeRowsLoader } from '../dashboard/widget-loaders';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import InfoIcon from '@mui/icons-material/Info';
 import WarningIcon from '@mui/icons-material/Warning';
@@ -99,12 +100,7 @@ export default function NotificationsCard({ showTitle = true }: { showTitle?: bo
         <Tab label={`All (${notifications.length})`} />
       </Tabs>
       {loading ? (
-        <Box
-          sx={{
-            display: "flex",
-            justifyContent: "center",
-            p: 4
-          }}><CircularProgress /></Box>
+        <Box sx={{ flex: 1, minHeight: 0 }}><CascadeRowsLoader /></Box>
       ) : filteredNotifications.length === 0 ? (
         <Box
           sx={{

--- a/sensor_hub/ui/sensor_hub_ui/src/components/ReadingsChart.test.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/components/ReadingsChart.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Sensor } from '../gen/aliases';
+import ReadingsChart from './ReadingsChart';
+
+const { readingsDataMock } = vi.hoisted(() => ({ readingsDataMock: vi.fn() }));
+
+vi.mock('../hooks/useReadingsData', () => ({
+  useReadingsData: () => readingsDataMock(),
+}));
+
+vi.mock('../theme/chartColours', () => ({
+  useChartColours: () => ({
+    categorical: ['#D4451A', '#0288D1'],
+    health: ['', '', ''],
+    stat: ['', '', ''],
+    grid: '#D9D0C7',
+    axisText: '#5C5C5C',
+    noData: '#E0D8D0',
+  }),
+}));
+
+function makeSensor(overrides: Partial<Sensor> = {}): Sensor {
+  return {
+    id: 1,
+    name: 'living-room',
+    external_id: 'lr',
+    sensor_driver: 'zigbee2mqtt',
+    config: {},
+    metadata: {},
+    health_status: 'good',
+    health_reason: 'ok',
+    enabled: true,
+    status: 'active',
+    retention_hours: null,
+    ...overrides,
+  };
+}
+
+function renderChart() {
+  return render(
+    <MemoryRouter>
+      <ReadingsChart sensors={[makeSensor()]} startDate={null} endDate={null} measurementType="temperature" />
+    </MemoryRouter>,
+  );
+}
+
+describe('ReadingsChart loading states', () => {
+  beforeEach(() => {
+    readingsDataMock.mockReset();
+  });
+
+  it('shows the signal-trace loader while the first fetch is in flight', () => {
+    readingsDataMock.mockReturnValue({ mergedData: [], aggregation: { interval: 'raw', function: 'none' }, isLoading: true, error: null });
+
+    renderChart();
+
+    expect(screen.getByTestId('widget-loader')).toBeInTheDocument();
+    expect(screen.queryByText('No readings in selected date range')).not.toBeInTheDocument();
+  });
+
+  it('shows the chart (no loader, no empty state) once data has arrived', () => {
+    readingsDataMock.mockReturnValue({
+      mergedData: [{ time: '2026-05-09T10:00:00Z', 'living-room': 21 }],
+      aggregation: { interval: 'raw', function: 'none' },
+      isLoading: false,
+      error: null,
+    });
+
+    renderChart();
+
+    expect(screen.queryByTestId('widget-loader')).not.toBeInTheDocument();
+    expect(screen.queryByText('No readings in selected date range')).not.toBeInTheDocument();
+  });
+
+  it('shows the empty state once loaded with no readings', () => {
+    readingsDataMock.mockReturnValue({ mergedData: [], aggregation: { interval: 'raw', function: 'none' }, isLoading: false, error: null });
+
+    renderChart();
+
+    expect(screen.queryByTestId('widget-loader')).not.toBeInTheDocument();
+    expect(screen.getByText('No readings in selected date range')).toBeInTheDocument();
+  });
+
+  it('shows an error empty state when the fetch failed with no data', () => {
+    readingsDataMock.mockReturnValue({ mergedData: [], aggregation: { interval: 'raw', function: 'none' }, isLoading: false, error: 'boom' });
+
+    renderChart();
+
+    expect(screen.getByText("Couldn't load readings")).toBeInTheDocument();
+  });
+});

--- a/sensor_hub/ui/sensor_hub_ui/src/components/ReadingsChart.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/components/ReadingsChart.tsx
@@ -22,6 +22,7 @@ import type { DateTime } from "luxon";
 import EmptyState from "./EmptyState";
 import ShowChartOutlinedIcon from "@mui/icons-material/ShowChartOutlined";
 import { useChartColours } from "../theme/chartColours";
+import { WidgetSwap, SignalTraceLoader } from "../dashboard/widget-loaders";
 
 const ReadingsChart = React.memo(function ReadingsChart({
   sensors,
@@ -49,7 +50,7 @@ const ReadingsChart = React.memo(function ReadingsChart({
 
   const [linesHidden, setLinesHidden] = useReducer(linesHiddenReducer, {});
 
-  const { mergedData: chartData } = useReadingsData({
+  const { mergedData: chartData, isLoading, error } = useReadingsData({
     startDate: startDate ? startDate : null,
     endDate: endDate ? endDate : null,
     sensors,
@@ -59,6 +60,10 @@ const ReadingsChart = React.memo(function ReadingsChart({
     resolveTimeRange,
     onDataUpdate,
   });
+
+  const noData = !Array.isArray(chartData) || chartData.length === 0;
+  // Show the loader only on the first load when we have sensors but no data yet.
+  const loading = sensors.length > 0 && isLoading && noData;
 
   // Only include sensors that have at least one non-null data point
   const activeSensors = useMemo(() => {
@@ -96,6 +101,7 @@ const ReadingsChart = React.memo(function ReadingsChart({
 
   return (
     <div data-testid="readings-chart" style={{ ...graphContainerStyle, flex: 1, minHeight: 0, position: 'relative' }}>
+      <WidgetSwap loading={loading} loader={<SignalTraceLoader />}>
       {sensors.length === 0 ? (
         <EmptyState
           icon={<ShowChartOutlinedIcon sx={{ fontSize: 48 }} />}
@@ -105,7 +111,14 @@ const ReadingsChart = React.memo(function ReadingsChart({
           actionHref="/sensors-overview"
           minHeight={200}
         />
-      ) : !Array.isArray(chartData) || chartData.length === 0 ? (
+      ) : error && noData ? (
+        <EmptyState
+          icon={<ShowChartOutlinedIcon sx={{ fontSize: 48 }} />}
+          title="Couldn't load readings"
+          description="Something went wrong fetching this chart. It will retry automatically."
+          minHeight={200}
+        />
+      ) : noData ? (
         <EmptyState
           icon={<ShowChartOutlinedIcon sx={{ fontSize: 48 }} />}
           title="No readings in selected date range"
@@ -172,6 +185,7 @@ const ReadingsChart = React.memo(function ReadingsChart({
           </ResponsiveContainer>
         </div>
       )}
+      </WidgetSwap>
     </div>
   );
 });

--- a/sensor_hub/ui/sensor_hub_ui/src/components/SensorDetailCard.test.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/components/SensorDetailCard.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen, waitForElementToBeRemoved } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Sensor } from '../gen/aliases';
+import SensorDetailCard from './SensorDetailCard';
+
+const { getMock, readingsMock } = vi.hoisted(() => ({ getMock: vi.fn(), readingsMock: vi.fn() }));
+
+vi.mock('../gen/client', () => ({ apiClient: { GET: getMock } }));
+vi.mock('../hooks/useCurrentReadings', () => ({ useCurrentReadings: () => readingsMock() }));
+vi.mock('../theme/chartColours', () => ({
+  useChartColours: () => ({ categorical: ['#D4451A'], health: ['', '', ''], stat: ['', '', ''], grid: '#000', axisText: '#000', noData: '#E0D8D0' }),
+}));
+
+function makeSensor(): Sensor {
+  return {
+    id: 7, name: 'greenhouse', external_id: 'g', sensor_driver: 'z', config: {}, metadata: {},
+    health_status: 'good', health_reason: 'ok', enabled: true, status: 'active', retention_hours: null,
+  };
+}
+
+describe('SensorDetailCard loading state', () => {
+  beforeEach(() => {
+    getMock.mockReset();
+    readingsMock.mockReset();
+    readingsMock.mockReturnValue({});
+  });
+
+  it('shows cascading tiles while measurement types are loading', () => {
+    getMock.mockReturnValue(new Promise(() => {}));
+    render(<SensorDetailCard sensor={makeSensor()} />);
+    expect(screen.getByTestId('widget-loader')).toBeInTheDocument();
+    expect(screen.getAllByTestId('detail-tile').length).toBe(6);
+  });
+
+  it('shows the detail grid once measurement types load', async () => {
+    getMock.mockResolvedValue({ data: [{ name: 'temperature', display_name: 'Temperature', unit: '°C' }] });
+    render(<SensorDetailCard sensor={makeSensor()} />);
+    await waitForElementToBeRemoved(() => screen.queryByTestId('widget-loader'));
+    expect(screen.getByText('Temperature')).toBeInTheDocument();
+  });
+});

--- a/sensor_hub/ui/sensor_hub_ui/src/components/SensorDetailCard.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/components/SensorDetailCard.tsx
@@ -5,6 +5,7 @@ import { apiClient } from '../gen/client';
 import { useCurrentReadings } from '../hooks/useCurrentReadings';
 import LayoutCard from '../tools/LayoutCard';
 import { TypographyH2 } from '../tools/Typography';
+import { WidgetSwap, SensorDetailTilesLoader } from '../dashboard/widget-loaders';
 
 interface SensorDetailCardProps {
     sensor: Sensor;
@@ -13,18 +14,22 @@ interface SensorDetailCardProps {
 
 export default function SensorDetailCard({ sensor, onDataUpdate }: SensorDetailCardProps) {
     const [measurementTypes, setMeasurementTypes] = useState<MeasurementTypeInfo[]>([]);
+    const [loading, setLoading] = useState(true);
     const readings = useCurrentReadings({ onDataUpdate });
 
     useEffect(() => {
-        apiClient.GET('/sensors/by-id/{id}/measurement-types', { params: { path: { id: sensor.id } } }).then(({ data }) => setMeasurementTypes(data ?? []));
+        setLoading(true);
+        apiClient.GET('/sensors/by-id/{id}/measurement-types', { params: { path: { id: sensor.id } } })
+            .then(({ data }) => setMeasurementTypes(data ?? []))
+            .finally(() => setLoading(false));
     }, [sensor.id]);
-
-    if (measurementTypes.length === 0) return null;
 
     const sensorReadings = readings[sensor.name] ?? {};
 
     return (
-        <LayoutCard variant="secondary" changes={{ height: '100%', width: '100%' }}>
+        <WidgetSwap loading={loading && measurementTypes.length === 0} loader={<SensorDetailTilesLoader />}>
+            {measurementTypes.length === 0 ? null : (
+            <LayoutCard variant="secondary" changes={{ height: '100%', width: '100%' }}>
             <TypographyH2>{sensor.name}: Details</TypographyH2>
             <Grid container spacing={1} sx={{ mt: 1 }}>
                 {measurementTypes.map((mt) => {
@@ -48,5 +53,7 @@ export default function SensorDetailCard({ sensor, onDataUpdate }: SensorDetailC
                 })}
             </Grid>
         </LayoutCard>
+            )}
+        </WidgetSwap>
     );
 }

--- a/sensor_hub/ui/sensor_hub_ui/src/components/SensorHealthCard.test.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/components/SensorHealthCard.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Sensor } from '../gen/aliases';
+import SensorHealthCard from './SensorHealthCard';
+
+const { contextMock } = vi.hoisted(() => ({ contextMock: vi.fn() }));
+
+vi.mock('../hooks/useSensorContext', () => ({ useSensorContext: () => contextMock() }));
+vi.mock('./SensorHealthPieChart', () => ({ default: () => <div data-testid="health-pie" /> }));
+vi.mock('../theme/chartColours', () => ({
+  useChartColours: () => ({ categorical: ['#D4451A'], health: ['', '', ''], stat: ['', '', ''], grid: '#000', axisText: '#000', noData: '#E0D8D0' }),
+}));
+
+function makeSensor(): Sensor {
+  return {
+    id: 1, name: 'living-room', external_id: 'lr', sensor_driver: 'z', config: {}, metadata: {},
+    health_status: 'good', health_reason: 'ok', enabled: true, status: 'active', retention_hours: null,
+  };
+}
+
+describe('SensorHealthCard loading state', () => {
+  beforeEach(() => contextMock.mockReset());
+
+  it('shows the circular-draw loader while sensors are still loading', () => {
+    contextMock.mockReturnValue({ sensors: [], loaded: false });
+    render(<SensorHealthCard />);
+    expect(screen.getByTestId('widget-loader')).toBeInTheDocument();
+    expect(screen.queryByTestId('health-pie')).not.toBeInTheDocument();
+  });
+
+  it('shows the pie chart once loaded with sensors', () => {
+    contextMock.mockReturnValue({ sensors: [makeSensor()], loaded: true });
+    render(<SensorHealthCard />);
+    expect(screen.queryByTestId('widget-loader')).not.toBeInTheDocument();
+    expect(screen.getByTestId('health-pie')).toBeInTheDocument();
+  });
+});

--- a/sensor_hub/ui/sensor_hub_ui/src/components/SensorHealthCard.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/components/SensorHealthCard.tsx
@@ -2,10 +2,11 @@ import {TypographyH2} from "../tools/Typography.tsx";
 import SensorHealthPieChart from "./SensorHealthPieChart.tsx";
 import LayoutCard from "../tools/LayoutCard.tsx";
 import {useSensorContext} from "../hooks/useSensorContext.ts";
-import { CircularProgress, Box } from "@mui/material";
+import { Box } from "@mui/material";
 import EmptyState from "./EmptyState";
 import MonitorHeartOutlinedIcon from "@mui/icons-material/MonitorHeartOutlined";
 import { scrollToAndHighlight } from "../tools/scrollToAndHighlight";
+import { CircularDrawLoader } from "../dashboard/widget-loaders";
 
 
 function SensorHealthCard({ showTitle = true }: { showTitle?: boolean }) {
@@ -15,8 +16,8 @@ function SensorHealthCard({ showTitle = true }: { showTitle?: boolean }) {
     <LayoutCard variant="secondary" changes={{alignItems: "center", height: "100%", width: "100%", overflow: "hidden"}}>
       {showTitle && <TypographyH2>Sensor Health</TypographyH2>}
       {!loaded ? (
-        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', flex: 1, minHeight: 0 }}>
-          <CircularProgress />
+        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', flex: 1, minHeight: 0, width: '100%' }}>
+          <CircularDrawLoader />
         </Box>
       ) : sensors.length === 0 ? (
         <EmptyState

--- a/sensor_hub/ui/sensor_hub_ui/src/components/SensorHealthHistoryChart.test.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/components/SensorHealthHistoryChart.test.tsx
@@ -23,8 +23,12 @@ vi.mock('../hooks/useMobile', () => ({
 
 vi.mock('../theme/chartColours', () => ({
   useChartColours: () => ({
+    categorical: ['#D4451A'],
     grid: '#ccc',
     health: ['#0f0', '#f00', '#999'],
+    stat: ['', '', ''],
+    axisText: '#000',
+    noData: '#E0D8D0',
   }),
 }));
 
@@ -82,6 +86,15 @@ describe('SensorHealthHistoryChart', () => {
     vi.setSystemTime(new Date('2026-05-09T12:00:00Z'));
     Object.keys(properties).forEach((key) => delete properties[key]);
     useSensorHealthHistoryMock.mockReset();
+  });
+
+  it('shows the signal-trace loader while history is loading with no data yet', () => {
+    useSensorHealthHistoryMock.mockReturnValue([[], vi.fn(), true]);
+
+    render(<SensorHealthHistoryChart sensor={makeSensor()} />);
+
+    expect(screen.getByTestId('widget-loader')).toBeInTheDocument();
+    expect(screen.queryByTestId('area-chart')).not.toBeInTheDocument();
   });
 
   it('extends the latest health state to now before rendering the step chart', () => {

--- a/sensor_hub/ui/sensor_hub_ui/src/components/SensorHealthHistoryChart.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/components/SensorHealthHistoryChart.tsx
@@ -17,6 +17,7 @@ import { useIsMobile } from "../hooks/useMobile";
 import { useChartColours } from "../theme/chartColours";
 import { buildHealthWindowModel, formatDurationShort, formatWindowLabel } from "../health/healthWindow";
 import { useProperties } from "../hooks/useProperties.ts";
+import { SignalTraceLoader } from "../dashboard/widget-loaders";
 
 // Custom dot that only renders at transition points for lines with valid values
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -36,7 +37,7 @@ function SensorHealthHistoryChart({sensor}: SensorHealthHistoryChartProps) {
   const isMobile = useIsMobile();
   const properties = useProperties();
 
-  const [healthHistoryData] = useSensorHealthHistory(sensor.name);
+  const [healthHistoryData, , historyLoading] = useSensorHealthHistory(sensor.name);
 
   const model = useMemo(() => {
     if (!Array.isArray(healthHistoryData) || healthHistoryData.length === 0) return null;
@@ -112,7 +113,11 @@ function SensorHealthHistoryChart({sensor}: SensorHealthHistoryChartProps) {
           </span>
         </div>
       )}
-      {!Array.isArray(mappedData) || mappedData.length === 0 ? (
+      {historyLoading && mappedData.length === 0 ? (
+        <div style={chartAreaStyle}>
+          <SignalTraceLoader />
+        </div>
+      ) : !Array.isArray(mappedData) || mappedData.length === 0 ? (
         <></>
       ) : (
         <div style={chartAreaStyle}>

--- a/sensor_hub/ui/sensor_hub_ui/src/components/SensorTypeCard.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/components/SensorTypeCard.tsx
@@ -3,9 +3,10 @@ import LayoutCard from "../tools/LayoutCard.tsx";
 import { useSensorContext } from "../hooks/useSensorContext.ts";
 import { useDrivers } from "../hooks/useDrivers.ts";
 import SensorTypePieChart from "./SensorTypePieChart.tsx";
-import { CircularProgress, Box } from "@mui/material";
+import { Box } from "@mui/material";
 import EmptyState from "./EmptyState";
 import CategoryOutlinedIcon from "@mui/icons-material/CategoryOutlined";
+import { CircularDrawLoader } from "../dashboard/widget-loaders";
 
 function SensorTypeCard({ showTitle = true }: { showTitle?: boolean }) {
   const { sensors, loaded } = useSensorContext();
@@ -18,8 +19,8 @@ function SensorTypeCard({ showTitle = true }: { showTitle?: boolean }) {
     >
       {showTitle && <TypographyH2>Sensor Types</TypographyH2>}
       {!loaded ? (
-        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', flex: 1, minHeight: 0 }}>
-          <CircularProgress />
+        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', flex: 1, minHeight: 0, width: '100%' }}>
+          <CircularDrawLoader />
         </Box>
       ) : sensors.length === 0 ? (
         <EmptyState

--- a/sensor_hub/ui/sensor_hub_ui/src/components/TotalReadingsForEachSensorCard.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/components/TotalReadingsForEachSensorCard.tsx
@@ -8,6 +8,7 @@ import {Alert, Button, Snackbar} from "@mui/material";
 import {useState} from "react";
 import { useSensorContext } from "../hooks/useSensorContext.ts";
 import EmptyState from "./EmptyState.tsx";
+import { CascadeRowsLoader } from "../dashboard/widget-loaders";
 
 function TotalReadingsForEachSensorCard({ showTitle = true }: { showTitle?: boolean }) {
   const [data, refresh] = useTotalReadingsForEachSensor();
@@ -48,7 +49,9 @@ function TotalReadingsForEachSensorCard({ showTitle = true }: { showTitle?: bool
       </div>
 
       <div style={{ flex: 1, minHeight: 0, width: '100%' }}>
-        {loaded && rows.length === 0 ? (
+        {!loaded ? (
+          <CascadeRowsLoader />
+        ) : rows.length === 0 ? (
           <EmptyState
             icon={<BarChartOutlinedIcon sx={{ fontSize: 48 }} />}
             title="No reading data yet"
@@ -65,7 +68,6 @@ function TotalReadingsForEachSensorCard({ showTitle = true }: { showTitle?: bool
                 paginationModel: { pageSize: 5, page: 0 },
               },
             }}
-            loading={!loaded}
             sx={{
               height: '100%',
               backgroundColor: 'background.paper',

--- a/sensor_hub/ui/sensor_hub_ui/src/components/WeatherForecastCard.test.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/components/WeatherForecastCard.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import WeatherForecastCard from './WeatherForecastCard';
+
+const { weatherMock } = vi.hoisted(() => ({ weatherMock: vi.fn() }));
+
+const properties: Record<string, string> = {};
+
+vi.mock('../hooks/useProperties', () => ({ useProperties: () => properties }));
+vi.mock('../hooks/useWeatherApi', () => ({ useWeatherApi: () => weatherMock() }));
+vi.mock('../hooks/useMobile', () => ({ useIsMobile: () => false }));
+vi.mock('./DayForecastCard', () => ({ default: () => <div data-testid="day-card" /> }));
+vi.mock('./HourlyForecastDetail', () => ({ default: () => <div data-testid="hourly" /> }));
+vi.mock('../theme/chartColours', () => ({
+  useChartColours: () => ({ categorical: ['#D4451A'], health: ['', '', ''], stat: ['', '', ''], grid: '#000', axisText: '#000', noData: '#E0D8D0' }),
+}));
+
+describe('WeatherForecastCard loading state', () => {
+  beforeEach(() => {
+    weatherMock.mockReset();
+    properties['weather.latitude'] = '51.5';
+    properties['weather.longitude'] = '-0.1';
+    properties['weather.location.name'] = 'Home';
+  });
+
+  it('shows the cascading weather loader (not a spinner/text) while loading', () => {
+    weatherMock.mockReturnValue({ data: null, loading: true, error: null });
+    render(<WeatherForecastCard />);
+    expect(screen.getByTestId('widget-loader')).toBeInTheDocument();
+    expect(screen.getAllByTestId('wx-day').length).toBe(6);
+    expect(screen.queryByText('Loading forecast…')).not.toBeInTheDocument();
+  });
+});

--- a/sensor_hub/ui/sensor_hub_ui/src/components/WeatherForecastCard.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/components/WeatherForecastCard.tsx
@@ -1,8 +1,6 @@
 import { useState } from "react";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
-import CircularProgress from "@mui/material/CircularProgress";
-import Typography from "@mui/material/Typography";
 import Alert from "@mui/material/Alert";
 import ExpandMoreOutlined from "@mui/icons-material/ExpandMoreOutlined";
 import ExpandLessOutlined from "@mui/icons-material/ExpandLessOutlined";
@@ -14,6 +12,7 @@ import { useIsMobile } from "../hooks/useMobile.ts";
 import DayForecastCard from "./DayForecastCard.tsx";
 import HourlyForecastDetail from "./HourlyForecastDetail.tsx";
 import EmptyState from "./EmptyState.tsx";
+import { WeatherColumnsLoader } from "../dashboard/widget-loaders";
 
 export default function WeatherForecastCard({ showTitle = true }: { showTitle?: boolean }) {
   const properties = useProperties();
@@ -48,23 +47,8 @@ export default function WeatherForecastCard({ showTitle = true }: { showTitle?: 
         />
       )}
       {hasLocation && loading && !data && (
-        <Box
-          sx={{
-            display: "flex",
-            justifyContent: "center",
-            alignItems: "center",
-            py: 4,
-          }}
-        >
-          <CircularProgress size={32} />
-          <Typography
-            variant="body2"
-            sx={{
-              color: "text.secondary",
-              ml: 1
-            }}>
-            Loading forecast…
-          </Typography>
+        <Box sx={{ flex: 1, minHeight: 0 }}>
+          <WeatherColumnsLoader />
         </Box>
       )}
       {hasLocation && error && (

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/CascadeRowsLoader.test.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/CascadeRowsLoader.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import CascadeRowsLoader from './CascadeRowsLoader';
+
+vi.mock('../../theme/chartColours', () => ({
+  useChartColours: () => ({ categorical: ['#D4451A'], health: ['', '', ''], stat: ['', '', ''], grid: '#000', axisText: '#000', noData: '#E0D8D0' }),
+}));
+
+describe('CascadeRowsLoader', () => {
+  it('renders skeleton rows inside an aria-busy loader shell', () => {
+    render(<CascadeRowsLoader rows={4} />);
+    const loader = screen.getByTestId('widget-loader');
+    expect(loader).toBeInTheDocument();
+    expect(loader).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getAllByTestId('cascade-row')).toHaveLength(4);
+  });
+});

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/CascadeRowsLoader.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/CascadeRowsLoader.tsx
@@ -1,0 +1,49 @@
+import { Box } from '@mui/material';
+import { useChartColours } from '../../theme/chartColours';
+import { usePrefersReducedMotion } from './usePrefersReducedMotion';
+import { cascade } from './keyframes';
+import LoaderShell from './LoaderShell';
+
+interface CascadeRowsLoaderProps {
+  rows?: number;
+}
+
+/**
+ * Loader for table / list widgets: skeleton rows stream in top-to-bottom on a
+ * loop, like records arriving. Reduced-motion shows the rows statically.
+ */
+export default function CascadeRowsLoader({ rows = 4 }: CascadeRowsLoaderProps) {
+  const colours = useChartColours();
+  const reduced = usePrefersReducedMotion();
+
+  return (
+    <LoaderShell>
+      <Box sx={{ width: '100%', display: 'flex', flexDirection: 'column', gap: 1.2, px: 1 }}>
+        {Array.from({ length: rows }).map((_, i) => (
+          <Box
+            key={i}
+            data-testid="cascade-row"
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1.2,
+              ...(reduced
+                ? {}
+                : {
+                    opacity: 0,
+                    animation: `${cascade} 2.6s ease-in-out infinite`,
+                    animationDelay: `${(i * 0.18).toFixed(2)}s`,
+                  }),
+            }}
+          >
+            <Box sx={{ width: 20, height: 20, borderRadius: '50%', bgcolor: colours.noData, flex: 'none' }} />
+            <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 0.6, minWidth: 0 }}>
+              <Box sx={{ height: 9, borderRadius: 1, bgcolor: colours.noData, width: '70%' }} />
+              <Box sx={{ height: 8, borderRadius: 1, bgcolor: colours.noData, width: '42%' }} />
+            </Box>
+          </Box>
+        ))}
+      </Box>
+    </LoaderShell>
+  );
+}

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/CircularDrawLoader.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/CircularDrawLoader.tsx
@@ -1,0 +1,43 @@
+import { Box } from '@mui/material';
+import { useChartColours } from '../../theme/chartColours';
+import { usePrefersReducedMotion } from './usePrefersReducedMotion';
+import { drawRing } from './keyframes';
+import LoaderShell from './LoaderShell';
+
+/**
+ * Loader for radial widgets — gauge, pie, donut, health. A terracotta ring
+ * draws itself around a calm grey track and erases, a looped cousin of the
+ * chart signal trace. One radial motif shared by gauge and pie.
+ */
+export default function CircularDrawLoader() {
+  const colours = useChartColours();
+  const reduced = usePrefersReducedMotion();
+
+  return (
+    <LoaderShell>
+      <Box
+        component="svg"
+        viewBox="0 0 100 100"
+        sx={{ width: '70%', maxWidth: 130, height: 'auto', aspectRatio: '1 / 1' }}
+      >
+        <g transform="rotate(-90 50 50)">
+          <circle cx="50" cy="50" r="40" fill="none" stroke={colours.noData} strokeWidth={9} />
+          <Box
+            component="circle"
+            cx="50"
+            cy="50"
+            r="40"
+            fill="none"
+            stroke={colours.categorical[0]}
+            strokeWidth={9}
+            strokeLinecap="round"
+            sx={{
+              strokeDasharray: 251.3,
+              ...(reduced ? { strokeDashoffset: 0 } : { animation: `${drawRing} 2.4s ease-in-out infinite` }),
+            }}
+          />
+        </g>
+      </Box>
+    </LoaderShell>
+  );
+}

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/IndeterminateBarLoader.test.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/IndeterminateBarLoader.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import IndeterminateBarLoader from './IndeterminateBarLoader';
+
+vi.mock('../../theme/chartColours', () => ({
+  useChartColours: () => ({ categorical: ['#D4451A'], health: ['', '', ''], stat: ['', '', ''], grid: '#000', axisText: '#000', noData: '#E0D8D0' }),
+}));
+
+describe('IndeterminateBarLoader', () => {
+  it('renders the sliding bar inside an aria-busy loader shell', () => {
+    render(<IndeterminateBarLoader />);
+    const loader = screen.getByTestId('widget-loader');
+    expect(loader).toBeInTheDocument();
+    expect(loader).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getByTestId('indeterminate-bar')).toBeInTheDocument();
+  });
+});

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/IndeterminateBarLoader.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/IndeterminateBarLoader.tsx
@@ -1,0 +1,40 @@
+import { Box } from '@mui/material';
+import { useChartColours } from '../../theme/chartColours';
+import { usePrefersReducedMotion } from './usePrefersReducedMotion';
+import { indeterminate } from './keyframes';
+import LoaderShell from './LoaderShell';
+
+/**
+ * Loader for the uptime widget: a terracotta segment slides across a rounded
+ * track (matching the real LinearProgress), with calm grey placeholders for the
+ * percentage and caption. No number is shown.
+ */
+export default function IndeterminateBarLoader() {
+  const colours = useChartColours();
+  const reduced = usePrefersReducedMotion();
+
+  return (
+    <LoaderShell>
+      <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 1.8, width: '100%' }}>
+        <Box sx={{ width: '56%', maxWidth: 130, height: 12, borderRadius: 1, bgcolor: colours.noData }} />
+        <Box sx={{ position: 'relative', width: '80%', height: 10, borderRadius: 5, bgcolor: colours.noData, overflow: 'hidden' }}>
+          <Box
+            data-testid="indeterminate-bar"
+            sx={{
+              position: 'absolute',
+              top: 0,
+              height: '100%',
+              width: '38%',
+              borderRadius: 5,
+              bgcolor: colours.categorical[0],
+              ...(reduced
+                ? { left: 0 }
+                : { animation: `${indeterminate} 1.5s cubic-bezier(.65,.05,.36,1) infinite` }),
+            }}
+          />
+        </Box>
+        <Box sx={{ width: '42%', maxWidth: 96, height: 8, borderRadius: 1, bgcolor: colours.noData }} />
+      </Box>
+    </LoaderShell>
+  );
+}

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/LoaderShell.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/LoaderShell.tsx
@@ -1,0 +1,36 @@
+import { Box } from '@mui/material';
+import type { ReactNode } from 'react';
+
+interface LoaderShellProps {
+  children: ReactNode;
+  /** Accessible label announced while loading (the family is otherwise text-free). */
+  label?: string;
+}
+
+/**
+ * Common wrapper for every Incoming-family loader: fills the widget body,
+ * centres the motif, and exposes the loading state to assistive tech via
+ * role="status" + aria-busy (since the visuals carry no literal text).
+ */
+export default function LoaderShell({ children, label = 'Loading data' }: LoaderShellProps) {
+  return (
+    <Box
+      role="status"
+      aria-busy="true"
+      aria-label={label}
+      data-testid="widget-loader"
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        height: '100%',
+        width: '100%',
+        p: 1,
+        boxSizing: 'border-box',
+        overflow: 'hidden',
+      }}
+    >
+      {children}
+    </Box>
+  );
+}

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/RippleHeatmapLoader.test.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/RippleHeatmapLoader.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import RippleHeatmapLoader from './RippleHeatmapLoader';
+
+vi.mock('../../theme/chartColours', () => ({
+  useChartColours: () => ({ categorical: ['#D4451A'], health: ['', '', ''], stat: ['', '', ''], grid: '#000', axisText: '#000', noData: '#E0D8D0' }),
+}));
+
+describe('RippleHeatmapLoader', () => {
+  it('renders the loader shell with a 30-cell grid matching the real heatmap', () => {
+    render(<RippleHeatmapLoader />);
+    const loader = screen.getByTestId('widget-loader');
+    expect(loader).toBeInTheDocument();
+    expect(loader).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getAllByTestId('heatmap-cell')).toHaveLength(30);
+  });
+});

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/RippleHeatmapLoader.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/RippleHeatmapLoader.tsx
@@ -1,0 +1,61 @@
+import { Box } from '@mui/material';
+import { useChartColours } from '../../theme/chartColours';
+import { usePrefersReducedMotion } from './usePrefersReducedMotion';
+import { ripple } from './keyframes';
+import LoaderShell from './LoaderShell';
+
+interface RippleHeatmapLoaderProps {
+  /** Columns in the grid — matches the real heatmap (7). */
+  columns?: number;
+  /** Total cells — matches the real heatmap (30 days). */
+  count?: number;
+}
+
+/**
+ * Loader for the heatmap widget: a diagonal wave of warmth sweeps across the
+ * grid as if days of data are filling in. Mirrors the real 7-column / 30-day
+ * grid. No day numbers are shown (never fake a value).
+ */
+export default function RippleHeatmapLoader({ columns = 7, count = 30 }: RippleHeatmapLoaderProps) {
+  const colours = useChartColours();
+  const reduced = usePrefersReducedMotion();
+
+  return (
+    <LoaderShell>
+      <Box
+        sx={{
+          width: '100%',
+          maxWidth: 260,
+          display: 'grid',
+          gridTemplateColumns: `repeat(${columns}, 1fr)`,
+          gridAutoRows: '1fr',
+          gap: '4px',
+          '--cell-base': colours.noData,
+          '--cell-active': colours.categorical[0],
+        }}
+      >
+        {Array.from({ length: count }).map((_, i) => {
+          const row = Math.floor(i / columns);
+          const col = i % columns;
+          return (
+            <Box
+              key={i}
+              data-testid="heatmap-cell"
+              sx={{
+                aspectRatio: '1 / 1',
+                borderRadius: '2px',
+                backgroundColor: 'var(--cell-base)',
+                ...(reduced
+                  ? {}
+                  : {
+                      animation: `${ripple} 2.6s ease-in-out infinite`,
+                      animationDelay: `${((row + col) * 0.09).toFixed(2)}s`,
+                    }),
+              }}
+            />
+          );
+        })}
+      </Box>
+    </LoaderShell>
+  );
+}

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/ScanLineLoader.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/ScanLineLoader.tsx
@@ -1,0 +1,55 @@
+import { Box } from '@mui/material';
+import { alpha } from '@mui/material/styles';
+import { useChartColours } from '../../theme/chartColours';
+import { usePrefersReducedMotion } from './usePrefersReducedMotion';
+import { keyframes } from '@mui/system';
+import LoaderShell from './LoaderShell';
+
+const scanMove = keyframes`
+  0% { top: -26px; }
+  100% { top: 100%; }
+`;
+
+interface ScanLineLoaderProps {
+  rows?: number;
+}
+
+/**
+ * Alternative table/list loader: a terracotta line sweeps down static skeleton
+ * rows, like a reader pulling them in. Reduced-motion hides the moving line.
+ */
+export default function ScanLineLoader({ rows = 4 }: ScanLineLoaderProps) {
+  const colours = useChartColours();
+  const reduced = usePrefersReducedMotion();
+
+  return (
+    <LoaderShell>
+      <Box sx={{ position: 'relative', width: '100%', height: '100%', overflow: 'hidden', display: 'flex', alignItems: 'center' }}>
+        {!reduced && (
+          <Box
+            sx={{
+              position: 'absolute',
+              left: 0,
+              right: 0,
+              height: 26,
+              background: `linear-gradient(${alpha(colours.categorical[0], 0.25)}, transparent)`,
+              borderTop: `2px solid ${colours.categorical[0]}`,
+              animation: `${scanMove} 2.2s ease-in-out infinite`,
+            }}
+          />
+        )}
+        <Box sx={{ width: '100%', display: 'flex', flexDirection: 'column', gap: 1.2, px: 1 }}>
+          {Array.from({ length: rows }).map((_, i) => (
+            <Box key={i} sx={{ display: 'flex', alignItems: 'center', gap: 1.2 }}>
+              <Box sx={{ width: 20, height: 20, borderRadius: '50%', bgcolor: colours.noData, flex: 'none' }} />
+              <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 0.6, minWidth: 0 }}>
+                <Box sx={{ height: 9, borderRadius: 1, bgcolor: colours.noData, width: '70%' }} />
+                <Box sx={{ height: 8, borderRadius: 1, bgcolor: colours.noData, width: '42%' }} />
+              </Box>
+            </Box>
+          ))}
+        </Box>
+      </Box>
+    </LoaderShell>
+  );
+}

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/SensorDetailTilesLoader.test.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/SensorDetailTilesLoader.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import SensorDetailTilesLoader from './SensorDetailTilesLoader';
+
+vi.mock('../../theme/chartColours', () => ({
+  useChartColours: () => ({ categorical: ['#D4451A'], health: ['', '', ''], stat: ['', '', ''], grid: '#000', axisText: '#000', noData: '#E0D8D0' }),
+}));
+
+describe('SensorDetailTilesLoader', () => {
+  it('renders cascading skeleton tiles inside an aria-busy shell', () => {
+    render(<SensorDetailTilesLoader tiles={6} />);
+    const loader = screen.getByTestId('widget-loader');
+    expect(loader).toBeInTheDocument();
+    expect(loader).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getAllByTestId('detail-tile')).toHaveLength(6);
+  });
+});

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/SensorDetailTilesLoader.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/SensorDetailTilesLoader.tsx
@@ -1,0 +1,47 @@
+import { Box } from '@mui/material';
+import { useChartColours } from '../../theme/chartColours';
+import { usePrefersReducedMotion } from './usePrefersReducedMotion';
+import { cascade } from './keyframes';
+import LoaderShell from './LoaderShell';
+
+interface SensorDetailTilesLoaderProps {
+  tiles?: number;
+}
+
+/**
+ * Loader for the sensor-detail card: the responsive stat-paper grid rendered as
+ * cascading skeleton tiles (label + value placeholder). No values are invented.
+ */
+export default function SensorDetailTilesLoader({ tiles = 6 }: SensorDetailTilesLoaderProps) {
+  const colours = useChartColours();
+  const reduced = usePrefersReducedMotion();
+
+  return (
+    <LoaderShell>
+      <Box sx={{ width: '100%', display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 1, alignContent: 'center' }}>
+        {Array.from({ length: tiles }).map((_, i) => (
+          <Box
+            key={i}
+            data-testid="detail-tile"
+            sx={{
+              border: 1,
+              borderColor: 'divider',
+              borderRadius: 2,
+              p: 1.2,
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              gap: 0.9,
+              ...(reduced
+                ? {}
+                : { opacity: 0, animation: `${cascade} 2.8s ease-in-out infinite`, animationDelay: `${(i * 0.12).toFixed(2)}s` }),
+            }}
+          >
+            <Box sx={{ width: '64%', height: 7, borderRadius: 1, bgcolor: colours.noData }} />
+            <Box sx={{ width: '84%', height: 14, borderRadius: 1, bgcolor: colours.noData }} />
+          </Box>
+        ))}
+      </Box>
+    </LoaderShell>
+  );
+}

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/SignalTraceLoader.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/SignalTraceLoader.tsx
@@ -1,0 +1,44 @@
+import { Box } from '@mui/material';
+import { useChartColours } from '../../theme/chartColours';
+import { usePrefersReducedMotion } from './usePrefersReducedMotion';
+import { draw } from './keyframes';
+import LoaderShell from './LoaderShell';
+
+const PATH = 'M0,80 L24,64 L48,72 L72,46 L96,56 L120,32 L144,48 L168,26 L192,40 L216,20 L240,16';
+
+/**
+ * Loader for line/area chart widgets: a terracotta line that draws itself
+ * across the chart on a loop, like a reading streaming in. The hero motif of
+ * the Incoming family.
+ */
+export default function SignalTraceLoader() {
+  const colours = useChartColours();
+  const reduced = usePrefersReducedMotion();
+
+  return (
+    <LoaderShell label="Loading chart data">
+      <Box
+        component="svg"
+        viewBox="-6 -6 252 132"
+        preserveAspectRatio="none"
+        sx={{ width: '100%', height: '100%', overflow: 'hidden' }}
+      >
+        <line x1="0" y1="40" x2="240" y2="40" stroke={colours.grid} strokeWidth={1} />
+        <line x1="0" y1="80" x2="240" y2="80" stroke={colours.grid} strokeWidth={1} />
+        <Box
+          component="path"
+          d={PATH}
+          fill="none"
+          stroke={colours.categorical[0]}
+          strokeWidth={2.5}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          sx={{
+            strokeDasharray: 320,
+            ...(reduced ? { strokeDashoffset: 0 } : { animation: `${draw} 2.6s linear infinite` }),
+          }}
+        />
+      </Box>
+    </LoaderShell>
+  );
+}

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/SkeletonTilesLoader.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/SkeletonTilesLoader.tsx
@@ -1,0 +1,55 @@
+import { Box } from '@mui/material';
+import { lighten } from '@mui/material/styles';
+import { useChartColours } from '../../theme/chartColours';
+import { usePrefersReducedMotion } from './usePrefersReducedMotion';
+import { shimmer } from './keyframes';
+import LoaderShell from './LoaderShell';
+
+interface SkeletonTilesLoaderProps {
+  tiles?: number;
+}
+
+/**
+ * Loader for stat-tile widgets (min/max/avg). A calm label + value placeholder
+ * per tile, with a shimmer sweeping the tiles in turn. Never shows numbers.
+ */
+export default function SkeletonTilesLoader({ tiles = 3 }: SkeletonTilesLoaderProps) {
+  const colours = useChartColours();
+  const reduced = usePrefersReducedMotion();
+
+  const valueSx = reduced
+    ? { bgcolor: colours.noData }
+    : {
+        background: `linear-gradient(90deg, ${colours.noData} 25%, ${lighten(colours.noData, 0.4)} 45%, ${colours.noData} 65%)`,
+        backgroundSize: '220% 100%',
+        animation: `${shimmer} 1.5s ease-in-out infinite`,
+      };
+
+  return (
+    <LoaderShell>
+      <Box sx={{ display: 'flex', gap: 1.5, width: '100%', alignItems: 'center', justifyContent: 'center' }}>
+        {Array.from({ length: tiles }).map((_, i) => (
+          <Box
+            key={i}
+            data-testid="stat-tile"
+            sx={{
+              flex: 1,
+              maxWidth: 140,
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              gap: 1.2,
+              p: 1.5,
+              border: 1,
+              borderColor: 'divider',
+              borderRadius: 2,
+            }}
+          >
+            <Box sx={{ width: '50%', height: 8, borderRadius: 1, bgcolor: colours.noData }} />
+            <Box sx={{ width: '75%', height: 20, borderRadius: 1, animationDelay: `${(i * 0.25).toFixed(2)}s`, ...valueSx }} />
+          </Box>
+        ))}
+      </Box>
+    </LoaderShell>
+  );
+}

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/ValuePlaceholderLoader.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/ValuePlaceholderLoader.tsx
@@ -1,0 +1,77 @@
+import { Box, Typography } from '@mui/material';
+import { lighten } from '@mui/material/styles';
+import { useChartColours } from '../../theme/chartColours';
+import { usePrefersReducedMotion } from './usePrefersReducedMotion';
+import { shimmer, pulse } from './keyframes';
+import LoaderShell from './LoaderShell';
+
+interface ValuePlaceholderLoaderProps {
+  /**
+   * Unit to anchor next to the placeholder. Resolve this from the widget's
+   * configured measurement type — never guess. Omit when it cannot be resolved.
+   */
+  unit?: string;
+  variant?: 'block' | 'dashes';
+}
+
+/**
+ * Loader for big-number / current-reading widgets. Never renders a real or
+ * invented value — only the shape of one (a shimmer block or em-dashes), with
+ * an optional dynamic unit anchored alongside.
+ */
+export default function ValuePlaceholderLoader({ unit, variant = 'block' }: ValuePlaceholderLoaderProps) {
+  const colours = useChartColours();
+  const reduced = usePrefersReducedMotion();
+
+  if (variant === 'dashes') {
+    return (
+      <LoaderShell>
+        <Typography
+          component="div"
+          sx={{
+            fontSize: '3rem',
+            fontWeight: 'bold',
+            color: 'text.secondary',
+            letterSpacing: 2,
+            ...(reduced ? {} : { animation: `${pulse} 1.6s ease-in-out infinite` }),
+          }}
+        >
+          —.—
+          {unit ? (
+            <Box component="span" sx={{ fontSize: '1.4rem', ml: 0.5 }}>
+              {unit}
+            </Box>
+          ) : null}
+        </Typography>
+      </LoaderShell>
+    );
+  }
+
+  return (
+    <LoaderShell>
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 1 }}>
+        <Box
+          sx={{
+            width: 130,
+            maxWidth: '64%',
+            height: 44,
+            borderRadius: 1,
+            bgcolor: colours.noData,
+            ...(reduced
+              ? {}
+              : {
+                  background: `linear-gradient(90deg, ${colours.noData} 25%, ${lighten(colours.noData, 0.4)} 45%, ${colours.noData} 65%)`,
+                  backgroundSize: '220% 100%',
+                  animation: `${shimmer} 1.5s ease-in-out infinite`,
+                }),
+          }}
+        />
+        {unit ? (
+          <Typography component="span" sx={{ fontSize: '1.4rem', fontWeight: 700, color: 'text.secondary' }}>
+            {unit}
+          </Typography>
+        ) : null}
+      </Box>
+    </LoaderShell>
+  );
+}

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/WeatherColumnsLoader.test.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/WeatherColumnsLoader.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import WeatherColumnsLoader from './WeatherColumnsLoader';
+
+vi.mock('../../theme/chartColours', () => ({
+  useChartColours: () => ({ categorical: ['#D4451A'], health: ['', '', ''], stat: ['', '', ''], grid: '#000', axisText: '#000', noData: '#E0D8D0' }),
+}));
+
+describe('WeatherColumnsLoader', () => {
+  it('renders skeleton day columns inside an aria-busy loader shell', () => {
+    render(<WeatherColumnsLoader days={6} />);
+    const loader = screen.getByTestId('widget-loader');
+    expect(loader).toBeInTheDocument();
+    expect(loader).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getAllByTestId('wx-day')).toHaveLength(6);
+  });
+});

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/WeatherColumnsLoader.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/WeatherColumnsLoader.tsx
@@ -1,0 +1,45 @@
+import { Box } from '@mui/material';
+import { useChartColours } from '../../theme/chartColours';
+import { usePrefersReducedMotion } from './usePrefersReducedMotion';
+import { cascade } from './keyframes';
+import LoaderShell from './LoaderShell';
+
+interface WeatherColumnsLoaderProps {
+  days?: number;
+}
+
+/**
+ * Loader for the weather forecast card: skeleton day columns (label, icon disc,
+ * hi/lo) cascade in left-to-right, so the forecast visibly "arrives" day by day.
+ */
+export default function WeatherColumnsLoader({ days = 6 }: WeatherColumnsLoaderProps) {
+  const colours = useChartColours();
+  const reduced = usePrefersReducedMotion();
+
+  return (
+    <LoaderShell>
+      <Box sx={{ display: 'flex', gap: 1.5, alignItems: 'center', justifyContent: 'center', width: '100%', overflow: 'hidden' }}>
+        {Array.from({ length: days }).map((_, i) => (
+          <Box
+            key={i}
+            data-testid="wx-day"
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              gap: 0.9,
+              ...(reduced
+                ? {}
+                : { opacity: 0, animation: `${cascade} 2.8s ease-in-out infinite`, animationDelay: `${(i * 0.14).toFixed(2)}s` }),
+            }}
+          >
+            <Box sx={{ width: 26, height: 8, borderRadius: 1, bgcolor: colours.noData }} />
+            <Box sx={{ width: 28, height: 28, borderRadius: '50%', bgcolor: colours.noData }} />
+            <Box sx={{ width: 24, height: 9, borderRadius: 1, bgcolor: colours.noData }} />
+            <Box sx={{ width: 18, height: 8, borderRadius: 1, bgcolor: colours.noData }} />
+          </Box>
+        ))}
+      </Box>
+    </LoaderShell>
+  );
+}

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/WidgetSwap.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/WidgetSwap.tsx
@@ -1,0 +1,40 @@
+import { Box } from '@mui/material';
+import type { ReactNode } from 'react';
+import { useLoaderVisibility } from './useLoaderVisibility';
+import { usePrefersReducedMotion } from './usePrefersReducedMotion';
+import { fadeIn } from './keyframes';
+
+interface WidgetSwapProps {
+  /** True while the widget's own data is still being fetched for the first time. */
+  loading: boolean;
+  /** The Incoming-family loader to show while loading. */
+  loader: ReactNode;
+  /** Override the anti-flash minimum visible time. */
+  minVisibleMs?: number;
+  /** The resolved UI: content, empty state, or error (decided by the widget). */
+  children: ReactNode;
+}
+
+/**
+ * The core integration primitive for the loader family. Shows `loader` while
+ * loading (with anti-flash min-display), then cross-fades to the resolved
+ * `children`. Occupies the same box throughout so there is no layout shift.
+ */
+export default function WidgetSwap({ loading, loader, minVisibleMs, children }: WidgetSwapProps) {
+  const showLoader = useLoaderVisibility(loading, { minVisibleMs });
+  const reduced = usePrefersReducedMotion();
+
+  if (showLoader) return <>{loader}</>;
+
+  return (
+    <Box
+      sx={{
+        height: '100%',
+        width: '100%',
+        ...(reduced ? {} : { animation: `${fadeIn} 250ms ease-out` }),
+      }}
+    >
+      {children}
+    </Box>
+  );
+}

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/index.test.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/index.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import * as loaders from './index';
+
+/**
+ * Coverage guard for the Incoming loader family. Every widget shape that gets a
+ * loader must have its component exported here, so the family stays complete and
+ * discoverable. If you add a new loader, add it to this list.
+ */
+const EXPECTED_LOADERS = [
+  'ValuePlaceholderLoader',
+  'SignalTraceLoader',
+  'CircularDrawLoader',
+  'RippleHeatmapLoader',
+  'CascadeRowsLoader',
+  'ScanLineLoader',
+  'SkeletonTilesLoader',
+  'IndeterminateBarLoader',
+  'WeatherColumnsLoader',
+  'SensorDetailTilesLoader',
+];
+
+describe('widget-loaders family', () => {
+  it('exports every loader plus the shared primitives', () => {
+    for (const name of EXPECTED_LOADERS) {
+      expect(loaders[name as keyof typeof loaders], `missing loader export: ${name}`).toBeTypeOf('function');
+    }
+    expect(loaders.WidgetSwap).toBeTypeOf('function');
+    expect(loaders.LoaderShell).toBeTypeOf('function');
+    expect(loaders.useLoaderVisibility).toBeTypeOf('function');
+    expect(loaders.usePrefersReducedMotion).toBeTypeOf('function');
+  });
+});

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/index.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/index.ts
@@ -8,5 +8,6 @@ export { default as CascadeRowsLoader } from './CascadeRowsLoader';
 export { default as ScanLineLoader } from './ScanLineLoader';
 export { default as SkeletonTilesLoader } from './SkeletonTilesLoader';
 export { default as IndeterminateBarLoader } from './IndeterminateBarLoader';
+export { default as WeatherColumnsLoader } from './WeatherColumnsLoader';
 export { useLoaderVisibility, DEFAULT_MIN_VISIBLE_MS } from './useLoaderVisibility';
 export { usePrefersReducedMotion } from './usePrefersReducedMotion';

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/index.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/index.ts
@@ -4,5 +4,7 @@ export { default as ValuePlaceholderLoader } from './ValuePlaceholderLoader';
 export { default as SignalTraceLoader } from './SignalTraceLoader';
 export { default as CircularDrawLoader } from './CircularDrawLoader';
 export { default as RippleHeatmapLoader } from './RippleHeatmapLoader';
+export { default as CascadeRowsLoader } from './CascadeRowsLoader';
+export { default as ScanLineLoader } from './ScanLineLoader';
 export { useLoaderVisibility, DEFAULT_MIN_VISIBLE_MS } from './useLoaderVisibility';
 export { usePrefersReducedMotion } from './usePrefersReducedMotion';

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/index.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/index.ts
@@ -7,5 +7,6 @@ export { default as RippleHeatmapLoader } from './RippleHeatmapLoader';
 export { default as CascadeRowsLoader } from './CascadeRowsLoader';
 export { default as ScanLineLoader } from './ScanLineLoader';
 export { default as SkeletonTilesLoader } from './SkeletonTilesLoader';
+export { default as IndeterminateBarLoader } from './IndeterminateBarLoader';
 export { useLoaderVisibility, DEFAULT_MIN_VISIBLE_MS } from './useLoaderVisibility';
 export { usePrefersReducedMotion } from './usePrefersReducedMotion';

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/index.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/index.ts
@@ -1,5 +1,6 @@
 export { default as LoaderShell } from './LoaderShell';
 export { default as WidgetSwap } from './WidgetSwap';
 export { default as ValuePlaceholderLoader } from './ValuePlaceholderLoader';
+export { default as SignalTraceLoader } from './SignalTraceLoader';
 export { useLoaderVisibility, DEFAULT_MIN_VISIBLE_MS } from './useLoaderVisibility';
 export { usePrefersReducedMotion } from './usePrefersReducedMotion';

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/index.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/index.ts
@@ -3,5 +3,6 @@ export { default as WidgetSwap } from './WidgetSwap';
 export { default as ValuePlaceholderLoader } from './ValuePlaceholderLoader';
 export { default as SignalTraceLoader } from './SignalTraceLoader';
 export { default as CircularDrawLoader } from './CircularDrawLoader';
+export { default as RippleHeatmapLoader } from './RippleHeatmapLoader';
 export { useLoaderVisibility, DEFAULT_MIN_VISIBLE_MS } from './useLoaderVisibility';
 export { usePrefersReducedMotion } from './usePrefersReducedMotion';

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/index.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/index.ts
@@ -1,0 +1,5 @@
+export { default as LoaderShell } from './LoaderShell';
+export { default as WidgetSwap } from './WidgetSwap';
+export { default as ValuePlaceholderLoader } from './ValuePlaceholderLoader';
+export { useLoaderVisibility, DEFAULT_MIN_VISIBLE_MS } from './useLoaderVisibility';
+export { usePrefersReducedMotion } from './usePrefersReducedMotion';

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/index.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/index.ts
@@ -6,5 +6,6 @@ export { default as CircularDrawLoader } from './CircularDrawLoader';
 export { default as RippleHeatmapLoader } from './RippleHeatmapLoader';
 export { default as CascadeRowsLoader } from './CascadeRowsLoader';
 export { default as ScanLineLoader } from './ScanLineLoader';
+export { default as SkeletonTilesLoader } from './SkeletonTilesLoader';
 export { useLoaderVisibility, DEFAULT_MIN_VISIBLE_MS } from './useLoaderVisibility';
 export { usePrefersReducedMotion } from './usePrefersReducedMotion';

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/index.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/index.ts
@@ -9,5 +9,6 @@ export { default as ScanLineLoader } from './ScanLineLoader';
 export { default as SkeletonTilesLoader } from './SkeletonTilesLoader';
 export { default as IndeterminateBarLoader } from './IndeterminateBarLoader';
 export { default as WeatherColumnsLoader } from './WeatherColumnsLoader';
+export { default as SensorDetailTilesLoader } from './SensorDetailTilesLoader';
 export { useLoaderVisibility, DEFAULT_MIN_VISIBLE_MS } from './useLoaderVisibility';
 export { usePrefersReducedMotion } from './usePrefersReducedMotion';

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/index.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/index.ts
@@ -2,5 +2,6 @@ export { default as LoaderShell } from './LoaderShell';
 export { default as WidgetSwap } from './WidgetSwap';
 export { default as ValuePlaceholderLoader } from './ValuePlaceholderLoader';
 export { default as SignalTraceLoader } from './SignalTraceLoader';
+export { default as CircularDrawLoader } from './CircularDrawLoader';
 export { useLoaderVisibility, DEFAULT_MIN_VISIBLE_MS } from './useLoaderVisibility';
 export { usePrefersReducedMotion } from './usePrefersReducedMotion';

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/keyframes.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/keyframes.ts
@@ -23,6 +23,14 @@ export const fadeIn = keyframes`
   to { opacity: 1; }
 `;
 
+/** Rows/columns/tiles streaming in on a loop, like records arriving. */
+export const cascade = keyframes`
+  0% { opacity: 0; transform: translateY(8px); }
+  13% { opacity: 1; transform: none; }
+  74% { opacity: 1; }
+  92%, 100% { opacity: 0; }
+`;
+
 /** Self-drawing line: draw on, then sweep off, on a loop (dasharray 320). */
 export const draw = keyframes`
   0% { stroke-dashoffset: 320; }

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/keyframes.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/keyframes.ts
@@ -23,9 +23,16 @@ export const fadeIn = keyframes`
   to { opacity: 1; }
 `;
 
-/** Self-drawing line/ring: draw on, then sweep off, on a loop (dasharray 320). */
+/** Self-drawing line: draw on, then sweep off, on a loop (dasharray 320). */
 export const draw = keyframes`
   0% { stroke-dashoffset: 320; }
   55% { stroke-dashoffset: 0; }
   100% { stroke-dashoffset: -320; }
+`;
+
+/** Self-drawing ring: draw around, then sweep off (dasharray 251.3 = 2*pi*40). */
+export const drawRing = keyframes`
+  0% { stroke-dashoffset: 251.3; }
+  55% { stroke-dashoffset: 0; }
+  100% { stroke-dashoffset: -251.3; }
 `;

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/keyframes.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/keyframes.ts
@@ -22,3 +22,10 @@ export const fadeIn = keyframes`
   from { opacity: 0; }
   to { opacity: 1; }
 `;
+
+/** Self-drawing line/ring: draw on, then sweep off, on a loop (dasharray 320). */
+export const draw = keyframes`
+  0% { stroke-dashoffset: 320; }
+  55% { stroke-dashoffset: 0; }
+  100% { stroke-dashoffset: -320; }
+`;

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/keyframes.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/keyframes.ts
@@ -1,0 +1,24 @@
+import { keyframes } from '@mui/system';
+
+/**
+ * Shared keyframes for the "Incoming" loader family.
+ * A calm grey skeleton base with a single terracotta element in motion.
+ */
+
+/** Horizontal sweep across a skeleton block. */
+export const shimmer = keyframes`
+  0% { background-position: 130% 0; }
+  100% { background-position: -130% 0; }
+`;
+
+/** Gentle opacity breathing. */
+export const pulse = keyframes`
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+`;
+
+/** Cross-fade content in when a loader gives way to real data. */
+export const fadeIn = keyframes`
+  from { opacity: 0; }
+  to { opacity: 1; }
+`;

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/keyframes.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/keyframes.ts
@@ -36,3 +36,12 @@ export const drawRing = keyframes`
   55% { stroke-dashoffset: 0; }
   100% { stroke-dashoffset: -251.3; }
 `;
+
+/**
+ * Heatmap cell warming up. Colours are theme-dependent, so they are read from
+ * CSS custom properties set on the grid (--cell-base / --cell-active).
+ */
+export const ripple = keyframes`
+  0%, 65%, 100% { background-color: var(--cell-base); }
+  32% { background-color: var(--cell-active); }
+`;

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/keyframes.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/keyframes.ts
@@ -53,3 +53,9 @@ export const ripple = keyframes`
   0%, 65%, 100% { background-color: var(--cell-base); }
   32% { background-color: var(--cell-active); }
 `;
+
+/** Indeterminate progress segment sliding across a track. */
+export const indeterminate = keyframes`
+  0% { left: -40%; }
+  100% { left: 102%; }
+`;

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/useLoaderVisibility.test.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/useLoaderVisibility.test.ts
@@ -1,0 +1,56 @@
+import { renderHook, act } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useLoaderVisibility } from './useLoaderVisibility';
+
+describe('useLoaderVisibility', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it('is not visible when never loading', () => {
+    const { result } = renderHook(() => useLoaderVisibility(false));
+    expect(result.current).toBe(false);
+  });
+
+  it('shows immediately when loading starts', () => {
+    const { result } = renderHook(({ l }) => useLoaderVisibility(l), { initialProps: { l: true } });
+    expect(result.current).toBe(true);
+  });
+
+  it('stays visible for at least minVisibleMs after loading ends (anti-flash)', () => {
+    const { result, rerender } = renderHook(({ l }) => useLoaderVisibility(l, { minVisibleMs: 350 }), {
+      initialProps: { l: true },
+    });
+    expect(result.current).toBe(true);
+
+    // Data arrives almost immediately.
+    rerender({ l: false });
+    expect(result.current).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(349);
+    });
+    expect(result.current).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it('hides promptly once the min window has already elapsed', () => {
+    const { result, rerender } = renderHook(({ l }) => useLoaderVisibility(l, { minVisibleMs: 200 }), {
+      initialProps: { l: true },
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    rerender({ l: false });
+    expect(result.current).toBe(false);
+  });
+});

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/useLoaderVisibility.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/useLoaderVisibility.ts
@@ -1,0 +1,43 @@
+import { useEffect, useRef, useState } from 'react';
+
+export const DEFAULT_MIN_VISIBLE_MS = 350;
+
+interface Options {
+  /** Minimum time the loader stays visible once shown, to avoid flicker on fast loads. */
+  minVisibleMs?: number;
+}
+
+/**
+ * Anti-flash gate for widget loaders. Once a loader becomes visible it stays
+ * visible for at least `minVisibleMs`, so quick/warm-cache loads don't blink.
+ *
+ * Returns whether the loader should currently be shown.
+ */
+export function useLoaderVisibility(isLoading: boolean, options: Options = {}): boolean {
+  const minVisibleMs = options.minVisibleMs ?? DEFAULT_MIN_VISIBLE_MS;
+  const [showLoader, setShowLoader] = useState(isLoading);
+  const shownAtRef = useRef<number | null>(isLoading ? Date.now() : null);
+
+  useEffect(() => {
+    if (isLoading) {
+      if (!showLoader) {
+        shownAtRef.current = Date.now();
+        setShowLoader(true);
+      }
+      return;
+    }
+
+    // Loading finished — keep the loader up until the min window has elapsed.
+    if (!showLoader) return;
+    const shownAt = shownAtRef.current ?? Date.now();
+    const remaining = minVisibleMs - (Date.now() - shownAt);
+    if (remaining <= 0) {
+      setShowLoader(false);
+      return;
+    }
+    const timer = setTimeout(() => setShowLoader(false), remaining);
+    return () => clearTimeout(timer);
+  }, [isLoading, showLoader, minVisibleMs]);
+
+  return showLoader;
+}

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/usePrefersReducedMotion.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widget-loaders/usePrefersReducedMotion.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+
+const QUERY = '(prefers-reduced-motion: reduce)';
+
+/**
+ * Tracks the user's prefers-reduced-motion setting so loaders can degrade
+ * to a static skeleton instead of animating.
+ */
+export function usePrefersReducedMotion(): boolean {
+  const [reduced, setReduced] = useState<boolean>(() =>
+    typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+      ? window.matchMedia(QUERY).matches
+      : false,
+  );
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return;
+    const mql = window.matchMedia(QUERY);
+    const onChange = () => setReduced(mql.matches);
+    onChange();
+    mql.addEventListener?.('change', onChange);
+    return () => mql.removeEventListener?.('change', onChange);
+  }, []);
+
+  return reduced;
+}

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/AlertSummaryWidget.test.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/AlertSummaryWidget.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen, waitForElementToBeRemoved } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import AlertSummaryWidget from './AlertSummaryWidget';
+
+const { scheduleMock, reportUpdateMock } = vi.hoisted(() => ({
+  scheduleMock: vi.fn(),
+  reportUpdateMock: vi.fn(),
+}));
+
+vi.mock('../WidgetUpdateContext', () => ({ useReportWidgetUpdate: () => reportUpdateMock }));
+vi.mock('../../scheduler/requestScheduler', () => ({ requestScheduler: { schedule: scheduleMock } }));
+vi.mock('../../gen/client', () => ({ apiClient: { GET: vi.fn() } }));
+vi.mock('../../theme/chartColours', () => ({
+  useChartColours: () => ({ categorical: ['#D4451A'], health: ['', '', ''], stat: ['', '', ''], grid: '#000', axisText: '#000', noData: '#E0D8D0' }),
+}));
+
+const props = { id: 'w', isEditing: false, config: {} };
+
+describe('AlertSummaryWidget loading state', () => {
+  beforeEach(() => {
+    scheduleMock.mockReset();
+    reportUpdateMock.mockReset();
+  });
+
+  it('shows the cascade loader (not a "Loading…" label) while fetching', () => {
+    scheduleMock.mockReturnValue(new Promise(() => {}));
+    render(<AlertSummaryWidget {...props} />);
+    expect(screen.getByTestId('widget-loader')).toBeInTheDocument();
+    expect(screen.queryByText('Loading…')).not.toBeInTheDocument();
+  });
+
+  it('shows the empty state once loaded with no rules', async () => {
+    scheduleMock.mockResolvedValue({ data: [] });
+    render(<AlertSummaryWidget {...props} />);
+    await waitForElementToBeRemoved(() => screen.queryByTestId('widget-loader'));
+    expect(screen.getByText('No alert rules configured')).toBeInTheDocument();
+  });
+});

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/AlertSummaryWidget.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/AlertSummaryWidget.tsx
@@ -5,6 +5,7 @@ import { Box, Typography, List, ListItem, ListItemText, Chip } from '@mui/materi
 import { apiClient } from '../../gen/client';
 import { requestScheduler } from '../../scheduler/requestScheduler';
 import { useReportWidgetUpdate } from '../WidgetUpdateContext';
+import { WidgetSwap, CascadeRowsLoader } from '../widget-loaders';
 
 export default function AlertSummaryWidget(_props: WidgetProps) {
     const [rules, setRules] = useState<AlertRule[]>([]);
@@ -21,45 +22,35 @@ export default function AlertSummaryWidget(_props: WidgetProps) {
         });
     }, []);
 
-    if (!loaded) {
-        return (
-            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}>
-                <Typography sx={{
-                    color: "text.secondary"
-                }}>Loading…</Typography>
-            </Box>
-        );
-    }
-
-    if (rules.length === 0) {
-        return (
-            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}>
-                <Typography sx={{
-                    color: "text.secondary"
-                }}>No alert rules configured</Typography>
-            </Box>
-        );
-    }
-
     return (
-        <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
-            <Box sx={{ overflow: 'auto', flex: 1, minHeight: 0 }}>
-                <List dense>
-                    {rules.map((rule) => (
-                        <ListItem key={rule.ID}>
-                            <ListItemText
-                                primary={rule.SensorName}
-                                secondary={`${rule.AlertType} — threshold: ${rule.HighThreshold ?? rule.LowThreshold ?? '—'}${rule.LastAlertSentAt ? ` · last: ${new Date(rule.LastAlertSentAt).toLocaleDateString()}` : ''}`}
-                            />
-                            <Chip
-                                label={rule.Enabled ? 'Enabled' : 'Disabled'}
-                                size="small"
-                                color={rule.Enabled ? 'success' : 'default'}
-                            />
-                        </ListItem>
-                    ))}
-                </List>
-            </Box>
-        </Box>
+        <WidgetSwap loading={!loaded} loader={<CascadeRowsLoader />}>
+            {rules.length === 0 ? (
+                <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}>
+                    <Typography sx={{
+                        color: "text.secondary"
+                    }}>No alert rules configured</Typography>
+                </Box>
+            ) : (
+                <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
+                    <Box sx={{ overflow: 'auto', flex: 1, minHeight: 0 }}>
+                        <List dense>
+                            {rules.map((rule) => (
+                                <ListItem key={rule.ID}>
+                                    <ListItemText
+                                        primary={rule.SensorName}
+                                        secondary={`${rule.AlertType} — threshold: ${rule.HighThreshold ?? rule.LowThreshold ?? '—'}${rule.LastAlertSentAt ? ` · last: ${new Date(rule.LastAlertSentAt).toLocaleDateString()}` : ''}`}
+                                    />
+                                    <Chip
+                                        label={rule.Enabled ? 'Enabled' : 'Disabled'}
+                                        size="small"
+                                        color={rule.Enabled ? 'success' : 'default'}
+                                    />
+                                </ListItem>
+                            ))}
+                        </List>
+                    </Box>
+                </Box>
+            )}
+        </WidgetSwap>
     );
 }

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/ComparisonChartWidget.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/ComparisonChartWidget.tsx
@@ -18,6 +18,7 @@ import { useChartColours } from '../../theme/chartColours';
 import NeedsConfiguration from '../NeedsConfiguration';
 import { resolveTimeRange } from '../timeRange';
 import { useReportWidgetUpdate } from '../WidgetUpdateContext';
+import { WidgetSwap, SignalTraceLoader } from '../widget-loaders';
 
 export default function ComparisonChartWidget({ config }: WidgetProps) {
     const { sensors } = useSensorContext();
@@ -48,7 +49,7 @@ export default function ComparisonChartWidget({ config }: WidgetProps) {
         ? config.refreshInterval * 1000 : undefined;
     const resolveRange = useCallback(() => resolveTimeRange(config), [config]);
 
-    const { mergedData: chartData } = useReadingsData({
+    const { mergedData: chartData, isLoading, error } = useReadingsData({
         startDate: null,
         endDate: null,
         sensors: filteredSensors,
@@ -73,41 +74,44 @@ export default function ComparisonChartWidget({ config }: WidgetProps) {
         );
     }
 
-    if (chartData.length === 0) {
-        return (
-            <Typography
-                sx={{
-                    color: "text.secondary",
-                    p: 2
-                }}>No data for the selected range</Typography>
-        );
-    }
+    const noData = chartData.length === 0;
+    const loading = isLoading && noData;
 
     return (
         <div style={{ flex: 1, minHeight: 0, width: '100%' }}>
-            <ResponsiveContainer width="100%" height="100%">
-                <LineChart data={chartData}>
-                    <CartesianGrid stroke={chartColours.grid} strokeDasharray="3 3" />
-                    <XAxis
-                        dataKey="time"
-                        tickFormatter={(t: string) => new Date(t).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
-                        minTickGap={50}
-                    />
-                    <YAxis label={yAxisLabel} />
-                    <Tooltip />
-                    <Legend />
-                    {filteredSensors.map((sensor, index) => (
-                        <Line
-                            key={sensor.name}
-                            type="linear"
-                            dataKey={sensor.name}
-                            stroke={chartColours.categorical[index % chartColours.categorical.length]}
-                            dot={false}
-                            connectNulls
-                        />
-                    ))}
-                </LineChart>
-            </ResponsiveContainer>
+            <WidgetSwap loading={loading} loader={<SignalTraceLoader />}>
+                {error && noData ? (
+                    <Typography sx={{ color: "text.secondary", p: 2 }}>
+                        Couldn't load comparison data. It will retry automatically.
+                    </Typography>
+                ) : noData ? (
+                    <Typography sx={{ color: "text.secondary", p: 2 }}>No data for the selected range</Typography>
+                ) : (
+                    <ResponsiveContainer width="100%" height="100%">
+                        <LineChart data={chartData}>
+                            <CartesianGrid stroke={chartColours.grid} strokeDasharray="3 3" />
+                            <XAxis
+                                dataKey="time"
+                                tickFormatter={(t: string) => new Date(t).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                                minTickGap={50}
+                            />
+                            <YAxis label={yAxisLabel} />
+                            <Tooltip />
+                            <Legend />
+                            {filteredSensors.map((sensor, index) => (
+                                <Line
+                                    key={sensor.name}
+                                    type="linear"
+                                    dataKey={sensor.name}
+                                    stroke={chartColours.categorical[index % chartColours.categorical.length]}
+                                    dot={false}
+                                    connectNulls
+                                />
+                            ))}
+                        </LineChart>
+                    </ResponsiveContainer>
+                )}
+            </WidgetSwap>
         </div>
     );
 }

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/CurrentReadingWidget.test.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/CurrentReadingWidget.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Sensor } from '../../gen/aliases';
+import CurrentReadingWidget from './CurrentReadingWidget';
+
+const { readingsMock, readyMock, reportUpdateMock } = vi.hoisted(() => ({
+  readingsMock: vi.fn(),
+  readyMock: vi.fn(),
+  reportUpdateMock: vi.fn(),
+}));
+
+const sensors: Sensor[] = [];
+
+vi.mock('../../hooks/useSensorContext', () => ({
+  useSensorContext: () => ({ sensors }),
+}));
+
+vi.mock('../../hooks/useCurrentReadings', () => ({
+  useCurrentReadings: () => readingsMock(),
+  useCurrentReadingsReady: () => readyMock(),
+}));
+
+vi.mock('../WidgetUpdateContext', () => ({
+  useReportWidgetUpdate: () => reportUpdateMock,
+}));
+
+vi.mock('../../theme/chartColours', () => ({
+  useChartColours: () => ({
+    categorical: [],
+    health: ['', '', ''],
+    stat: ['', '', ''],
+    grid: '#000',
+    axisText: '#000',
+    noData: '#E0D8D0',
+  }),
+}));
+
+function makeSensor(overrides: Partial<Sensor> = {}): Sensor {
+  return {
+    id: 7,
+    name: 'living-room',
+    external_id: 'lr',
+    sensor_driver: 'zigbee2mqtt',
+    config: {},
+    metadata: {},
+    health_status: 'good',
+    health_reason: 'ok',
+    enabled: true,
+    status: 'active',
+    retention_hours: null,
+    ...overrides,
+  };
+}
+
+const config = { sensorId: 7, measurementType: 'temperature' };
+
+describe('CurrentReadingWidget', () => {
+  beforeEach(() => {
+    sensors.splice(0, sensors.length, makeSensor());
+    readingsMock.mockReset();
+    readyMock.mockReset();
+  });
+
+  it('shows the loader (not the empty dash) while the first snapshot is still loading', () => {
+    readingsMock.mockReturnValue({});
+    readyMock.mockReturnValue(false);
+
+    render(<CurrentReadingWidget id="w" isEditing={false} config={config} />);
+
+    const loader = screen.getByTestId('widget-loader');
+    expect(loader).toBeInTheDocument();
+    expect(loader).toHaveAttribute('aria-busy', 'true');
+    expect(screen.queryByText('—')).not.toBeInTheDocument();
+  });
+
+  it('shows the reading once data has arrived', () => {
+    readingsMock.mockReturnValue({
+      'living-room': { temperature: { numeric_value: 21.4, unit: '°C', time: '2026-05-09T10:00:00Z' } },
+    });
+    readyMock.mockReturnValue(true);
+
+    render(<CurrentReadingWidget id="w" isEditing={false} config={config} />);
+
+    expect(screen.queryByTestId('widget-loader')).not.toBeInTheDocument();
+    expect(screen.getByText(/21\.4/)).toBeInTheDocument();
+  });
+
+  it('shows the empty dash once the snapshot is in but this sensor has no reading', () => {
+    readingsMock.mockReturnValue({});
+    readyMock.mockReturnValue(true);
+
+    render(<CurrentReadingWidget id="w" isEditing={false} config={config} />);
+
+    expect(screen.queryByTestId('widget-loader')).not.toBeInTheDocument();
+    expect(screen.getByText('—')).toBeInTheDocument();
+  });
+});

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/CurrentReadingWidget.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/CurrentReadingWidget.tsx
@@ -1,15 +1,17 @@
 import type { WidgetProps } from '../types';
 import { Box, Typography } from '@mui/material';
 import { useSensorContext } from '../../hooks/useSensorContext';
-import { useCurrentReadings } from '../../hooks/useCurrentReadings';
+import { useCurrentReadings, useCurrentReadingsReady } from '../../hooks/useCurrentReadings';
 import { parseUTCTime } from '../../tools/Utils';
 import NeedsConfiguration from '../NeedsConfiguration';
 import { useReportWidgetUpdate } from '../WidgetUpdateContext';
+import { WidgetSwap, ValuePlaceholderLoader } from '../widget-loaders';
 
 export default function CurrentReadingWidget({ config }: WidgetProps) {
     const { sensors } = useSensorContext();
     const reportUpdate = useReportWidgetUpdate();
     const readings = useCurrentReadings({ onDataUpdate: reportUpdate });
+    const ready = useCurrentReadingsReady();
 
     const sensorId = config.sensorId as number | undefined;
     const measurementType = config.measurementType as string | undefined;
@@ -20,26 +22,31 @@ export default function CurrentReadingWidget({ config }: WidgetProps) {
     }
 
     const reading = readings[sensor.name]?.[measurementType];
+    // Loading only while we have no reading for this widget AND no snapshot has
+    // arrived yet. Once the snapshot is in, a missing reading is genuinely empty.
+    const isLoading = !reading && !ready;
 
     return (
-        <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', height: '100%', p: 2 }}>
-            <Typography variant="subtitle1" sx={{
-                color: "text.secondary"
-            }}>{sensor.name}</Typography>
-            <Typography variant="h1" sx={{ fontSize: '4rem', fontWeight: 'bold', textAlign: 'center' }}>
-                {reading
-                    ? reading.numeric_value != null
-                        ? `${reading.numeric_value.toFixed(1)}${reading.unit ? ` ${reading.unit}` : ''}`
-                        : reading.text_state ?? '—'
-                    : '—'}
-            </Typography>
-            {reading && (
-                <Typography variant="caption" sx={{
+        <WidgetSwap loading={isLoading} loader={<ValuePlaceholderLoader />}>
+            <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', height: '100%', p: 2 }}>
+                <Typography variant="subtitle1" sx={{
                     color: "text.secondary"
-                }}>
-                    {parseUTCTime(reading.time).toLocaleString()}
+                }}>{sensor.name}</Typography>
+                <Typography variant="h1" sx={{ fontSize: '4rem', fontWeight: 'bold', textAlign: 'center' }}>
+                    {reading
+                        ? reading.numeric_value != null
+                            ? `${reading.numeric_value.toFixed(1)}${reading.unit ? ` ${reading.unit}` : ''}`
+                            : reading.text_state ?? '—'
+                        : '—'}
                 </Typography>
-            )}
-        </Box>
+                {reading && (
+                    <Typography variant="caption" sx={{
+                        color: "text.secondary"
+                    }}>
+                        {parseUTCTime(reading.time).toLocaleString()}
+                    </Typography>
+                )}
+            </Box>
+        </WidgetSwap>
     );
 }

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/GaugeWidget.test.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/GaugeWidget.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Sensor } from '../../gen/aliases';
+import GaugeWidget from './GaugeWidget';
+
+const { readingsMock, readyMock, reportUpdateMock } = vi.hoisted(() => ({
+  readingsMock: vi.fn(),
+  readyMock: vi.fn(),
+  reportUpdateMock: vi.fn(),
+}));
+
+const sensors: Sensor[] = [];
+
+vi.mock('../../hooks/useSensorContext', () => ({ useSensorContext: () => ({ sensors }) }));
+vi.mock('../../hooks/useCurrentReadings', () => ({
+  useCurrentReadings: () => readingsMock(),
+  useCurrentReadingsReady: () => readyMock(),
+}));
+vi.mock('../WidgetUpdateContext', () => ({ useReportWidgetUpdate: () => reportUpdateMock }));
+vi.mock('../../theme/chartColours', () => ({
+  useChartColours: () => ({ categorical: ['#D4451A'], health: ['', '', ''], stat: ['', '', ''], grid: '#000', axisText: '#000', noData: '#E0D8D0' }),
+}));
+
+function makeSensor(overrides: Partial<Sensor> = {}): Sensor {
+  return {
+    id: 7, name: 'boiler', external_id: 'b', sensor_driver: 'z', config: {}, metadata: {},
+    health_status: 'good', health_reason: 'ok', enabled: true, status: 'active', retention_hours: null, ...overrides,
+  };
+}
+
+const config = { sensorId: 7, measurementType: 'temperature' };
+
+describe('GaugeWidget loading states', () => {
+  beforeEach(() => {
+    sensors.splice(0, sensors.length, makeSensor());
+    readingsMock.mockReset();
+    readyMock.mockReset();
+  });
+
+  it('shows the circular-draw loader while loading (not the empty dash)', () => {
+    readingsMock.mockReturnValue({});
+    readyMock.mockReturnValue(false);
+    render(<GaugeWidget id="w" isEditing={false} config={config} />);
+    expect(screen.getByTestId('widget-loader')).toBeInTheDocument();
+    expect(screen.queryByText('—')).not.toBeInTheDocument();
+  });
+
+  it('shows the gauge value once data has arrived', () => {
+    readingsMock.mockReturnValue({ boiler: { temperature: { numeric_value: 21.4, unit: '°C', time: '2026-05-09T10:00:00Z' } } });
+    readyMock.mockReturnValue(true);
+    render(<GaugeWidget id="w" isEditing={false} config={config} />);
+    expect(screen.queryByTestId('widget-loader')).not.toBeInTheDocument();
+    expect(screen.getByText(/21\.4/)).toBeInTheDocument();
+  });
+
+  it('shows the empty dash once loaded with no reading', () => {
+    readingsMock.mockReturnValue({});
+    readyMock.mockReturnValue(true);
+    render(<GaugeWidget id="w" isEditing={false} config={config} />);
+    expect(screen.queryByTestId('widget-loader')).not.toBeInTheDocument();
+    expect(screen.getByText('—')).toBeInTheDocument();
+  });
+});

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/GaugeWidget.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/GaugeWidget.tsx
@@ -1,14 +1,16 @@
 import type { WidgetProps } from '../types';
 import { Box, CircularProgress, Typography } from '@mui/material';
 import { useSensorContext } from '../../hooks/useSensorContext';
-import { useCurrentReadings } from '../../hooks/useCurrentReadings';
+import { useCurrentReadings, useCurrentReadingsReady } from '../../hooks/useCurrentReadings';
 import NeedsConfiguration from '../NeedsConfiguration';
 import { useReportWidgetUpdate } from '../WidgetUpdateContext';
+import { WidgetSwap, CircularDrawLoader } from '../widget-loaders';
 
 export default function GaugeWidget({ config }: WidgetProps) {
     const { sensors } = useSensorContext();
     const reportUpdate = useReportWidgetUpdate();
     const readings = useCurrentReadings({ onDataUpdate: reportUpdate });
+    const ready = useCurrentReadingsReady();
 
     const sensorId = config.sensorId as number | undefined;
     const measurementType = config.measurementType as string | undefined;
@@ -25,6 +27,7 @@ export default function GaugeWidget({ config }: WidgetProps) {
     const value = reading?.numeric_value ?? null;
     const unit = reading?.unit ?? '';
     const percentage = value !== null ? Math.max(0, Math.min(100, ((value - min) / (max - min)) * 100)) : 0;
+    const isLoading = value === null && !ready;
 
     const getColor = (pct: number) => {
         if (pct < 33) return '#1976d2';
@@ -33,6 +36,7 @@ export default function GaugeWidget({ config }: WidgetProps) {
     };
 
     return (
+        <WidgetSwap loading={isLoading} loader={<CircularDrawLoader />}>
         <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', height: '100%', p: 2 }}>
             <Box sx={{ position: 'relative', display: 'inline-flex' }}>
                 <CircularProgress
@@ -60,5 +64,6 @@ export default function GaugeWidget({ config }: WidgetProps) {
                 {sensor.name}
             </Typography>
         </Box>
+        </WidgetSwap>
     );
 }

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/GroupSummaryWidget.test.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/GroupSummaryWidget.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import GroupSummaryWidget from './GroupSummaryWidget';
+
+const { readingsMock, readyMock, reportUpdateMock } = vi.hoisted(() => ({
+  readingsMock: vi.fn(),
+  readyMock: vi.fn(),
+  reportUpdateMock: vi.fn(),
+}));
+
+vi.mock('../../hooks/useCurrentReadings', () => ({
+  useCurrentReadings: () => readingsMock(),
+  useCurrentReadingsReady: () => readyMock(),
+}));
+vi.mock('../WidgetUpdateContext', () => ({ useReportWidgetUpdate: () => reportUpdateMock }));
+vi.mock('../../theme/chartColours', () => ({
+  useChartColours: () => ({ categorical: ['#D4451A'], health: ['', '', ''], stat: ['', '', ''], grid: '#000', axisText: '#000', noData: '#E0D8D0' }),
+}));
+
+const config = { measurementType: 'temperature' };
+
+describe('GroupSummaryWidget loading state', () => {
+  beforeEach(() => {
+    readingsMock.mockReset();
+    readyMock.mockReset();
+  });
+
+  it('shows the loader while readings are still loading', () => {
+    readingsMock.mockReturnValue({});
+    readyMock.mockReturnValue(false);
+    render(<GroupSummaryWidget id="w" isEditing={false} config={config} />);
+    expect(screen.getByTestId('widget-loader')).toBeInTheDocument();
+    expect(screen.queryByText('No temperature readings available')).not.toBeInTheDocument();
+  });
+
+  it('shows the empty message once loaded with no readings', () => {
+    readingsMock.mockReturnValue({});
+    readyMock.mockReturnValue(true);
+    render(<GroupSummaryWidget id="w" isEditing={false} config={config} />);
+    expect(screen.queryByTestId('widget-loader')).not.toBeInTheDocument();
+    expect(screen.getByText('No temperature readings available')).toBeInTheDocument();
+  });
+
+  it('shows the group average once data arrives', () => {
+    readingsMock.mockReturnValue({ 'living-room': { temperature: { numeric_value: 20, unit: '°C', time: 't' } } });
+    readyMock.mockReturnValue(true);
+    render(<GroupSummaryWidget id="w" isEditing={false} config={config} />);
+    expect(screen.queryByTestId('widget-loader')).not.toBeInTheDocument();
+    expect(screen.getByText('Group Average')).toBeInTheDocument();
+    expect(screen.getAllByText(/20\.0/).length).toBeGreaterThan(0);
+  });
+});

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/GroupSummaryWidget.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/GroupSummaryWidget.tsx
@@ -1,12 +1,14 @@
 import type { WidgetProps } from '../types';
 import { Box, Typography } from '@mui/material';
-import { useCurrentReadings } from '../../hooks/useCurrentReadings';
+import { useCurrentReadings, useCurrentReadingsReady } from '../../hooks/useCurrentReadings';
 import NeedsConfiguration from '../NeedsConfiguration';
 import { useReportWidgetUpdate } from '../WidgetUpdateContext';
+import { WidgetSwap, ValuePlaceholderLoader } from '../widget-loaders';
 
 export default function GroupSummaryWidget({ config }: WidgetProps) {
     const reportUpdate = useReportWidgetUpdate();
     const readings = useCurrentReadings({ onDataUpdate: reportUpdate });
+    const ready = useCurrentReadingsReady();
     const measurementType = config.measurementType as string | undefined;
 
     if (!measurementType) {
@@ -22,38 +24,39 @@ export default function GroupSummaryWidget({ config }: WidgetProps) {
         }
     }
 
-    if (matched.length === 0) {
-        return (
-            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}>
-                <Typography sx={{
-                    color: "text.secondary"
-                }}>No {measurementType} readings available</Typography>
-            </Box>
-        );
-    }
-
+    const isLoading = matched.length === 0 && !ready;
     const nums = matched.filter(r => r.value !== null).map(r => r.value!);
     const avg = nums.length > 0 ? nums.reduce((sum, v) => sum + v, 0) / nums.length : 0;
     const unit = matched[0]?.unit ?? '';
 
     return (
-        <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', p: 2 }}>
-            <Typography variant="subtitle1" sx={{ fontWeight: 'bold' }}>Group Average</Typography>
-            <Box sx={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                <Typography variant="h2" sx={{ fontWeight: 'bold', textAlign: 'center' }}>
-                    {avg.toFixed(1)}{unit}
-                </Typography>
-            </Box>
-            <Box sx={{ maxHeight: 120, overflow: 'auto' }}>
-                {matched.map(({ name, value, unit: u }) => (
-                    <Box key={name} sx={{ display: 'flex', justifyContent: 'space-between', py: 0.25 }}>
-                        <Typography variant="caption" sx={{
-                            color: "text.secondary"
-                        }}>{name}</Typography>
-                        <Typography variant="caption">{value?.toFixed(1) ?? '—'}{u}</Typography>
+        <WidgetSwap loading={isLoading} loader={<ValuePlaceholderLoader />}>
+            {matched.length === 0 ? (
+                <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}>
+                    <Typography sx={{
+                        color: "text.secondary"
+                    }}>No {measurementType} readings available</Typography>
+                </Box>
+            ) : (
+                <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', p: 2 }}>
+                    <Typography variant="subtitle1" sx={{ fontWeight: 'bold' }}>Group Average</Typography>
+                    <Box sx={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                        <Typography variant="h2" sx={{ fontWeight: 'bold', textAlign: 'center' }}>
+                            {avg.toFixed(1)}{unit}
+                        </Typography>
                     </Box>
-                ))}
-            </Box>
-        </Box>
+                    <Box sx={{ maxHeight: 120, overflow: 'auto' }}>
+                        {matched.map(({ name, value, unit: u }) => (
+                            <Box key={name} sx={{ display: 'flex', justifyContent: 'space-between', py: 0.25 }}>
+                                <Typography variant="caption" sx={{
+                                    color: "text.secondary"
+                                }}>{name}</Typography>
+                                <Typography variant="caption">{value?.toFixed(1) ?? '—'}{u}</Typography>
+                            </Box>
+                        ))}
+                    </Box>
+                </Box>
+            )}
+        </WidgetSwap>
     );
 }

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/HeatmapWidget.test.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/HeatmapWidget.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen, waitForElementToBeRemoved } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Sensor } from '../../gen/aliases';
+import HeatmapWidget from './HeatmapWidget';
+
+const { scheduleMock, reportUpdateMock } = vi.hoisted(() => ({
+  scheduleMock: vi.fn(),
+  reportUpdateMock: vi.fn(),
+}));
+
+const sensors: Sensor[] = [];
+
+vi.mock('../../hooks/useSensorContext', () => ({ useSensorContext: () => ({ sensors }) }));
+vi.mock('../WidgetUpdateContext', () => ({ useReportWidgetUpdate: () => reportUpdateMock }));
+vi.mock('../../theme/useIsDark', () => ({ useIsDark: () => false }));
+vi.mock('../../scheduler/requestScheduler', () => ({ requestScheduler: { schedule: scheduleMock } }));
+vi.mock('../../gen/client', () => ({ apiClient: { GET: vi.fn() } }));
+vi.mock('../../theme/chartColours', () => ({
+  useChartColours: () => ({ categorical: ['#D4451A'], health: ['', '', ''], stat: ['', '', ''], grid: '#000', axisText: '#000', noData: '#E0D8D0' }),
+}));
+
+function makeSensor(): Sensor {
+  return {
+    id: 7, name: 'greenhouse', external_id: 'g', sensor_driver: 'z', config: {}, metadata: {},
+    health_status: 'good', health_reason: 'ok', enabled: true, status: 'active', retention_hours: null,
+  };
+}
+
+const config = { sensorId: 7, measurementType: 'temperature' };
+
+describe('HeatmapWidget loading state', () => {
+  beforeEach(() => {
+    sensors.splice(0, sensors.length, makeSensor());
+    scheduleMock.mockReset();
+    reportUpdateMock.mockReset();
+  });
+
+  it('shows the ripple loader while the fetch is in flight', () => {
+    scheduleMock.mockReturnValue(new Promise(() => {})); // never resolves
+    render(<HeatmapWidget id="w" isEditing={false} config={config} />);
+    expect(screen.getByTestId('widget-loader')).toBeInTheDocument();
+    expect(screen.getAllByTestId('heatmap-cell').length).toBe(30);
+  });
+
+  it('replaces the loader with the day grid once data has loaded', async () => {
+    scheduleMock.mockResolvedValue({ data: { readings: [] } });
+    render(<HeatmapWidget id="w" isEditing={false} config={config} />);
+    await waitForElementToBeRemoved(() => screen.queryByTestId('widget-loader'));
+    // Loader gone; the real grid (no animated loader cells) is shown.
+    expect(screen.queryByTestId('heatmap-cell')).not.toBeInTheDocument();
+  });
+});

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/HeatmapWidget.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/HeatmapWidget.tsx
@@ -8,6 +8,7 @@ import { useIsDark } from '../../theme/useIsDark';
 import { parseUTCTime } from '../../tools/Utils';
 import NeedsConfiguration from '../NeedsConfiguration';
 import { useReportWidgetUpdate } from '../WidgetUpdateContext';
+import { WidgetSwap, RippleHeatmapLoader } from '../widget-loaders';
 
 function valueToColor(value: number, low: number, high: number): string {
     const ratio = Math.max(0, Math.min(1, (value - low) / (high - low)));
@@ -40,6 +41,7 @@ export default function HeatmapWidget({ config }: WidgetProps) {
     const isDark = useIsDark();
     const reportUpdate = useReportWidgetUpdate();
     const [days, setDays] = useState<DayData[]>([]);
+    const [loading, setLoading] = useState(true);
     const [cellSize, setCellSize] = useState(28);
     const gridRef = useRef<HTMLDivElement>(null);
 
@@ -76,6 +78,7 @@ export default function HeatmapWidget({ config }: WidgetProps) {
     useEffect(() => {
         if (!sensor) return;
 
+        setLoading(true);
         const now = new Date();
         const start = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
 
@@ -101,7 +104,7 @@ export default function HeatmapWidget({ config }: WidgetProps) {
             }
             setDays(result);
             reportUpdate(new Date());
-        });
+        }).finally(() => setLoading(false));
     }, [sensor, measurementType]);
 
     if (!sensor || !measurementType) {
@@ -132,6 +135,7 @@ export default function HeatmapWidget({ config }: WidgetProps) {
                     justifyContent: 'center',
                 }}
             >
+                <WidgetSwap loading={loading && days.length === 0} loader={<RippleHeatmapLoader columns={cols} count={30} />}>
                 <Box
                     sx={{
                         display: 'grid',
@@ -159,6 +163,7 @@ export default function HeatmapWidget({ config }: WidgetProps) {
                         </Box>
                     ))}
                 </Box>
+                </WidgetSwap>
             </Box>
         </Box>
     );

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/MinMaxAvgWidget.test.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/MinMaxAvgWidget.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen, waitForElementToBeRemoved } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Sensor } from '../../gen/aliases';
+import MinMaxAvgWidget from './MinMaxAvgWidget';
+
+const { scheduleMock, reportUpdateMock } = vi.hoisted(() => ({
+  scheduleMock: vi.fn(),
+  reportUpdateMock: vi.fn(),
+}));
+
+const sensors: Sensor[] = [];
+
+vi.mock('../../hooks/useSensorContext', () => ({ useSensorContext: () => ({ sensors }) }));
+vi.mock('../WidgetUpdateContext', () => ({ useReportWidgetUpdate: () => reportUpdateMock }));
+vi.mock('../../scheduler/requestScheduler', () => ({ requestScheduler: { schedule: scheduleMock } }));
+vi.mock('../../gen/client', () => ({ apiClient: { GET: vi.fn() } }));
+vi.mock('../../theme/chartColours', () => ({
+  useChartColours: () => ({ categorical: ['#D4451A'], health: ['', '', ''], stat: ['#0288D1', '#5C5C5C', '#C62828'], grid: '#000', axisText: '#000', noData: '#E0D8D0' }),
+}));
+
+function makeSensor(): Sensor {
+  return {
+    id: 7, name: 'fridge', external_id: 'f', sensor_driver: 'z', config: {}, metadata: {},
+    health_status: 'good', health_reason: 'ok', enabled: true, status: 'active', retention_hours: null,
+  };
+}
+
+const config = { sensorId: 7, measurementType: 'temperature' };
+
+describe('MinMaxAvgWidget loading state', () => {
+  beforeEach(() => {
+    sensors.splice(0, sensors.length, makeSensor());
+    scheduleMock.mockReset();
+    reportUpdateMock.mockReset();
+  });
+
+  it('shows skeleton tiles (not "No data available") while loading', () => {
+    scheduleMock.mockReturnValue(new Promise(() => {}));
+    render(<MinMaxAvgWidget id="w" isEditing={false} config={config} />);
+    expect(screen.getByTestId('widget-loader')).toBeInTheDocument();
+    expect(screen.getAllByTestId('stat-tile')).toHaveLength(3);
+    expect(screen.queryByText('No data available')).not.toBeInTheDocument();
+  });
+
+  it('shows the empty state once loaded with no readings', async () => {
+    scheduleMock.mockResolvedValue({ data: { readings: [] } });
+    render(<MinMaxAvgWidget id="w" isEditing={false} config={config} />);
+    await waitForElementToBeRemoved(() => screen.queryByTestId('widget-loader'));
+    expect(screen.getByText('No data available')).toBeInTheDocument();
+  });
+});

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/MinMaxAvgWidget.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/MinMaxAvgWidget.tsx
@@ -8,12 +8,14 @@ import { useChartColours } from '../../theme/chartColours';
 import NeedsConfiguration from '../NeedsConfiguration';
 import { resolveTimeRange } from '../timeRange';
 import { useReportWidgetUpdate } from '../WidgetUpdateContext';
+import { WidgetSwap, SkeletonTilesLoader } from '../widget-loaders';
 
 export default function MinMaxAvgWidget({ config }: WidgetProps) {
     const { sensors } = useSensorContext();
     const chartColours = useChartColours();
     const reportUpdate = useReportWidgetUpdate();
     const [stats, setStats] = useState<{ min: number; max: number; avg: number; unit: string } | null>(null);
+    const [loading, setLoading] = useState(true);
 
     const sensorId = config.sensorId as number | undefined;
     const measurementType = config.measurementType as string | undefined;
@@ -26,6 +28,7 @@ export default function MinMaxAvgWidget({ config }: WidgetProps) {
     useEffect(() => {
         if (!sensor) return;
 
+        setLoading(true);
         requestScheduler.schedule('normal', () => apiClient.GET('/readings/between', { params: { query: { start: startIso, end: endIso, measurement_type: measurementType } } })).then(({ data: response }) => {
             const sensorReadings = (response?.readings ?? []).filter((r) => r.sensor_name === sensor.name);
             if (sensorReadings.length === 0) {
@@ -39,44 +42,46 @@ export default function MinMaxAvgWidget({ config }: WidgetProps) {
             const unit = sensorReadings[0]?.unit ?? '';
             setStats({ min, max, avg, unit });
             reportUpdate(new Date());
-        });
+        }).finally(() => setLoading(false));
     }, [sensor, startIso, endIso, measurementType]);
 
     if (!sensor || !measurementType) {
         return <NeedsConfiguration message="Select a sensor and measurement type" />;
     }
 
-    if (!stats) {
-        return (
-            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}>
-                <Typography sx={{
-                    color: "text.secondary"
-                }}>No data available</Typography>
-            </Box>
-        );
-    }
-
-    const statItems = [
-        { label: 'Min', value: stats.min, color: chartColours.stat[0] },
-        { label: 'Avg', value: stats.avg, color: chartColours.stat[1] },
-        { label: 'Max', value: stats.max, color: chartColours.stat[2] },
-    ];
+    const statItems = stats
+        ? [
+            { label: 'Min', value: stats.min, color: chartColours.stat[0] },
+            { label: 'Avg', value: stats.avg, color: chartColours.stat[1] },
+            { label: 'Max', value: stats.max, color: chartColours.stat[2] },
+        ]
+        : [];
 
     return (
-        <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', p: 2 }}>
-            <Typography variant="subtitle1" sx={{ mb: 1 }}>{sensor.name}</Typography>
-            <Box sx={{ display: 'flex', flexDirection: 'row', gap: 2, flex: 1, alignItems: 'center' }}>
-                {statItems.map((item) => (
-                    <Paper key={item.label} sx={{ flex: 1, p: 2, textAlign: 'center' }} elevation={1}>
-                        <Typography variant="caption" sx={{ color: item.color, fontWeight: 'bold' }}>
-                            {item.label}
-                        </Typography>
-                        <Typography variant="h5" sx={{ color: item.color }}>
-                            {item.value.toFixed(1)}{stats.unit}
-                        </Typography>
-                    </Paper>
-                ))}
-            </Box>
-        </Box>
+        <WidgetSwap loading={loading && !stats} loader={<SkeletonTilesLoader />}>
+            {!stats ? (
+                <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}>
+                    <Typography sx={{
+                        color: "text.secondary"
+                    }}>No data available</Typography>
+                </Box>
+            ) : (
+                <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', p: 2 }}>
+                    <Typography variant="subtitle1" sx={{ mb: 1 }}>{sensor.name}</Typography>
+                    <Box sx={{ display: 'flex', flexDirection: 'row', gap: 2, flex: 1, alignItems: 'center' }}>
+                        {statItems.map((item) => (
+                            <Paper key={item.label} sx={{ flex: 1, p: 2, textAlign: 'center' }} elevation={1}>
+                                <Typography variant="caption" sx={{ color: item.color, fontWeight: 'bold' }}>
+                                    {item.label}
+                                </Typography>
+                                <Typography variant="h5" sx={{ color: item.color }}>
+                                    {item.value.toFixed(1)}{stats.unit}
+                                </Typography>
+                            </Paper>
+                        ))}
+                    </Box>
+                </Box>
+            )}
+        </WidgetSwap>
     );
 }

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/UptimeWidget.test.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/UptimeWidget.test.tsx
@@ -29,6 +29,10 @@ vi.mock('../WidgetUpdateContext', () => ({
   useReportWidgetUpdate: () => reportUpdateMock,
 }));
 
+vi.mock('../../theme/chartColours', () => ({
+  useChartColours: () => ({ categorical: ['#D4451A'], health: ['', '', ''], stat: ['', '', ''], grid: '#000', axisText: '#000', noData: '#E0D8D0' }),
+}));
+
 function makeSensor(overrides: Partial<Sensor> = {}): Sensor {
   return {
     id: 7,
@@ -64,6 +68,15 @@ describe('UptimeWidget', () => {
     Object.keys(properties).forEach((key) => delete properties[key]);
     reportUpdateMock.mockReset();
     useSensorHealthHistoryMock.mockReset();
+  });
+
+  it('shows the indeterminate-bar loader while health history is loading', () => {
+    useSensorHealthHistoryMock.mockReturnValue([[], vi.fn(), true]);
+
+    render(<UptimeWidget id="widget-1" isEditing={false} config={{ sensorId: 7 }} />);
+
+    expect(screen.getByTestId('widget-loader')).toBeInTheDocument();
+    expect(screen.queryByText('—')).not.toBeInTheDocument();
   });
 
   it('shows a time-weighted uptime percentage instead of transition-count uptime', () => {

--- a/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/UptimeWidget.tsx
+++ b/sensor_hub/ui/sensor_hub_ui/src/dashboard/widgets/UptimeWidget.tsx
@@ -6,6 +6,7 @@ import useSensorHealthHistory from '../../hooks/useSensorHealthHistory';
 import { useReportWidgetUpdate } from '../WidgetUpdateContext';
 import { buildHealthWindowModel, formatDurationShort, formatWindowLabel } from '../../health/healthWindow';
 import { useProperties } from '../../hooks/useProperties';
+import { WidgetSwap, IndeterminateBarLoader } from '../widget-loaders';
 
 export default function UptimeWidget({ config }: WidgetProps) {
     const { sensors } = useSensorContext();
@@ -15,7 +16,7 @@ export default function UptimeWidget({ config }: WidgetProps) {
     const sensor = sensorId ? sensors.find((s) => s.id === sensorId) : undefined;
     const sensorName = sensor?.name ?? '';
 
-    const [history] = useSensorHealthHistory(sensorName);
+    const [history, , historyLoading] = useSensorHealthHistory(sensorName);
 
     useEffect(() => {
         if (history.length > 0) reportUpdate(new Date());
@@ -55,6 +56,7 @@ export default function UptimeWidget({ config }: WidgetProps) {
     }
 
     return (
+        <WidgetSwap loading={historyLoading && !model} loader={<IndeterminateBarLoader />}>
         <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', height: '100%', p: 2, gap: 2 }}>
             <Typography variant="h3" sx={{ fontWeight: 'bold' }}>
                 {model ? `${uptime.toFixed(1)}%` : '—'}
@@ -85,5 +87,6 @@ export default function UptimeWidget({ config }: WidgetProps) {
                 color: "text.secondary"
             }}>{sensor.name}</Typography>
         </Box>
+        </WidgetSwap>
     );
 }

--- a/sensor_hub/ui/sensor_hub_ui/src/hooks/useCurrentReadings.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/hooks/useCurrentReadings.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useRef, useState, useSyncExternalStore } from "react";
 import type { CommandStatusMessage, Reading } from "../gen/aliases";
 import { WEBSOCKET_BASE } from "../environment/Environment";
 import { useAuth } from "../providers/AuthContext.tsx";
@@ -8,6 +8,34 @@ import { useReconnectingWebSocket } from './useReconnectingWebSocket';
 export type CurrentReadingsMap = Record<string, Record<string, Reading>>;
 
 let cachedCurrentReadings: CurrentReadingsMap = {};
+
+// Tracks whether we have ever received a readings snapshot this session, so
+// widgets can tell "still waiting for the first message" apart from "received,
+// but genuinely empty". Survives remounts (module scope) like the cache above.
+let hasReceivedFirstSnapshot = Object.keys(cachedCurrentReadings).length > 0;
+const readyListeners = new Set<() => void>();
+
+function markSnapshotReceived() {
+  if (hasReceivedFirstSnapshot) return;
+  hasReceivedFirstSnapshot = true;
+  readyListeners.forEach((listener) => listener());
+}
+
+/**
+ * Reactive flag: true once the first current-readings snapshot has arrived
+ * (or a warm cache is already populated). Use alongside a per-widget data check
+ * to drive a loading state — loader while `!ready && noReadingYet`.
+ */
+export function useCurrentReadingsReady(): boolean {
+  return useSyncExternalStore(
+    (callback) => {
+      readyListeners.add(callback);
+      return () => { readyListeners.delete(callback); };
+    },
+    () => hasReceivedFirstSnapshot,
+    () => hasReceivedFirstSnapshot,
+  );
+}
 
 interface UseCurrentReadingsOptions {
     onDataUpdate?: (date: Date) => void;
@@ -52,6 +80,7 @@ export function useCurrentReadings(options?: UseCurrentReadingsOptions): Current
           cachedCurrentReadings = next;
           return next;
         });
+        markSnapshotReceived();
         onDataUpdateRef.current?.(new Date());
         return;
       }
@@ -69,6 +98,7 @@ export function useCurrentReadings(options?: UseCurrentReadingsOptions): Current
           cachedCurrentReadings = next;
           return next;
         });
+        markSnapshotReceived();
         onDataUpdateRef.current?.(new Date());
         return;
       }
@@ -79,6 +109,7 @@ export function useCurrentReadings(options?: UseCurrentReadingsOptions): Current
           cachedCurrentReadings = next;
           return next;
         });
+        markSnapshotReceived();
         onDataUpdateRef.current?.(new Date());
       }
   }, []);

--- a/sensor_hub/ui/sensor_hub_ui/src/hooks/useReadingsData.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/hooks/useReadingsData.ts
@@ -39,6 +39,8 @@ export function useReadingsData({
                                    }: useReadingsDataProps) {
   const [mergedData, setMergedData] = useState<ChartEntry[]>([]);
   const [aggregation, setAggregation] = useState<AggregationMeta>({ interval: 'raw', function: 'none' });
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const prevResponseJsonRef = useRef<string | null>(null);
   const prevSensorsKeyRef = useRef<string>("");
   const prevMergedJsonRef = useRef<string>("");
@@ -72,7 +74,13 @@ export function useReadingsData({
     const resolved = resolveTimeRangeRef.current?.();
     const initStart = resolved?.startDate?.toUTC().toISO() ?? startIso;
     const initEnd = resolved?.endDate?.toUTC().toISO() ?? endIso;
-    if (!initStart || !initEnd) return;
+    if (!initStart || !initEnd) {
+      setIsLoading(false);
+      return;
+    }
+
+    // New range / sensor set: we're loading the first result again.
+    setIsLoading(true);
 
     const fetchAndMaybeUpdate = async (
       fetchStartIso: string,
@@ -90,6 +98,8 @@ export function useReadingsData({
         const data: Reading[] = response.data?.readings ?? [];
 
         if (requestIdRef.current !== currentRequestId || !isMountedRef.current) return;
+
+        setError(null);
 
         setAggregation({
           interval: response.data?.aggregation_interval ?? 'raw',
@@ -134,10 +144,13 @@ export function useReadingsData({
       } catch (err: unknown) {
         if (!isMountedRef.current) return;
         logger.error("Error fetching readings:", err);
+        setError(err instanceof Error ? err.message : String(err));
       }
     };
 
-    void fetchAndMaybeUpdate(initStart, initEnd, true, 'normal');
+    void fetchAndMaybeUpdate(initStart, initEnd, true, 'normal').finally(() => {
+      if (isMountedRef.current) setIsLoading(false);
+    });
 
     const intervalId = window.setInterval(() => {
       // Re-resolve time range on each tick so relative presets slide forward
@@ -158,5 +171,5 @@ export function useReadingsData({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [measurementType, aggregationFunction, sensorsKey, pollIntervalMs, timeKey]);
 
-  return { mergedData, aggregation };
+  return { mergedData, aggregation, isLoading, error };
 }

--- a/sensor_hub/ui/sensor_hub_ui/src/hooks/useSensorHealthHistory.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/hooks/useSensorHealthHistory.ts
@@ -4,10 +4,12 @@ import { apiClient } from "../gen/client";
 import { useAuth } from '../providers/AuthContext.tsx';
 import { logger } from '../tools/logger';
 
-function useSensorHealthHistory(sensorName: string): [SensorHealthHistory[], () => Promise<void>] {
+function useSensorHealthHistory(sensorName: string): [SensorHealthHistory[], () => Promise<void>, boolean] {
   const [healthHistory, setHealthHistory] = useState<SensorHealthHistory[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
 
   const fetchHistory = useCallback(async () => {
+    setIsLoading(true);
     try {
       const { data } = await apiClient.GET('/sensors/health/{name}', {
         params: { path: { name: sensorName } },
@@ -15,6 +17,8 @@ function useSensorHealthHistory(sensorName: string): [SensorHealthHistory[], () 
       setHealthHistory(data ?? []);
     } catch (err) {
       logger.error("Failed to load sensor health history", err);
+    } finally {
+      setIsLoading(false);
     }
   }, [sensorName]);
 
@@ -23,11 +27,14 @@ function useSensorHealthHistory(sensorName: string): [SensorHealthHistory[], () 
   useEffect(() => {
     if (user === undefined) return;
     if (user === null) return;
-    if (!sensorName) return;
+    if (!sensorName) {
+      setIsLoading(false);
+      return;
+    }
     void fetchHistory();
   }, [fetchHistory, user, sensorName]);
 
-  return [healthHistory, fetchHistory];
+  return [healthHistory, fetchHistory, isLoading];
 }
 
 export default useSensorHealthHistory;


### PR DESCRIPTION
## Animated loading states for dashboard widgets — the "Incoming" family

Implements PRD #219. Every data-driven widget now shows a consistent animated "data is on the way" state on first load, instead of flashing its empty state while the first fetch is in flight.

### What's here

A coherent loader family — a calm grey skeleton base (the existing `chartColours.noData` token) with a single terracotta element in motion — plus the plumbing to drive it. New shared module: `src/dashboard/widget-loaders/`.

**Foundation**
- `WidgetSwap` — the integration primitive: shows a loader while loading, then cross-fades to the resolved content, occupying the same box (no layout shift).
- `useLoaderVisibility` — anti-flash: once shown, a loader stays for a minimum duration (~350ms) so fast/warm-cache loads don't blink.
- `usePrefersReducedMotion` + `LoaderShell` (role="status" / `aria-busy`, since the family is text-free) — every loader degrades to a static skeleton under reduced motion.

**Per-widget loaders**
| Widget(s) | Loader |
|---|---|
| readings-chart, comparison-chart, health-timeline | Signal trace (self-drawing line) |
| current-reading, group-summary | Value placeholder (shimmer block / em-dashes, **dynamic unit**, no fake numbers) |
| gauge, sensor-health-pie, sensor-type-pie | Circular draw (shared radial ring) |
| heatmap | Ripple populate (7×30 grid, matches the real widget) |
| live-readings, reading-stats, alert-summary, notifications-feed | Cascade rows (+ scan-line alt) |
| min-max-avg | Skeleton tiles |
| uptime | Indeterminate bar |
| weather-forecast | Cascading day columns |
| sensor-detail | Cascading stat tiles |

Excluded: `sensor-toggle` (interactive) and `markdown-note` (static).

**Plumbing (loading vs empty)**
- `useCurrentReadings` → `useCurrentReadingsReady()` first-snapshot signal.
- `useReadingsData` → exposes `isLoading` + `error` (previously only logged).
- `useSensorHealthHistory` → `isLoading` (backward-compatible 3rd tuple element).
- Ad-hoc fetches (heatmap, alert-summary, min-max-avg, sensor-detail) → per-widget loading flag.

Family rules followed throughout: **visuals only** (no "loading…" text), **never fake a value** (no real/random numbers), **terracotta-in-motion over grey**.

### Testing

TDD across all slices. `vitest run`: **75 tests / 29 files green**. `tsc` clean and production build passes. Each slice is its own commit (#220–#229). Tests cover the three-state machine (loading → empty → data, plus error) for a representative widget per data source, the anti-flash hook timing, `aria-busy`, and a coverage guard over the family exports.

### Notes / follow-ups
- `npm run lint` is currently broken on the repo independently of this change: the installed ESLint 10 rejects the legacy `plugins`-array config emitted by a shared plugin config. Not touched here; flagged for a separate tooling fix. `tsc` + tests were used as the gates.
- Closes #220, #221, #222, #223, #224, #225, #226, #227, #228, #229.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
