### PR TITLE
Track the design artifacts in the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -258,4 +258,3 @@ sensorHub
 *.test
 
 docs/plans
-.lavish

--- a/.lavish/loading-states.html
+++ b/.lavish/loading-states.html
@@ -1,0 +1,394 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Widget Loading States — the Incoming family</title>
+<style>
+  :root {
+    --bg: #F5F0EB; --paper: #FFFFFF; --text: #1A1A1A; --text2: #5C5C5C;
+    --primary: #D4451A; --primary-soft: rgba(212,69,26,0.16); --divider: #D9D0C7;
+    --nodata: #E6DDD3; --nodata-hi: #F3EDE6; --grid: #E3DAD0;
+    --shadow: 0 1px 3px rgba(0,0,0,0.10), 0 1px 2px rgba(0,0,0,0.06);
+  }
+  body.dark {
+    --bg: #1A1A1A; --paper: #242424; --text: #E8E8E8; --text2: #A0A0A0;
+    --primary: #ED5125; --primary-soft: rgba(237,81,37,0.22); --divider: #333333;
+    --nodata: #333333; --nodata-hi: #444444; --grid: #2E2E2E;
+    --shadow: 0 1px 3px rgba(0,0,0,0.4), 0 1px 2px rgba(0,0,0,0.3);
+  }
+  * { box-sizing: border-box; }
+  body { margin: 0; font-family: "Open Sans", system-ui, -apple-system, sans-serif;
+    background: var(--bg); color: var(--text); transition: background .25s, color .25s; line-height: 1.5; }
+  .wrap { max-width: 1180px; margin: 0 auto; padding: 32px 24px 90px; }
+  header.top { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; flex-wrap: wrap; }
+  h1 { font-size: 26px; margin: 0 0 6px; font-weight: 700; letter-spacing: -0.01em; }
+  .sub { color: var(--text2); font-size: 15px; max-width: 780px; margin: 0; }
+  .themebtn { font-family: inherit; font-size: 13px; font-weight: 600; cursor: pointer;
+    background: var(--paper); color: var(--text); border: 1px solid var(--divider);
+    border-radius: 8px; padding: 8px 14px; box-shadow: var(--shadow); white-space: nowrap; }
+  .themebtn:hover { border-color: var(--primary); }
+
+  .locked { margin: 22px 0 8px; padding: 14px 16px; border-radius: 10px; background: var(--primary-soft);
+    border: 1px solid var(--divider); font-size: 14px; display: flex; align-items: center; gap: 16px; flex-wrap: wrap; }
+  .locked .mini { width: 150px; height: 54px; flex: none; background: var(--paper); border: 1px solid var(--divider); border-radius: 8px; overflow: hidden; }
+  .locked b { color: var(--primary); }
+
+  .rules { display: flex; gap: 12px; flex-wrap: wrap; margin: 18px 0 4px; }
+  .rule { flex: 1; min-width: 220px; background: var(--paper); border: 1px solid var(--divider); border-radius: 10px; padding: 12px 14px; box-shadow: var(--shadow); font-size: 13px; color: var(--text2); }
+  .rule b { color: var(--text); display: block; margin-bottom: 2px; font-size: 13.5px; }
+
+  h2.section { font-size: 13px; text-transform: uppercase; letter-spacing: .08em; color: var(--text2); margin: 34px 0 4px; font-weight: 700; }
+  h2.section .new { color: var(--primary); margin-left: 8px; font-size: 10px; border: 1px solid var(--primary); border-radius: 20px; padding: 1px 7px; vertical-align: middle; }
+
+  .shape { display: grid; grid-template-columns: minmax(0,240px) minmax(0,1fr); gap: 22px; align-items: start;
+    padding: 22px 0; border-top: 1px solid var(--divider); }
+  .shape-meta h3 { margin: 0 0 4px; font-size: 17px; font-weight: 700; }
+  .shape-meta .where { font-size: 11.5px; color: var(--text2); opacity: .85; margin: 0 0 8px; }
+  .shape-meta p { margin: 8px 0 0; font-size: 13px; color: var(--text2); }
+  .demos { display: grid; grid-template-columns: repeat(2, minmax(0,1fr)); gap: 14px; }
+  .demos.one { grid-template-columns: minmax(0,300px); }
+  @media (max-width: 880px) { .shape { grid-template-columns: 1fr; } .demos { grid-template-columns: 1fr; } }
+
+  .card { background: var(--paper); border: 1px solid var(--divider); border-radius: 12px; box-shadow: var(--shadow); overflow: hidden; }
+  .card-head { display: flex; align-items: center; padding: 10px 12px 0; }
+  .card-title { font-size: 12.5px; font-weight: 700; }
+  .card-body { padding: 12px; height: 150px; position: relative; overflow: hidden; min-width: 0; }
+  .variant-row { display: flex; align-items: center; gap: 8px; margin: 8px 2px 0; font-size: 12.5px; }
+  .variant-row input { accent-color: var(--primary); }
+  .vname { font-weight: 700; } .rec { color: var(--primary); font-weight: 700; }
+  .vdesc { color: var(--text2); font-size: 11.5px; margin: 2px 2px 0; }
+
+  /* shared */
+  .sk { background: var(--nodata); border-radius: 6px; }
+  .shimmer { background: linear-gradient(90deg, var(--nodata) 25%, var(--nodata-hi) 45%, var(--nodata) 65%);
+    background-size: 220% 100%; animation: shimmer 1.5s ease-in-out infinite; }
+  @keyframes shimmer { 0% { background-position: 130% 0; } 100% { background-position: -130% 0; } }
+  .pulse { animation: skpulse 1.6s ease-in-out infinite; }
+  @keyframes skpulse { 0%,100% { opacity: 1; } 50% { opacity: .4; } }
+  .cascade { opacity: 0; animation: cascade 2.8s ease-in-out infinite; }
+  @keyframes cascade { 0% { opacity: 0; transform: translateY(8px); } 13% { opacity: 1; transform: none; } 74% { opacity: 1; } 92%,100% { opacity: 0; } }
+
+  /* signal trace (hero recap) */
+  .trace-svg { width: 100%; height: 100%; overflow: hidden; }
+  .trace-grid { stroke: var(--grid); stroke-width: 1; }
+  .trace-line { fill: none; stroke: var(--primary); stroke-width: 2.5; stroke-linecap: round; stroke-linejoin: round;
+    stroke-dasharray: 320; animation: trace 2.6s linear infinite; }
+  @keyframes trace { 0% { stroke-dashoffset: 320; } 55% { stroke-dashoffset: 0; } 100% { stroke-dashoffset: -320; } }
+
+  /* big number — no real digits */
+  .numblock { display: flex; align-items: center; justify-content: center; gap: 8px; height: 100%; }
+  .numblock .blk { width: 130px; max-width: 64%; height: 44px; border-radius: 8px; }
+  .numblock .u { font-size: 22px; font-weight: 700; color: var(--text2); }
+  .dashes { display: flex; align-items: center; justify-content: center; height: 100%; font-size: 46px; font-weight: 800; color: var(--text2); letter-spacing: 2px; }
+  .dashes .u { font-size: 22px; margin-left: 4px; }
+
+  /* circular draw (gauge + pie + donut + health) */
+  .cdraw { width: 110px; height: 110px; display: block; margin: 0 auto; }
+  .cd-track { fill: none; stroke: var(--nodata); stroke-width: 9; }
+  .cd-line { fill: none; stroke: var(--primary); stroke-width: 9; stroke-linecap: round; stroke-dasharray: 251.3;
+    animation: cdraw 2.4s ease-in-out infinite; }
+  @keyframes cdraw { 0% { stroke-dashoffset: 251.3; } 55% { stroke-dashoffset: 0; } 100% { stroke-dashoffset: -251.3; } }
+
+  /* heatmap ripple — 7 cols, 30 cells (matches real widget) */
+  .hgrid { display: grid; grid-template-columns: repeat(7, 1fr); grid-auto-rows: 1fr; gap: 4px; height: 100%; width: 100%; margin: 0 auto; }
+  .hcell { border-radius: 2px; background: var(--nodata); animation: ripple 2.6s ease-in-out infinite; }
+  @keyframes ripple { 0%,65%,100% { background: var(--nodata); } 32% { background: var(--primary); } }
+
+  /* table cascade / scan */
+  .rows { display: flex; flex-direction: column; gap: 9px; justify-content: center; height: 100%; }
+  .row { display: flex; align-items: center; gap: 10px; }
+  .row .dot { width: 20px; height: 20px; border-radius: 50%; flex: none; }
+  .row .lines { flex: 1; display: flex; flex-direction: column; gap: 5px; min-width: 0; }
+  .row .l1 { height: 9px; border-radius: 5px; width: 70%; } .row .l2 { height: 8px; border-radius: 5px; width: 42%; }
+  .crow:nth-child(2) { animation-delay: .18s; } .crow:nth-child(3) { animation-delay: .36s; } .crow:nth-child(4) { animation-delay: .54s; }
+  .scan-host { position: relative; height: 100%; overflow: hidden; }
+  .scan { position: absolute; left: 0; right: 0; height: 26px; background: linear-gradient(var(--primary-soft), transparent);
+    border-top: 2px solid var(--primary); animation: scanmove 2.2s ease-in-out infinite; }
+  @keyframes scanmove { 0% { top: -26px; } 100% { top: 100%; } }
+
+  /* stat tiles — no numbers */
+  .sttrio { display: flex; gap: 10px; height: 100%; align-items: center; justify-content: center; }
+  .sttile { flex: 1; height: 86px; background: var(--bg); border: 1px solid var(--divider); border-radius: 8px;
+    display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 9px; }
+  .sttile .lbl { width: 50%; height: 7px; border-radius: 4px; }
+  .sttile .val { width: 70%; height: 20px; border-radius: 6px; }
+
+  /* uptime — linear indeterminate bar */
+  .uptime { display: flex; flex-direction: column; align-items: center; justify-content: center; height: 100%; gap: 14px; }
+  .uptime .cap { width: 130px; max-width: 70%; height: 12px; border-radius: 6px; }
+  .bar-track { position: relative; width: 80%; height: 10px; border-radius: 5px; background: var(--nodata); overflow: hidden; }
+  .bar-ind { position: absolute; top: 0; height: 100%; width: 38%; border-radius: 5px; background: var(--primary); animation: indeterminate 1.5s cubic-bezier(.65,.05,.36,1) infinite; }
+  @keyframes indeterminate { 0% { left: -40%; } 100% { left: 102%; } }
+  .uptime .sub { width: 96px; max-width: 55%; height: 8px; border-radius: 5px; }
+
+  /* weather — day columns cascading in */
+  .wx { display: flex; gap: 12px; height: 100%; align-items: center; justify-content: center; flex-wrap: nowrap; overflow: hidden; }
+  .wx-day { display: flex; flex-direction: column; align-items: center; gap: 7px; }
+  .wx-lbl { width: 26px; height: 8px; border-radius: 4px; }
+  .wx-ico { width: 28px; height: 28px; border-radius: 50%; }
+  .wx-t1 { width: 24px; height: 9px; border-radius: 5px; } .wx-t2 { width: 18px; height: 8px; border-radius: 5px; }
+
+  /* sensor detail — grid of stat tiles cascading */
+  .sd { display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px; height: 100%; align-content: center; }
+  .sd-tile { border: 1px solid var(--divider); border-radius: 8px; padding: 9px 6px; display: flex; flex-direction: column; align-items: center; gap: 7px; }
+  .sd-lbl { width: 64%; height: 7px; border-radius: 4px; } .sd-val { width: 84%; height: 14px; border-radius: 5px; }
+
+  /* form */
+  form.pick { margin-top: 34px; background: var(--paper); border: 1px solid var(--divider); border-radius: 12px; padding: 22px 24px; box-shadow: var(--shadow); }
+  form.pick h3 { margin: 0 0 6px; font-size: 17px; }
+  form.pick .hint { font-size: 13px; color: var(--text2); margin: 0 0 10px; }
+  textarea { width: 100%; font-family: inherit; font-size: 13px; padding: 9px 11px; border: 1px solid var(--divider); border-radius: 8px; background: var(--bg); color: var(--text); resize: vertical; min-height: 64px; }
+  .submit { margin-top: 16px; font-family: inherit; font-size: 14px; font-weight: 700; cursor: pointer; background: var(--primary); color: #fff; border: none; border-radius: 9px; padding: 11px 24px; box-shadow: var(--shadow); }
+  .submit:hover { filter: brightness(1.06); }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header class="top">
+    <div>
+      <h1>The "Incoming" loader family · v3</h1>
+      <p class="sub">Updated from your notes: gauge now matches the pie, no literal loading text anywhere, no fake numbers while loading, the heatmap matches the real 7-column / 30-day grid, and there are now loaders for uptime, weather and sensor detail. Toggle the theme to check dark mode.</p>
+    </div>
+    <button class="themebtn" onclick="document.body.classList.toggle('dark')">🌓 Toggle light / dark</button>
+  </header>
+
+  <div class="locked">
+    <div class="mini">
+      <svg class="trace-svg" viewBox="-6 -6 252 132" preserveAspectRatio="none">
+        <line class="trace-grid" x1="0" y1="40" x2="240" y2="40"/><line class="trace-grid" x1="0" y1="80" x2="240" y2="80"/>
+        <path class="trace-line" d="M0,80 L24,64 L48,72 L72,46 L96,56 L120,32 L144,48 L168,26 L192,40 L216,20 L240,16"/>
+      </svg>
+    </div>
+    <div><b>✓ Locked in:</b> line &amp; area charts use the live signal trace — the hero the rest of the family is built around.</div>
+  </div>
+
+  <div class="rules">
+    <div class="rule"><b>Rule 1 — visuals only</b>No "loading / receiving / streaming" text. The motion communicates state on its own.</div>
+    <div class="rule"><b>Rule 2 — never fake a value</b>No real or random numbers while loading. Placeholders show the <i>shape</i> of the data, not invented figures.</div>
+    <div class="rule"><b>Rule 3 — terracotta in motion</b>A calm grey skeleton base with a single terracotta element drawing, sweeping or rippling.</div>
+  </div>
+
+  <h2 class="section">Big number · current reading</h2>
+  <div class="shape">
+    <div class="shape-meta">
+      <h3>Value placeholder</h3>
+      <p class="where">current-reading, group-summary average</p>
+      <p>Good catch on the unit — never hardcoded. The unit comes from the widget's configured measurement type (sensor + type are in config, so it's known <i>before</i> the reading lands): °C, %, ppm, lux, hPa… Watch it cycle below.</p>
+      <p><b>Fallback (Rule 2):</b> if the unit can't be resolved from config yet, drop the unit and show the block / em-dashes alone — never guess a unit.</p>
+    </div>
+    <div class="demos">
+      <div>
+        <div class="card"><div class="card-head"><span class="card-title" id="bigtitle">Living room</span></div>
+          <div class="card-body"><div class="numblock"><div class="blk shimmer"></div><span class="u" id="bigunit">°C</span></div></div></div>
+        <label class="variant-row"><input type="radio" name="bignum" value="Shimmer value block" checked><span class="vname">Shimmer block</span> <span class="rec">★ rec</span></label>
+        <p class="vdesc">Unit (dynamic) anchored, value shimmering.</p>
+      </div>
+      <div>
+        <div class="card"><div class="card-head"><span class="card-title">Humidity</span></div>
+          <div class="card-body"><div class="dashes pulse">—.—<span class="u">%</span></div></div></div>
+        <label class="variant-row"><input type="radio" name="bignum" value="Em-dash placeholder"><span class="vname">Em-dashes</span></label>
+        <p class="vdesc">Mirrors the real "—" empty state.</p>
+      </div>
+    </div>
+  </div>
+
+  <h2 class="section">Radial · gauge, pie, donut, health</h2>
+  <div class="shape">
+    <div class="shape-meta">
+      <h3>Circular draw</h3>
+      <p class="where">gauge, uptime (radial), sensor-health-pie, sensor-type-pie</p>
+      <p>You were right — the real gauge is a full ring, so an arc-sweep looked off. Gauge and pie now share one loader: a terracotta ring that draws itself around and erases, a looped cousin of the chart trace. One radial motif everywhere.</p>
+    </div>
+    <div class="demos one">
+      <div>
+        <div class="card"><div class="card-head"><span class="card-title">Sensor health</span></div>
+          <div class="card-body"><svg class="cdraw" viewBox="0 0 100 100">
+            <g transform="rotate(-90 50 50)">
+              <circle class="cd-track" cx="50" cy="50" r="40"/>
+              <circle class="cd-line" cx="50" cy="50" r="40"/>
+            </g>
+          </svg></div></div>
+      </div>
+    </div>
+  </div>
+
+  <h2 class="section">Heatmap</h2>
+  <div class="shape">
+    <div class="shape-meta">
+      <h3>Ripple populate</h3>
+      <p class="where">heatmap (7 cols × 30 days)</p>
+      <p>Now matches the real grid exactly — 7 columns, 30 square cells. A diagonal wave of warmth sweeps across as if the days are filling in. No day numbers shown (Rule 2).</p>
+    </div>
+    <div class="demos one">
+      <div>
+        <div class="card"><div class="card-head"><span class="card-title">Daily averages</span></div>
+          <div class="card-body"><div class="hgrid" id="hgrid"></div></div></div>
+      </div>
+    </div>
+  </div>
+
+  <h2 class="section">Table · list</h2>
+  <div class="shape">
+    <div class="shape-meta">
+      <h3>Cascade vs scan line</h3>
+      <p class="where">live-readings, reading-stats, alert-summary, notifications-feed</p>
+      <p>Cascade: skeleton rows stream in top-to-bottom on a loop, like records arriving. Scan: a terracotta line sweeps down static skeleton rows.</p>
+    </div>
+    <div class="demos">
+      <div>
+        <div class="card"><div class="card-head"><span class="card-title">Live readings</span></div>
+          <div class="card-body"><div class="rows">
+            <div class="row crow cascade"><div class="dot sk"></div><div class="lines"><div class="l1 sk"></div><div class="l2 sk"></div></div></div>
+            <div class="row crow cascade"><div class="dot sk"></div><div class="lines"><div class="l1 sk"></div><div class="l2 sk"></div></div></div>
+            <div class="row crow cascade"><div class="dot sk"></div><div class="lines"><div class="l1 sk"></div><div class="l2 sk"></div></div></div>
+            <div class="row crow cascade"><div class="dot sk"></div><div class="lines"><div class="l1 sk"></div><div class="l2 sk"></div></div></div>
+          </div></div></div>
+        <label class="variant-row"><input type="radio" name="table" value="Cascade rows" checked><span class="vname">Cascade rows</span> <span class="rec">★ rec</span></label>
+        <p class="vdesc">Feels like records landing.</p>
+      </div>
+      <div>
+        <div class="card"><div class="card-head"><span class="card-title">Live readings</span></div>
+          <div class="card-body"><div class="scan-host"><div class="scan"></div><div class="rows">
+            <div class="row"><div class="dot sk"></div><div class="lines"><div class="l1 sk"></div><div class="l2 sk"></div></div></div>
+            <div class="row"><div class="dot sk"></div><div class="lines"><div class="l1 sk"></div><div class="l2 sk"></div></div></div>
+            <div class="row"><div class="dot sk"></div><div class="lines"><div class="l1 sk"></div><div class="l2 sk"></div></div></div>
+            <div class="row"><div class="dot sk"></div><div class="lines"><div class="l1 sk"></div><div class="l2 sk"></div></div></div>
+          </div></div></div></div>
+        <label class="variant-row"><input type="radio" name="table" value="Scan line"><span class="vname">Scan line</span></label>
+        <p class="vdesc">Quieter, single moving element.</p>
+      </div>
+    </div>
+  </div>
+
+  <h2 class="section">Stat tiles<span class="new">redone</span></h2>
+  <div class="shape">
+    <div class="shape-meta">
+      <h3>Skeleton tiles</h3>
+      <p class="where">min-max-avg</p>
+      <p>Dropped the rolling numbers entirely (they faked values). Each tile now shows a calm label + value placeholder with a shimmer sweeping across the three in turn — alive, but honest about having no data yet.</p>
+    </div>
+    <div class="demos one">
+      <div>
+        <div class="card"><div class="card-head"><span class="card-title">Last 24h</span></div>
+          <div class="card-body"><div class="sttrio">
+            <div class="sttile"><div class="lbl sk"></div><div class="val shimmer" style="animation-delay:0s"></div></div>
+            <div class="sttile"><div class="lbl sk"></div><div class="val shimmer" style="animation-delay:.25s"></div></div>
+            <div class="sttile"><div class="lbl sk"></div><div class="val shimmer" style="animation-delay:.5s"></div></div>
+          </div></div></div>
+      </div>
+    </div>
+  </div>
+
+  <h2 class="section">Uptime<span class="new">new</span></h2>
+  <div class="shape">
+    <div class="shape-meta">
+      <h3>Indeterminate bar</h3>
+      <p class="where">uptime widget</p>
+      <p>The real widget is a horizontal progress bar, so the loader is the natural one: a terracotta segment sliding across the rounded track (MUI's indeterminate look), with calm placeholders for the percentage and caption above and below — no number shown.</p>
+    </div>
+    <div class="demos one">
+      <div>
+        <div class="card"><div class="card-head"><span class="card-title">Freezer sensor</span></div>
+          <div class="card-body"><div class="uptime">
+            <div class="cap sk pulse"></div>
+            <div class="bar-track"><div class="bar-ind"></div></div>
+            <div class="sub sk pulse"></div>
+          </div></div></div>
+      </div>
+    </div>
+  </div>
+
+  <h2 class="section">Weather forecast<span class="new">new</span></h2>
+  <div class="shape">
+    <div class="shape-meta">
+      <h3>Forecast filling in</h3>
+      <p class="where">weather-forecast</p>
+      <p>The real card is a row of day columns (label, icon, hi/lo). The loader cascades those columns in left-to-right — each a skeleton day with a pulsing icon disc — so the forecast visibly "arrives" day by day.</p>
+    </div>
+    <div class="demos one">
+      <div>
+        <div class="card"><div class="card-head"><span class="card-title">Weather — Home</span></div>
+          <div class="card-body"><div class="wx" id="wx"></div></div></div>
+      </div>
+    </div>
+  </div>
+
+  <h2 class="section">Sensor detail<span class="new">new</span></h2>
+  <div class="shape">
+    <div class="shape-meta">
+      <h3>Cascading stat tiles</h3>
+      <p class="where">sensor-detail</p>
+      <p>The real card is a responsive grid of small outlined stat papers (one per measurement type). The loader is that same grid as skeleton tiles cascading in — label + value placeholder, no values invented.</p>
+    </div>
+    <div class="demos one">
+      <div>
+        <div class="card"><div class="card-head"><span class="card-title">Greenhouse: Details</span></div>
+          <div class="card-body"><div class="sd" id="sd"></div></div></div>
+      </div>
+    </div>
+  </div>
+
+  <form class="pick" data-lavish-question="incoming-family-v3"
+    onsubmit="event.preventDefault();
+      const f = new FormData(event.currentTarget);
+      const bignum=f.get('bignum'), table=f.get('table'), notes=f.get('notes');
+      window.lavish.queuePrompt(
+        'Incoming loader family v3 — picks: Big number = '+bignum+'; Table = '+table+'. Fixed: Radial(gauge/pie/donut/health)=Circular draw, Heatmap=Ripple(7x30), Stat tiles=Skeleton tiles, Uptime=Indeterminate bar, Weather=Cascading day columns, Sensor detail=Cascading stat tiles. Charts=Signal trace. Notes: '+(notes||'none'),
+        { tag:'decision', text:'v3 picks: '+bignum+' / '+table, element:event.currentTarget,
+          data:{ bignum, table, radial:'Circular draw', heatmap:'Ripple', statTiles:'Skeleton tiles', uptime:'Indeterminate bar', weather:'Cascading columns', sensorDetail:'Cascading tiles', notes } });
+      window.lavish.sendQueuedPrompts && window.lavish.sendQueuedPrompts();">
+    <h3>Lock in the family</h3>
+    <p class="hint">Two open choices left (big number, table). Everything else is settled per your notes. Add anything to push further and send.</p>
+    <textarea name="notes" placeholder="e.g. tweak speeds, the weather icon shape, ripple direction, or anything that still feels off…"></textarea>
+    <div><button type="submit" class="submit">Send my picks →</button></div>
+  </form>
+</div>
+
+<script>
+  // heatmap: 7 cols, 30 cells, diagonal wave
+  (function(){
+    var g=document.getElementById('hgrid'); if(!g) return;
+    var cols=7, total=30;
+    for(var i=0;i<total;i++){
+      var r=Math.floor(i/cols), c=i%cols;
+      var d=document.createElement('div'); d.className='hcell';
+      d.style.animationDelay=(((c+r)*0.10)).toFixed(2)+'s';
+      g.appendChild(d);
+    }
+  })();
+  // weather: 6 day columns cascading
+  (function(){
+    var w=document.getElementById('wx'); if(!w) return;
+    for(var i=0;i<6;i++){
+      var day=document.createElement('div'); day.className='wx-day cascade';
+      day.style.animationDelay=(i*0.14).toFixed(2)+'s';
+      day.innerHTML='<div class="wx-lbl sk"></div><div class="wx-ico sk"></div><div class="wx-t1 sk"></div><div class="wx-t2 sk"></div>';
+      w.appendChild(day);
+    }
+  })();
+  // sensor detail: 6 stat tiles cascading
+  (function(){
+    var s=document.getElementById('sd'); if(!s) return;
+    for(var i=0;i<6;i++){
+      var t=document.createElement('div'); t.className='sd-tile cascade';
+      t.style.animationDelay=(i*0.12).toFixed(2)+'s';
+      t.innerHTML='<div class="sd-lbl sk"></div><div class="sd-val sk"></div>';
+      s.appendChild(t);
+    }
+  })();
+  // big-number: demonstrate the unit is dynamic (driven by widget's measurement type)
+  (function(){
+    var u=document.getElementById('bigunit'), t=document.getElementById('bigtitle'); if(!u) return;
+    var examples=[['Living room','°C'],['Bathroom','%'],['Office CO₂','ppm'],['Desk lamp','lux'],['Study','hPa']];
+    var i=0;
+    setInterval(function(){
+      i=(i+1)%examples.length;
+      u.style.opacity=0;
+      setTimeout(function(){ if(t) t.textContent=examples[i][0]; u.textContent=examples[i][1]; u.style.opacity=1; }, 220);
+    }, 2200);
+    u.style.transition='opacity .25s';
+  })();
+</script>
+</body>
+</html>

--- a/.lavish/perf-design.html
+++ b/.lavish/perf-design.html
@@ -1,0 +1,398 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="luxury">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Dashboard perceived-performance: controllable-first loading</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/daisyui@5.5.19/daisyui.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/daisyui@5.5.19/themes.css">
+<script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4.2.4/dist/index.global.js"></script>
+<script type="module">
+  import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11.15.0/dist/mermaid.esm.min.mjs";
+  mermaid.initialize({ startOnLoad: true, theme: "dark", securityLevel: "strict", flowchart: { useMaxWidth: true } });
+</script>
+<style>
+  *, *::before, *::after { box-sizing: border-box; }
+  :where(.grid, .flex) > * { min-width: 0; }
+  :where(p, h1, h2, h3, h4, li, dd, td, th, .badge) { overflow-wrap: anywhere; }
+  :where(img, svg) { max-width: 100%; height: auto; }
+  .mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+  .lead-num { font-variant-numeric: tabular-nums; }
+  .mermaid { background: var(--color-base-200); border-radius: 1rem; padding: 1rem; }
+</style>
+</head>
+<body class="bg-base-200 text-base-content">
+<main class="mx-auto max-w-5xl p-5 lg:p-10 flex flex-col gap-10">
+
+  <!-- HERO -->
+  <header class="flex flex-col gap-3">
+    <div class="flex flex-wrap items-center gap-2">
+      <span class="badge badge-primary badge-soft">Design proposal</span>
+      <span class="badge badge-ghost">Frontend only</span>
+      <span class="badge badge-ghost">sensor-hub UI</span>
+    </div>
+    <h1 class="text-3xl lg:text-4xl font-bold leading-tight">Make the dashboard feel fast: controllable widgets first</h1>
+    <p class="text-base-content/70 max-w-3xl">
+      When a dashboard opens, the controllable toggles should settle into the correct state and respond to taps
+      as fast as possible - even while the read-only charts are still blank. This document proposes how, grounds it in
+      the current code, weighs alternatives, and ends with decisions for you to make.
+    </p>
+  </header>
+
+  <!-- GOAL / SYMPTOM -->
+  <section class="grid md:grid-cols-3 gap-4">
+    <div class="card card-border bg-base-100 md:col-span-2">
+      <div class="card-body gap-3">
+        <h2 class="card-title text-xl">The symptom</h2>
+        <p class="text-base-content/80">
+          On the Raspberry Pi + SQLite deployment, opening a dashboard to flip a single switch feels sluggish:
+        </p>
+        <ul class="flex flex-col gap-2">
+          <li class="flex gap-3"><span class="badge badge-warning badge-soft mt-0.5">1</span>
+            <span><b>Settle delay</b> - the switch takes a few seconds to show the correct on/off position after load.</span></li>
+          <li class="flex gap-3"><span class="badge badge-warning badge-soft mt-0.5">2</span>
+            <span><b>Command lag</b> - flipping the switch takes ~a second to take effect, and gets worse the more widgets are on the dashboard.</span></li>
+        </ul>
+        <p class="text-base-content/60 text-sm">The "scales with widget count" clue is the key: this is resource contention, not a fixed cost.</p>
+      </div>
+    </div>
+    <div class="card card-border bg-base-100">
+      <div class="card-body gap-2">
+        <h2 class="card-title text-base">Diagnosis</h2>
+        <p class="text-sm text-base-content/80">Browser is snappy; render is fine. The wait is the <b>backend returning data</b>.</p>
+        <div class="divider my-1"></div>
+        <p class="text-sm">Every read-only chart fires <span class="mono text-xs">GET /readings/between</span> on mount and again every 30s. N charts &rArr; a burst of heavy SQLite aggregation queries that the single-threaded-ish Pi serializes.</p>
+        <p class="text-sm text-base-content/70">The toggle's data and command queue up <i>behind</i> that burst.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- MEASUREMENT -->
+  <section class="card card-border bg-base-100 border-success/40">
+    <div class="card-body gap-4">
+      <div class="flex items-center gap-3 flex-wrap">
+        <span class="badge badge-success">Measured &bull; confirmed</span>
+        <h2 class="card-title text-xl">We proved the bottleneck on the live Pi</h2>
+      </div>
+      <p class="text-base-content/80 max-w-3xl text-sm">
+        Using the authenticated CLI against the real instance, we timed a small "probe" request (proxy for the toggle's
+        snapshot + command) while idle, then again while 6 concurrent chart-style aggregation queries hammered the Pi -
+        a simulated busy dashboard. Read-only, bounded, one-shot.
+      </p>
+      <div class="stats stats-vertical sm:stats-horizontal bg-base-200 w-full">
+        <div class="stat">
+          <div class="stat-title">Probe, Pi idle</div>
+          <div class="stat-value text-success lead-num">~23<span class="text-lg">ms</span></div>
+          <div class="stat-desc">warm baseline (median)</div>
+        </div>
+        <div class="stat">
+          <div class="stat-title">Probe, under load</div>
+          <div class="stat-value text-error lead-num">1.3-2.6<span class="text-lg">s</span></div>
+          <div class="stat-desc">while charts query</div>
+        </div>
+        <div class="stat">
+          <div class="stat-title">Amplification</div>
+          <div class="stat-value text-warning lead-num">55-115&times;</div>
+          <div class="stat-desc">snaps back to ~20ms when load clears</div>
+        </div>
+      </div>
+      <div role="alert" class="alert alert-success alert-soft">
+        <span>The probe recovered to baseline <b>the instant</b> the query burst drained - so this is pure contention, not a fixed cost.
+        Metering concurrency (the proposed scheduler) is exactly the right lever. A single aggregated chart query also costs <b>0.7-1.1s</b> on its own, so even a handful firing at once saturates the Pi.</span>
+      </div>
+    </div>
+  </section>
+
+  <!-- THE REFRAME -->
+  <section class="card card-border bg-base-100 border-primary/40">
+    <div class="card-body gap-4">
+      <div class="flex items-center gap-3 flex-wrap">
+        <span class="badge badge-primary">Important reframe</span>
+        <h2 class="card-title text-xl">"Controllable first" really means "read-only out of the way"</h2>
+      </div>
+      <p class="text-base-content/80 max-w-3xl">
+        The natural framing is "send the controllable widget's request first." But the one controllable widget
+        (<span class="mono text-sm">sensor-toggle</span>) <b>makes no REST request to prioritize</b>. It reads from two shared
+        WebSockets and writes commands to a third endpoint:
+      </p>
+      <div class="grid sm:grid-cols-3 gap-3">
+        <div class="rounded-box bg-base-200 p-3">
+          <div class="mono text-xs text-success">/sensors/ws</div>
+          <p class="text-sm mt-1">Sensor list + capabilities = what makes a sensor controllable.</p>
+        </div>
+        <div class="rounded-box bg-base-200 p-3">
+          <div class="mono text-xs text-success">/readings/ws/current</div>
+          <p class="text-sm mt-1">Live current values = the toggle's on/off position (the "settle").</p>
+        </div>
+        <div class="rounded-box bg-base-200 p-3">
+          <div class="mono text-xs text-info">POST /sensors/{id}/command</div>
+          <p class="text-sm mt-1">The command itself (the "flip"). Already optimistic in the UI.</p>
+        </div>
+      </div>
+      <div role="alert" class="alert alert-info alert-soft">
+        <span>So the lever is <b>not</b> jumping a queue. It is <b>throttling the read-only REST flood</b> so the Pi keeps spare
+        capacity to answer the WebSocket snapshot and the command POST quickly. We get the controllable widget fast by getting everything else out of its way.</span>
+      </div>
+    </div>
+  </section>
+
+  <!-- CURRENT VS TARGET -->
+  <section class="flex flex-col gap-4">
+    <h2 class="text-2xl font-bold">Current behavior vs target behavior</h2>
+    <div class="grid md:grid-cols-2 gap-4">
+      <div class="card card-border bg-base-100 border-error/30">
+        <div class="card-body gap-2">
+          <div class="flex items-center gap-2"><span class="badge badge-error badge-soft">Today</span><h3 class="card-title text-base">Thundering herd on load</h3></div>
+          <ul class="text-sm flex flex-col gap-1.5 text-base-content/80">
+            <li>&bull; All widgets mount at once; every chart fires its request immediately.</li>
+            <li>&bull; No concurrency limit - the Pi gets N+ heavy queries simultaneously.</li>
+            <li>&bull; No ordering - the toggle's WS snapshot competes with chart aggregation.</li>
+            <li>&bull; Background 30s polls keep firing; a command can land mid-burst.</li>
+            <li>&bull; <span class="mono text-xs">useReadingsData</span> calls <span class="mono text-xs">apiClient.GET</span> directly in a <span class="mono text-xs">useEffect</span>.</li>
+          </ul>
+        </div>
+      </div>
+      <div class="card card-border bg-base-100 border-success/30">
+        <div class="card-body gap-2">
+          <div class="flex items-center gap-2"><span class="badge badge-success badge-soft">Target</span><h3 class="card-title text-base">Metered, prioritized loading</h3></div>
+          <ul class="text-sm flex flex-col gap-1.5 text-base-content/80">
+            <li>&bull; A small client scheduler caps how many requests hit the Pi at once.</li>
+            <li>&bull; Controllable data is highest priority; read-only charts wait their turn.</li>
+            <li>&bull; The Pi always has headroom, so the WS snapshot settles quickly.</li>
+            <li>&bull; A command preempts background polls so the flip lands fast.</li>
+            <li>&bull; Read-only widgets fetch <i>through</i> the scheduler, not directly.</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- PROPOSED ARCHITECTURE -->
+  <section class="flex flex-col gap-4">
+    <h2 class="text-2xl font-bold">Proposed approach: a small priority request scheduler</h2>
+    <p class="text-base-content/80 max-w-3xl">
+      Introduce one focused module - a <b>priority-aware concurrency limiter</b> (a priority semaphore, ~a hundred lines,
+      not a framework). Every read-only REST fetch goes through it. It admits at most <span class="mono text-sm">N</span> requests
+      to the Pi at a time and always admits the highest-priority waiter next.
+    </p>
+
+    <div class="mermaid">
+flowchart TD
+    L["Dashboard opens"] --> WS["Open WebSockets immediately<br/>(sensors + current readings)"]
+    L --> Q["Read-only widgets enqueue<br/>their REST fetches"]
+    WS -.->|"toggle settles from<br/>live snapshot"| T["Controllable widget<br/>interactive"]
+    Q --> S{{"Priority scheduler<br/>max N in flight"}}
+    S -->|"priority: high"| C["Controllable-related<br/>+ commands"]
+    S -->|"priority: normal"| V["Visible read-only<br/>charts"]
+    S -->|"priority: low"| B["Background 30s<br/>polls"]
+    C --> PI[("Raspberry Pi<br/>SQLite")]
+    V --> PI
+    B --> PI
+    CMD["User flips switch"] -->|"preempt: pause low polls"| S
+    CMD --> C
+    </div>
+
+    <div class="grid md:grid-cols-3 gap-4">
+      <div class="card card-border bg-base-100">
+        <div class="card-body gap-2">
+          <div class="flex items-center gap-2"><span class="badge badge-primary badge-soft">Mechanism 1</span></div>
+          <h3 class="card-title text-base">Concurrency cap</h3>
+          <p class="text-sm text-base-content/80">At most <span class="mono">N</span> REST requests in flight to the Pi (a <b>tunable setting</b>, default 4). Stops the thundering herd, leaving CPU/SQLite headroom for the WS snapshot and commands.</p>
+        </div>
+      </div>
+      <div class="card card-border bg-base-100">
+        <div class="card-body gap-2">
+          <div class="flex items-center gap-2"><span class="badge badge-primary badge-soft">Mechanism 2</span></div>
+          <h3 class="card-title text-base">Priority ordering</h3>
+          <p class="text-sm text-base-content/80">When a slot frees, the scheduler runs the highest-priority waiter. Controllable-related work first, then visible charts, then background polls.</p>
+        </div>
+      </div>
+      <div class="card card-border bg-base-100">
+        <div class="card-body gap-2">
+          <div class="flex items-center gap-2"><span class="badge badge-primary badge-soft">Mechanism 3</span></div>
+          <h3 class="card-title text-base">Command preemption</h3>
+          <p class="text-sm text-base-content/80">While a command POST is in flight, the scheduler stops admitting <i>new</i> low-priority polls, so the Pi drains and the flip confirms quickly.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- INJECTION POINTS -->
+  <section class="flex flex-col gap-4">
+    <h2 class="text-2xl font-bold">Where this plugs into the existing code</h2>
+    <div class="overflow-x-auto rounded-box border border-base-content/10 bg-base-100">
+      <table class="table table-sm">
+        <thead><tr><th>File</th><th>Today</th><th>Change</th></tr></thead>
+        <tbody>
+          <tr>
+            <td class="mono text-xs">hooks/useReadingsData.ts</td>
+            <td class="text-sm">Calls <span class="mono text-xs">apiClient.GET('/readings/between')</span> directly on mount + 30s interval.</td>
+            <td class="text-sm">Route the call through the scheduler at <b>normal</b> priority; the 30s poll at <b>low</b>.</td>
+          </tr>
+          <tr>
+            <td class="mono text-xs">widgets/MinMaxAvgWidget.tsx<br>widgets/HeatmapWidget.tsx<br>widgets/AlertSummaryWidget.tsx</td>
+            <td class="text-sm">One-shot <span class="mono text-xs">apiClient.GET</span> in a <span class="mono text-xs">useEffect</span>.</td>
+            <td class="text-sm">Same: enqueue through the scheduler at <b>normal</b> priority.</td>
+          </tr>
+          <tr>
+            <td class="mono text-xs">widgets/SensorToggleWidget.tsx</td>
+            <td class="text-sm">Reads WS cache; <span class="mono text-xs">POST /sensors/{id}/command</span> on flip.</td>
+            <td class="text-sm">Wrap the command in a <b>preempt</b> signal (pause low-priority admits) for its duration.</td>
+          </tr>
+          <tr>
+            <td class="mono text-xs">scheduler/requestScheduler.ts <span class="badge badge-success badge-xs">new</span></td>
+            <td class="text-sm">-</td>
+            <td class="text-sm">The priority semaphore: <span class="mono text-xs">schedule(priority, fn)</span>, a cap, and a preempt latch.</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div role="alert" class="alert alert-warning alert-soft">
+      <span><b>Note on the WebSockets:</b> they already connect on widget mount, so no per-request scheduling applies to them. Their speedup comes for free from capping the REST flood. If we want extra insurance, we can hoist the current-readings WS to connect at dashboard load whenever a controllable widget is present (a small, optional addition - flagged as Decision 3).</span>
+    </div>
+  </section>
+
+  <!-- ALTERNATIVES -->
+  <section class="flex flex-col gap-4">
+    <h2 class="text-2xl font-bold">Alternatives considered</h2>
+    <div class="grid md:grid-cols-3 gap-4">
+      <div class="card card-border bg-base-100 border-success/40">
+        <div class="card-body gap-2">
+          <div class="flex items-center justify-between"><h3 class="card-title text-base">A. Priority scheduler</h3><span class="badge badge-success">Recommended</span></div>
+          <p class="text-sm text-base-content/80">Central concurrency cap + priority + preempt.</p>
+          <div class="text-sm"><b class="text-success">Wins:</b> fixes settle <i>and</i> command lag; scales as widgets are added; one clear home for priority.</div>
+          <div class="text-sm"><b class="text-error">Cost:</b> route every read-only fetch through it (~4 call sites today).</div>
+        </div>
+      </div>
+      <div class="card card-border bg-base-100">
+        <div class="card-body gap-2">
+          <h3 class="card-title text-base">B. Load-order only</h3>
+          <p class="text-sm text-base-content/80">Render controllable widgets first; delay/stagger read-only mounts a tick later.</p>
+          <div class="text-sm"><b class="text-success">Wins:</b> tiny change; helps the settle.</div>
+          <div class="text-sm"><b class="text-error">Cost:</b> does <b>not</b> fix steady-state command lag (30s polls still collide); ordering is implicit and fragile.</div>
+        </div>
+      </div>
+      <div class="card card-border bg-base-100">
+        <div class="card-body gap-2">
+          <h3 class="card-title text-base">C. Request coalescing</h3>
+          <p class="text-sm text-base-content/80">Dedupe identical <span class="mono text-xs">/readings/between</span> queries so charts share one request.</p>
+          <div class="text-sm"><b class="text-success">Wins:</b> cuts total load; good complement.</div>
+          <div class="text-sm"><b class="text-error">Cost:</b> only helps when widgets overlap; no prioritization or preemption. Orthogonal - can add later.</div>
+        </div>
+      </div>
+    </div>
+    <p class="text-sm text-base-content/60">A and C compose well; B is effectively a weaker subset of A. The recommendation is A, optionally folding in C as a later enhancement.</p>
+  </section>
+
+  <!-- RISKS -->
+  <section class="flex flex-col gap-3">
+    <h2 class="text-2xl font-bold">Risks &amp; things to verify</h2>
+    <div class="grid sm:grid-cols-2 gap-3">
+      <div class="rounded-box bg-base-100 border border-success/30 p-4">
+        <h3 class="font-semibold text-sm mb-1 text-success">Root cause confirmed (measured)</h3>
+        <p class="text-sm text-base-content/70">Backend contention is now <b>proven</b> on the live Pi: probe latency rose from ~23ms to 1.3-2.6s under chart load and recovered instantly. No longer a risk - it's the validated premise. Remaining tuning: pick the right cap against this same Pi.</p>
+      </div>
+      <div class="rounded-box bg-base-100 border border-base-content/10 p-4">
+        <h3 class="font-semibold text-sm mb-1">Cap too low = sluggish charts</h3>
+        <p class="text-sm text-base-content/70">If the concurrency cap is too aggressive, read-only charts feel slow to fill in. The cap needs tuning against the real Pi (Decision 1).</p>
+      </div>
+      <div class="rounded-box bg-base-100 border border-base-content/10 p-4">
+        <h3 class="font-semibold text-sm mb-1">Stale-response guards</h3>
+        <p class="text-sm text-base-content/70"><span class="mono text-xs">useReadingsData</span> already guards stale responses via <span class="mono text-xs">requestIdRef</span>. Queueing must not break that ordering or its cleanup on unmount.</p>
+      </div>
+      <div class="rounded-box bg-base-100 border border-base-content/10 p-4">
+        <h3 class="font-semibold text-sm mb-1">Preempt starvation</h3>
+        <p class="text-sm text-base-content/70">Pausing low-priority polls during commands must be bounded (e.g. only for the in-flight command, with a timeout) so polls can't be starved indefinitely.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- DECISIONS -->
+  <section class="flex flex-col gap-5">
+    <div class="flex items-center gap-3 flex-wrap">
+      <span class="badge badge-success">Locked</span>
+      <h2 class="text-2xl font-bold">Decisions</h2>
+    </div>
+    <div class="overflow-x-auto rounded-box border border-success/30 bg-base-100">
+      <table class="table table-sm">
+        <tbody>
+          <tr><td class="font-semibold">Approach</td><td>A - priority request scheduler (cap + priority + preempt)</td></tr>
+          <tr><td class="font-semibold">Concurrency cap</td><td>Tunable setting (default 4)</td></tr>
+          <tr><td class="font-semibold">Command preemption</td><td>Yes - pause low-priority polls while a command is in flight (bounded)</td></tr>
+          <tr><td class="font-semibold">WS hoist</td><td>No - keep existing on-mount connection (smaller scope)</td></tr>
+          <tr><td class="font-semibold">Measure first</td><td>Done - contention confirmed on the live Pi (see evidence above)</td></tr>
+        </tbody>
+      </table>
+    </div>
+    <p class="text-base-content/60 max-w-3xl text-sm">Locked in from your answers. Want to change one? Use the controls below or annotate this table.</p>
+
+    <!-- D0 -->
+    <form class="card card-border bg-base-100" data-lavish-question="approach"
+      onsubmit="event.preventDefault(); const v=new FormData(event.currentTarget).get('approach'); if(v) window.lavish.queuePrompt('Decision - overall approach: '+v, {tag:'choice', text:'Approach: '+v, element:event.currentTarget});">
+      <div class="card-body gap-3">
+        <h3 class="card-title text-base">0. Overall approach</h3>
+        <label class="flex gap-3 items-start cursor-pointer"><input type="radio" name="approach" value="A: priority scheduler (recommended)" class="radio radio-primary radio-sm mt-1" checked><span class="text-sm"><b>A - Priority scheduler.</b> Cap + priority + command preempt. Fixes both symptoms.</span></label>
+        <label class="flex gap-3 items-start cursor-pointer"><input type="radio" name="approach" value="A + C: scheduler with request coalescing" class="radio radio-primary radio-sm mt-1"><span class="text-sm"><b>A + C.</b> Scheduler now, also dedupe identical chart queries.</span></label>
+        <label class="flex gap-3 items-start cursor-pointer"><input type="radio" name="approach" value="B: load-order only (minimal)" class="radio radio-primary radio-sm mt-1"><span class="text-sm"><b>B - Load-order only.</b> Minimal; settle only, leaves command lag.</span></label>
+        <div class="card-actions justify-end"><button type="submit" class="btn btn-primary btn-sm">Queue answer</button></div>
+      </div>
+    </form>
+
+    <!-- D1 -->
+    <form class="card card-border bg-base-100" data-lavish-question="cap"
+      onsubmit="event.preventDefault(); const v=new FormData(event.currentTarget).get('cap'); if(v) window.lavish.queuePrompt('Decision - concurrency cap: '+v, {tag:'choice', text:'Cap: '+v, element:event.currentTarget});">
+      <div class="card-body gap-3">
+        <h3 class="card-title text-base">1. Concurrency cap (max REST in flight to the Pi)</h3>
+        <p class="text-sm text-base-content/60">Browsers allow ~6 per host; the Pi is the real limit. Lower = more headroom for the toggle, slower charts.</p>
+        <div class="flex flex-wrap gap-4">
+          <label class="flex gap-2 items-center cursor-pointer"><input type="radio" name="cap" value="3" class="radio radio-primary radio-sm"><span class="text-sm">3</span></label>
+          <label class="flex gap-2 items-center cursor-pointer"><input type="radio" name="cap" value="4 (recommended starting point)" class="radio radio-primary radio-sm" checked><span class="text-sm">4 (recommended)</span></label>
+          <label class="flex gap-2 items-center cursor-pointer"><input type="radio" name="cap" value="6" class="radio radio-primary radio-sm"><span class="text-sm">6</span></label>
+          <label class="flex gap-2 items-center cursor-pointer"><input type="radio" name="cap" value="make it a tunable setting" class="radio radio-primary radio-sm"><span class="text-sm">Make it tunable</span></label>
+        </div>
+        <div class="card-actions justify-end"><button type="submit" class="btn btn-primary btn-sm">Queue answer</button></div>
+      </div>
+    </form>
+
+    <!-- D2 -->
+    <form class="card card-border bg-base-100" data-lavish-question="preempt"
+      onsubmit="event.preventDefault(); const v=new FormData(event.currentTarget).get('preempt'); if(v) window.lavish.queuePrompt('Decision - command preemption: '+v, {tag:'choice', text:'Preempt: '+v, element:event.currentTarget});">
+      <div class="card-body gap-3">
+        <h3 class="card-title text-base">2. Command preemption</h3>
+        <label class="flex gap-3 items-start cursor-pointer"><input type="radio" name="preempt" value="yes - pause low-priority polls during a command (recommended)" class="radio radio-primary radio-sm mt-1" checked><span class="text-sm"><b>Yes.</b> Pause background polls while a command is in flight so the flip lands fast. (Bounded with a timeout.)</span></label>
+        <label class="flex gap-3 items-start cursor-pointer"><input type="radio" name="preempt" value="no - just make commands highest priority" class="radio radio-primary radio-sm mt-1"><span class="text-sm"><b>No.</b> Simpler: commands are just highest priority, no pausing.</span></label>
+        <div class="card-actions justify-end"><button type="submit" class="btn btn-primary btn-sm">Queue answer</button></div>
+      </div>
+    </form>
+
+    <!-- D3 -->
+    <form class="card card-border bg-base-100" data-lavish-question="wshoist"
+      onsubmit="event.preventDefault(); const v=new FormData(event.currentTarget).get('wshoist'); if(v) window.lavish.queuePrompt('Decision - WS hoist: '+v, {tag:'choice', text:'WS hoist: '+v, element:event.currentTarget});">
+      <div class="card-body gap-3">
+        <h3 class="card-title text-base">3. Hoist the current-readings WebSocket to connect at dashboard load?</h3>
+        <label class="flex gap-3 items-start cursor-pointer"><input type="radio" name="wshoist" value="yes - connect WS as soon as the dashboard has a controllable widget" class="radio radio-primary radio-sm mt-1"><span class="text-sm"><b>Yes.</b> Extra insurance the toggle warms early, even if it renders below the fold.</span></label>
+        <label class="flex gap-3 items-start cursor-pointer"><input type="radio" name="wshoist" value="no - keep existing on-mount connection (recommended, less scope)" class="radio radio-primary radio-sm mt-1" checked><span class="text-sm"><b>No.</b> Keep current on-mount behavior; the cap alone should suffice. Smaller scope.</span></label>
+        <div class="card-actions justify-end"><button type="submit" class="btn btn-primary btn-sm">Queue answer</button></div>
+      </div>
+    </form>
+
+    <!-- D4 -->
+    <form class="card card-border bg-base-100" data-lavish-question="measure"
+      onsubmit="event.preventDefault(); const v=new FormData(event.currentTarget).get('measure'); if(v) window.lavish.queuePrompt('Decision - measurement first: '+v, {tag:'choice', text:'Measure: '+v, element:event.currentTarget});">
+      <div class="card-body gap-3">
+        <h3 class="card-title text-base">4. Confirm the bottleneck with a quick measurement first?</h3>
+        <label class="flex gap-3 items-start cursor-pointer"><input type="radio" name="measure" value="yes - add a small before/after timing step before building" class="radio radio-primary radio-sm mt-1"><span class="text-sm"><b>Yes.</b> Capture request timings on the Pi before building, so we know we hit the real bottleneck.</span></label>
+        <label class="flex gap-3 items-start cursor-pointer"><input type="radio" name="measure" value="no - the diagnosis is good enough, just build it" class="radio radio-primary radio-sm mt-1" checked><span class="text-sm"><b>No.</b> Diagnosis is convincing; the scheduler helps regardless. Build it.</span></label>
+        <div class="card-actions justify-end"><button type="submit" class="btn btn-primary btn-sm">Queue answer</button></div>
+      </div>
+    </form>
+
+    <div role="alert" class="alert">
+      <span class="text-sm">Queue each answer, add any annotations, then press <b>Send to Agent</b>. Disagree with the framing anywhere? Annotate that section directly.</span>
+    </div>
+  </section>
+
+  <footer class="text-center text-xs text-base-content/40 pt-4">sensor-hub &bull; perceived-performance design &bull; brainstorming stage</footer>
+</main>
+</body>
+</html>

--- a/.lavish/properties-page-design.html
+++ b/.lavish/properties-page-design.html
@@ -1,0 +1,527 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Properties page - the design</title>
+<style>
+  *, *::before, *::after { box-sizing: border-box; }
+  :root {
+    --bg: #F5F0EB; --paper: #FFFFFF; --paper-2: #FAF7F4;
+    --primary: #D4451A; --primary-dark: #B33612; --on-primary: #FFFFFF;
+    --text: #1A1A1A; --text-2: #5C5C5C; --divider: #D9D0C7; --hover: rgba(212,69,26,0.06);
+    --shadow: 0 1px 3px rgba(0,0,0,0.10), 0 1px 2px rgba(0,0,0,0.06);
+    --ok: #2E7D32; --warn: #B26A00; --err: #C62828; --info: #1565C0; --code-bg: #F1ECE7;
+  }
+  :root[data-theme="dark"] {
+    --bg: #1A1A1A; --paper: #242424; --paper-2: #2C2C2C;
+    --primary: #ED5125; --primary-dark: #C43D18; --on-primary: #FFFFFF;
+    --text: #E8E8E8; --text-2: #A0A0A0; --divider: #333333; --hover: rgba(237,81,37,0.08);
+    --shadow: 0 1px 3px rgba(0,0,0,0.5);
+    --ok: #66BB6A; --warn: #FFB74D; --err: #EF5350; --info: #64B5F6; --code-bg: #1E1E1E;
+  }
+  html { background: var(--bg); }
+  body { margin: 0; background: var(--bg); color: var(--text);
+    font-family: Roboto, -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
+    font-size: 15px; line-height: 1.6; -webkit-font-smoothing: antialiased; }
+  main { max-width: 1120px; margin: 0 auto; padding: 32px 20px 120px; }
+  section { margin-bottom: 54px; }
+  h1,h2,h3,h4 { line-height: 1.25; margin: 0; }
+  h1 { font-size: 33px; font-weight: 500; letter-spacing: -0.4px; }
+  h2 { font-size: 23px; font-weight: 500; }
+  h3 { font-size: 18px; font-weight: 500; }
+  h4 { font-size: 15px; font-weight: 600; }
+  p { margin: 12px 0; }
+  :where(p,li,td,th,h1,h2,h3,h4) { overflow-wrap: anywhere; }
+  a { color: var(--primary); }
+  .eyebrow { text-transform: uppercase; letter-spacing: 1.4px; font-size: 11px; font-weight: 700; color: var(--primary); }
+  .lede { font-size: 17px; color: var(--text-2); max-width: 70ch; }
+  .muted { color: var(--text-2); } .small { font-size: 13px; } .tiny { font-size: 12px; }
+  .mono { font-family: "SF Mono","Roboto Mono",ui-monospace,Menlo,Consolas,monospace; }
+  .rule { display:flex; align-items:center; gap:14px; margin:0 0 20px; }
+  .rule h2 { white-space: nowrap; }
+  .rule::after { content:""; flex:1; height:1px; background: var(--divider); }
+  .paper { background: var(--paper); border:1px solid var(--divider); border-radius:6px; box-shadow: var(--shadow); }
+  .pad { padding: 20px 22px; }
+  .grid { display:grid; gap:16px; } .grid > * { min-width:0; }
+  .g2 { grid-template-columns: repeat(2, minmax(0,1fr)); }
+  @media (max-width: 900px) { .g2 { grid-template-columns: minmax(0,1fr); } }
+  code { font-family:"SF Mono","Roboto Mono",ui-monospace,Menlo,Consolas,monospace; font-size:.86em;
+    background: var(--code-bg); border-radius:3px; padding:1px 5px; color: var(--text); }
+  pre { background: var(--code-bg); border:1px solid var(--divider); border-radius:4px; padding:14px 16px;
+    overflow-x:auto; font-size:12.5px; line-height:1.6; margin:12px 0; }
+  pre code { background:none; padding:0; font-size:inherit; }
+  .badge { display:inline-block; font-size:11px; font-weight:600; padding:2px 8px; border-radius:11px;
+    border:1px solid currentColor; white-space:nowrap; }
+  .b-ok{color:var(--ok);} .b-warn{color:var(--warn);} .b-err{color:var(--err);} .b-info{color:var(--info);} .b-flat{color:var(--text-2);}
+  .b-rec { color: var(--on-primary); background: var(--primary); border-color: var(--primary); }
+  .callout { border:1px solid var(--divider); border-left:4px solid var(--primary); background: var(--paper);
+    border-radius:0 6px 6px 0; padding:18px 22px; box-shadow: var(--shadow); }
+  .callout.warn { border-left-color: var(--warn); }
+  .callout.info { border-left-color: var(--info); }
+  .callout.ok { border-left-color: var(--ok); }
+  table { border-collapse: collapse; width:100%; font-size:13.5px; }
+  .tblwrap { overflow-x:auto; border:1px solid var(--divider); border-radius:6px; background: var(--paper); }
+  th,td { text-align:left; padding:9px 14px; border-bottom:1px solid var(--divider); vertical-align:top; }
+  th { font-weight:600; font-size:12px; text-transform:uppercase; letter-spacing:.6px; color:var(--text-2); background: var(--paper-2); }
+  tbody tr:last-child td { border-bottom:none; }
+  tbody tr:hover { background: var(--hover); }
+  ul.tight { margin:8px 0; padding-left:20px; } ul.tight li { margin:5px 0; }
+  ol.tight { margin:8px 0; padding-left:20px; } ol.tight li { margin:6px 0; }
+  .mermaid { background: var(--paper); border:1px solid var(--divider); border-radius:6px; padding:16px; overflow-x:auto; }
+  .mermaid svg { max-width:100%; height:auto; }
+  .q { background: var(--paper); border:1px solid var(--divider); border-left:4px solid var(--primary);
+    border-radius:0 6px 6px 0; padding:20px 22px; box-shadow: var(--shadow); margin-top:20px; }
+  .q h3 { margin-bottom:4px; } .q .qsub { color:var(--text-2); font-size:13.5px; margin:0 0 14px; }
+  .opts { display:grid; gap:8px; margin-bottom:14px; }
+  .opt { display:grid; grid-template-columns:20px minmax(0,1fr); gap:10px; align-items:start; padding:11px 13px;
+    border:1px solid var(--divider); border-radius:5px; cursor:pointer; background: var(--paper-2); }
+  .opt:hover { border-color: var(--primary); }
+  .opt input { margin:3px 0 0; accent-color: var(--primary); width:16px; height:16px; }
+  .opt .ol { font-weight:600; font-size:14px; display:block; }
+  .opt .od { font-size:12.5px; color:var(--text-2); margin-top:2px; display:block; }
+  .qbtn { background: var(--primary); color: var(--on-primary); border:none; border-radius:4px; padding:8px 18px;
+    font-size:13px; font-weight:600; letter-spacing:.4px; text-transform:uppercase; cursor:pointer; }
+  .qbtn:hover { background: var(--primary-dark); }
+  .qfree { width:100%; border:1px solid var(--divider); border-radius:4px; background: var(--paper-2);
+    padding:9px 11px; color:var(--text); font:inherit; font-size:13px; margin-bottom:12px; resize:vertical; }
+  .themebtn { position:fixed; top:14px; right:14px; z-index:50; background: var(--paper); color:var(--text);
+    border:1px solid var(--divider); border-radius:20px; padding:6px 14px; font-size:12px; cursor:pointer; box-shadow: var(--shadow); }
+  .step { display:grid; grid-template-columns:30px minmax(0,1fr); gap:12px; margin-bottom:14px; }
+  .stepn { width:26px; height:26px; border-radius:50%; background: var(--primary); color: var(--on-primary);
+    display:flex; align-items:center; justify-content:center; font-size:13px; font-weight:600; }
+</style>
+</head>
+<body>
+
+<button class="themebtn" data-lavish-action onclick="toggleTheme()">Light / dark</button>
+
+<main>
+
+<header style="margin-bottom:40px">
+  <div class="eyebrow">Sensor Hub &middot; the design</div>
+  <h1 style="margin:10px 0 14px">Properties page: definitions, honest apply-states, one grouped page</h1>
+  <p class="lede">
+    Every decision from the interview is locked. This is the design itself - architecture, data flow,
+    error handling, testing - plus two bugs I hit while tracing the data flow that this design has to
+    answer for. Three questions left at the bottom.
+  </p>
+</header>
+
+<!-- ============ SHAPE ============ -->
+<section>
+  <div class="rule"><h2>The shape of it</h2></div>
+  <div class="grid g2">
+    <div class="paper pad">
+      <h4>Backend</h4>
+      <ul class="tight small" style="margin-bottom:0">
+        <li>Six new struct tags on <code>ApplicationConfiguration</code>: <code>desc</code>, <code>group</code>, <code>unit</code>, <code>enum</code>, <code>apply</code>, <code>readonly</code>.</li>
+        <li><code>PropertyDef</code> and <code>buildRegistry()</code> carry them through - the reflection loop already exists, this is six more <code>field.Tag.Get</code> calls.</li>
+        <li>New <code>GET /properties/definitions</code>, spec-first in <code>api/openapi.yaml</code>, <code>x-required-permission: view_properties</code>.</li>
+        <li><code>GET /properties</code> and <code>PATCH /properties</code> untouched. CLI and the retention cards keep working.</li>
+        <li>Sensitive-key plumbing deleted.</li>
+        <li>Two live-apply fixes: <code>slog.LevelVar</code> for the log level, and an interval function on <code>periodic.TaskConfig</code>.</li>
+      </ul>
+    </div>
+    <div class="paper pad">
+      <h4>Frontend</h4>
+      <ul class="tight small" style="margin-bottom:0">
+        <li><code>useProperties</code> unchanged - it stays the websocket-backed value feed for everyone.</li>
+        <li>New <code>usePropertyDefinitions</code> - one fetch, cached for the session, definitions don't change without a deploy.</li>
+        <li><code>PropertiesCard</code> is replaced by a page composed of <code>PropertyGroupSection</code> and one <code>PropertyField</code> per property, which picks its control from <code>Kind</code>, <code>enum</code> and <code>readonly</code>.</li>
+        <li>Rail with scroll-spy plus a search box filtering on key, label and description.</li>
+        <li>A property with a definition but no group, or a value with no definition, still renders - see the degradation rules below.</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<!-- ============ REGISTRY ============ -->
+<section>
+  <div class="rule"><h2>The registry, extended</h2></div>
+  <p class="muted small" style="margin-top:-6px">
+    Nothing here is a new mechanism - <code>buildRegistry()</code> already reflects over the struct at
+    <code>init()</code>. These are additional tags on the same pass.
+  </p>
+<pre><code>type PropertyDef struct {
+    // ... existing: FieldName, FieldIndex, Key, Kind, Default, File, Validate
+    Description string       // desc  - one sentence, shown under the label
+    Group       string       // group - sensors|retention|security|mqtt|email|weather|advanced
+    Unit        string       // unit  - "seconds", "days", "hours"; suffix on the input
+    Enum        []string     // enum  - comma-separated in the tag; renders a select
+    Apply       ApplyState   // apply - live|next-cycle|action:&lt;id&gt;   (default: live)
+    ReadOnly    bool         // readonly
+}</code></pre>
+
+  <div class="grid g2" style="margin-top:6px">
+    <div class="paper pad">
+      <h4>Why <code>apply</code> defaults to <code>live</code></h4>
+      <p class="small" style="margin-bottom:0">
+        18 of 29 properties are already live, so the default should be the common case and the tag should
+        only appear where something is unusual. It also means the failure mode of forgetting the tag is
+        "we claimed live and it was live" for most new properties - and the test below catches the rest.
+      </p>
+    </div>
+    <div class="paper pad">
+      <h4>Why <code>Validate</code> stays a string</h4>
+      <p class="small" style="margin-bottom:0">
+        Tempting to redesign it into min/max while we're here. Out of scope - the existing
+        <code>positive</code> / <code>non_negative</code> / <code>non_empty</code> vocabulary is enough
+        to drive client-side validation, and widening it is a separate change with its own risks.
+      </p>
+    </div>
+  </div>
+
+  <h3 style="margin:26px 0 10px">The endpoint</h3>
+<pre><code>GET /api/properties/definitions        x-required-permission: view_properties
+
+{
+  "definitions": [
+    {
+      "key": "sensor.collection.interval",
+      "label": "Collection interval",
+      "description": "How often every enabled sensor is polled.",
+      "type": "int",
+      "default": "300",
+      "group": "sensors",
+      "unit": "seconds",
+      "apply": "next-cycle",
+      "validate": "positive",
+      "readOnly": false
+    }
+  ],
+  "groups": [
+    { "id": "sensors", "label": "Sensors &amp; collection",
+      "description": "How often sensors are polled and how they are discovered.", "order": 1 }
+  ]
+}</code></pre>
+  <p class="small muted">
+    Groups are returned as their own ordered list rather than inferred from the properties, so ordering
+    and group descriptions live in the backend too and the UI holds no hardcoded knowledge of what a
+    group is. <code>label</code> is derived from the field name if no tag overrides it, so no property
+    can ship without a human-readable name.
+  </p>
+</section>
+
+<!-- ============ DATA FLOW ============ -->
+<section>
+  <div class="rule"><h2>Data flow</h2></div>
+  <div class="mermaid">
+flowchart TD
+  TAGS["ApplicationConfiguration struct tags"] --> REG["registry []PropertyDef&lt;br/&gt;built by reflection at init()"]
+  REG --> DEFS["GET /properties/definitions&lt;br/&gt;static for process lifetime"]
+  REG --> VALS["GET /properties&lt;br/&gt;key to value, unchanged"]
+  REG --> FILES["SaveToFiles&lt;br/&gt;three .properties files"]
+
+  DEFS --> HOOKD["usePropertyDefinitions&lt;br/&gt;fetch once, cache"]
+  VALS --> HOOKV["useProperties&lt;br/&gt;websocket feed"]
+  WS(["/properties/ws"]) --> HOOKV
+
+  HOOKD --> PAGE["Properties page"]
+  HOOKV --> PAGE
+  PAGE -->|PATCH /properties| SVC["PropertiesService"]
+  SVC -->|validate then reload| CFG["AppConfig in memory"]
+  SVC -->|async| FILES
+  SVC -->|broadcast| WS
+  WATCH["config file watcher&lt;br/&gt;polls mtime every 2s"] -->|external edit| CFG
+  WATCH -.->|MISSING: no broadcast| WS
+
+  style WATCH stroke-dasharray: 4 4
+  </div>
+</section>
+
+<!-- ============ TWO BUGS ============ -->
+<section>
+  <div class="rule"><h2>Two bugs the data flow exposed</h2></div>
+  <p class="muted small" style="margin-top:-6px">
+    Neither is caused by this work. Both sit directly in its path, and per the engineering standards we
+    fix what we find.
+  </p>
+
+  <div class="grid g2" style="margin-top:16px">
+    <div class="paper pad" style="border-left:3px solid var(--err)">
+      <h4><span class="badge b-err">Bug 1</span> A broadcast wipes your in-progress edits</h4>
+      <p class="small">
+        <code>PropertiesCard</code> does <code>useEffect(() =&gt; { if (properties) setEditedProperties(properties) }, [properties])</code>.
+        Every websocket message is a fresh object identity, so every broadcast overwrites local state.
+        If another admin saves - or you save in a second tab - everything you were half-way through typing
+        is silently replaced. On a page where you might be editing several fields before saving, that is
+        much worse than it is today.
+      </p>
+      <p class="small" style="margin-bottom:0"><strong>Design answer:</strong> hold two maps - server
+        values from the websocket, and a sparse map of only the fields you have touched. Render
+        <code>edited[key] ?? server[key]</code>. A broadcast then updates untouched fields freely and
+        leaves your edits alone. Where a broadcast changes a field you are editing, the helper line
+        changes to say someone else changed this to X - reset to take theirs.</p>
+      <span class="tiny mono muted">PropertiesCard.tsx:19-21</span>
+    </div>
+
+    <div class="paper pad" style="border-left:3px solid var(--warn)">
+      <h4><span class="badge b-warn">Bug 2</span> Editing the file over SSH doesn't reach the UI</h4>
+      <p class="small">
+        The watcher detects an external file change and calls <code>ReloadConfig</code>, but never calls
+        <code>ws.BroadcastToTopic("properties", ...)</code>. So an SSH edit - or an RPM upgrade rewriting
+        the defaults - updates the running config while every open browser keeps showing stale values
+        until someone reloads the page. On a page that is about to display "saved value" and
+        "modified from default", stale server state is actively misleading.
+      </p>
+      <p class="small" style="margin-bottom:0"><strong>Design answer:</strong> broadcast after a
+        successful watcher reload. One call, same as the service already does after a PATCH.</p>
+      <span class="tiny mono muted">config_watcher.go:89</span>
+    </div>
+  </div>
+</section>
+
+<!-- ============ COMPONENTS ============ -->
+<section>
+  <div class="rule"><h2>Components</h2></div>
+  <div class="tblwrap">
+    <table>
+      <thead><tr><th style="width:30%">Component</th><th>Responsibility</th></tr></thead>
+      <tbody>
+        <tr><td class="mono tiny">PropertiesPage</td><td class="small">Layout, rail, search state, dirty state, save orchestration. Owns the two maps from Bug 1.</td></tr>
+        <tr><td class="mono tiny">PropertySearchRail</td><td class="small">Group list with per-group edited counts, scroll-spy on the sections, search input. Collapses above the content on mobile.</td></tr>
+        <tr><td class="mono tiny">PropertyGroupSection</td><td class="small">One card per group: heading, group description, the fields in registry order. Owns its anchor id for <code>/properties#mqtt</code>.</td></tr>
+        <tr><td class="mono tiny">PropertyField</td><td class="small">Picks its control from the definition: <code>bool</code> to switch, <code>int</code> to number field with unit suffix, <code>enum</code> to select, <code>readonly</code> to plain text. Renders label, description, validation error, modified state and apply-state.</td></tr>
+        <tr><td class="mono tiny">PropertyApplyNotice</td><td class="small">The one chip plus its action button. <code>next-cycle</code> renders a muted line; <code>action:mqtt-restart</code> renders the chip and a confirm-first button; <code>action:oauth-reload</code> links to the existing Reload control.</td></tr>
+        <tr><td class="mono tiny">usePropertyDefinitions</td><td class="small">Fetch once, cache for the session, expose loading and error.</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <h3 style="margin:26px 0 10px">Degradation rules</h3>
+  <p class="small muted" style="margin-top:0">
+    The two sources can disagree. They must never produce a blank page.
+  </p>
+  <div class="tblwrap">
+    <table>
+      <thead><tr><th style="width:38%">Situation</th><th>Behaviour</th></tr></thead>
+      <tbody>
+        <tr><td class="small">A value has no definition</td><td class="small">Render it in an "Ungrouped" section as a plain text field with its raw key. Can only happen if the registry and the running config disagree, which shouldn't occur - but a silently missing property is worse than an ugly one.</td></tr>
+        <tr><td class="small">A definition has no value</td><td class="small">Render with the default as placeholder. Shouldn't happen - <code>ConvertToMaps</code> emits every registered key.</td></tr>
+        <tr><td class="small">A definition has an unknown group</td><td class="small">Falls into "Ungrouped" rather than vanishing.</td></tr>
+        <tr><td class="small">The definitions request fails</td><td class="small">Fall back to today's behaviour: flat list of key and text field, with a banner saying descriptions and typed controls are unavailable. The page still edits properties. This is the important one - a definitions outage must not take away the ability to fix your config.</td></tr>
+        <tr><td class="small">The user lacks <code>manage_properties</code></td><td class="small">Everything renders, all controls disabled, no Save button. Same as today.</td></tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<!-- ============ ERRORS ============ -->
+<section>
+  <div class="rule"><h2>Error handling</h2></div>
+  <div class="grid g2">
+    <div class="paper pad">
+      <h4>Client-side, before the PATCH</h4>
+      <ul class="tight small" style="margin-bottom:0">
+        <li>Type check from <code>Kind</code>: an <code>int</code> field rejects non-numeric input at the field.</li>
+        <li>Rule check from <code>Validate</code>: <code>positive</code>, <code>non_negative</code>, <code>non_empty</code>.</li>
+        <li>Save is disabled while any field is invalid, and the rail marks which groups hold errors - otherwise an invalid field in a scrolled-away group makes Save mysteriously dead.</li>
+        <li>Client validation is convenience only. The backend stays authoritative and the UI must handle a rejection it did not predict.</li>
+      </ul>
+    </div>
+    <div class="paper pad">
+      <h4>Server-side, on the PATCH</h4>
+      <ul class="tight small" style="margin-bottom:0">
+        <li><code>LoadConfigurationFromMaps</code> already validates before anything is written, and the whole batch is rejected together. That is the right behaviour and it stays.</li>
+        <li>Today the error reaches the user as a raw Go string in a snackbar. The errors are already formatted as <code>invalid &lt;key&gt; value: &lt;raw&gt;</code>, so the API can return the offending key alongside the message and the UI can attach it to the right field.</li>
+        <li>Local edits survive a failed save. Currently a failure leaves you looking at an error with no clear state; the two-map model means your edits are still there to correct.</li>
+        <li>The file write is already async and only logs on failure - so the UI can report success while the write fails. Out of scope to fix here, but noted as a follow-up: the save should surface a persistence failure.</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<!-- ============ TESTING ============ -->
+<section>
+  <div class="rule"><h2>Testing</h2></div>
+  <div class="grid g2">
+    <div class="paper pad">
+      <h4>Go</h4>
+      <ul class="tight small" style="margin-bottom:0">
+        <li><strong>Registry completeness</strong> - table test asserting every registered property has a non-empty <code>desc</code> and a known <code>group</code>. This is the test that keeps the metadata honest as properties are added, and it is the reason the docs table can be deleted safely.</li>
+        <li><strong>Enum validity</strong> - any <code>enum</code> tag must contain the field's <code>default</code>.</li>
+        <li><strong>Apply-state validity</strong> - <code>apply</code> parses to a known state, and any <code>action:&lt;id&gt;</code> names an action the API actually implements.</li>
+        <li><strong>Endpoint</strong> - handler test for shape and for the <code>view_properties</code> permission.</li>
+        <li><strong>Live-apply fixes</strong> - a test that changing <code>log.level</code> through the service changes what the logger emits, and a periodic test that a task picks up a new interval on the next tick.</li>
+        <li><strong>Integration</strong> - per <code>CLAUDE.md</code>, <code>go test -tags integration ./integration/</code> after any Go change. <code>integration/properties_test.go</code> already exists to extend.</li>
+      </ul>
+    </div>
+    <div class="paper pad">
+      <h4>Frontend</h4>
+      <ul class="tight small" style="margin-bottom:0">
+        <li><code>PropertyField</code> renders the right control per type, including read-only and enum.</li>
+        <li>The Bug 1 case explicitly: type into a field, deliver a websocket message, assert the edit survives and untouched fields update.</li>
+        <li>Definitions-fetch failure falls back to the flat editable list rather than an empty page.</li>
+        <li>Search matches on key, label and description, and the group counts follow the filter.</li>
+        <li>Permission gating: no <code>manage_properties</code> means disabled controls and no Save.</li>
+        <li>Existing <code>PendingSensorsCard.test.tsx</code> and friends set the pattern - Vitest with the same testing-library idiom.</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<!-- ============ SCOPE ============ -->
+<section>
+  <div class="rule"><h2>What this is not</h2></div>
+  <div class="grid g2">
+    <div class="paper pad" style="border-left:3px solid var(--ok)">
+      <h4>In</h4>
+      <ul class="tight small" style="margin-bottom:0">
+        <li>Registry tags, definitions endpoint, the rebuilt page.</li>
+        <li>Typed controls, descriptions, apply-state, modified marker and reset, inline validation, search.</li>
+        <li><code>log.level</code> and periodic-interval live-apply fixes.</li>
+        <li>Delete the sensitive-key plumbing.</li>
+        <li>Bugs 1 and 2.</li>
+        <li>Remove the property table from the docs and point at the UI.</li>
+      </ul>
+    </div>
+    <div class="paper pad" style="border-left:3px solid var(--warn)">
+      <h4>Out - raised as their own issues</h4>
+      <ul class="tight small" style="margin-bottom:0">
+        <li>Live-apply for <code>readings.aggregation.*</code> - needs its own thinking about re-tiering mid-flight.</li>
+        <li>Live-apply for <code>oauth.token.refresh.interval.minutes</code>.</li>
+        <li>Surfacing an async file-write failure to the user.</li>
+        <li>Dispersing groups into feature pages - the agreed later phase.</li>
+        <li>Any change to the <code>validate</code> vocabulary.</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<!-- ============ QUESTIONS ============ -->
+<section>
+  <div class="rule"><h2>Three things I want you to decide</h2></div>
+
+  <form class="q" data-lavish-question="conflict" onsubmit="return queueAnswer(event,'conflict','Concurrent edit handling')">
+    <h3>1. When someone else changes a field you're editing</h3>
+    <p class="qsub">Bug 1's design answer keeps your edits. The question is what happens on the field where you actually collide.</p>
+    <div class="opts">
+      <label class="opt"><input type="radio" name="conflict" value="keep my edit, show a muted line saying someone else set it to X with a link to take theirs"><span><span class="ol">Keep my edit, tell me about theirs <span class="badge b-rec">Recommended</span></span><span class="od">Your value stays in the box; the helper line says someone else changed this to 600 with a reset link. Nothing is lost and nothing changes under your cursor.</span></span></label>
+      <label class="opt"><input type="radio" name="conflict" value="keep my edit silently, let the save overwrite theirs"><span><span class="ol">Keep my edit silently</span><span class="od">Simplest. Last write wins with no warning, which on a single-admin home instance is arguably fine and is what happens today anyway.</span></span></label>
+      <label class="opt"><input type="radio" name="conflict" value="block the save and force a refresh when the server value changed under an edited field"><span><span class="ol">Block the save on conflict</span><span class="od">Strictest. Refuses the PATCH and makes you re-look. Probably heavier than a single-user home server warrants.</span></span></label>
+    </div>
+    <button type="submit" class="qbtn">Queue this answer</button>
+  </form>
+
+  <form class="q" data-lavish-question="mqttaction" onsubmit="return queueAnswer(event,'mqttaction','MQTT apply action')">
+    <h3>2. The MQTT broker action</h3>
+    <p class="qsub">The broker has <code>Start()</code>, <code>Stop()</code> and <code>IsRunning()</code> already, so bouncing it in-process is possible. Whether we should is your call - it disconnects every publishing sensor.</p>
+    <div class="opts">
+      <label class="opt"><input type="radio" name="mqttaction" value="build a restart-broker action with a confirmation naming the consequence"><span><span class="ol">Build the action, confirm first <span class="badge b-rec">Recommended</span></span><span class="od">A button that stops and restarts the broker on the new port, behind a dialog that says it disconnects connected sensors. Genuinely better than a restart, and honest about the cost.</span></span></label>
+      <label class="opt"><input type="radio" name="mqttaction" value="label only: say a service restart is required, build no action"><span><span class="ol">Label only</span><span class="od">The chip says a service restart is required and we build no action. Smallest scope; the properties change sits pending until you restart, which is exactly the confusing state we set out to fix.</span></span></label>
+      <label class="opt"><input type="radio" name="mqttaction" value="defer the action to a follow-up issue, ship the honest label now"><span><span class="ol">Honest label now, action later</span><span class="od">Ship the label in this work and raise the bounce-the-broker action separately, so the MQTT lifecycle gets its own thinking.</span></span></label>
+    </div>
+    <button type="submit" class="qbtn">Queue this answer</button>
+  </form>
+
+  <form class="q" data-lavish-question="docs2" onsubmit="return queueAnswer(event,'docs2','Docs table')">
+    <h3>3. The docs table - you didn't come back on this</h3>
+    <p class="qsub">Your instruction was to drop it and point at the UI. My caveat was that the docs are the only place someone can see what's configurable before they install. I'll do whichever you say; I'm not deciding it quietly.</p>
+    <div class="opts">
+      <label class="opt"><input type="radio" name="docs2" value="delete the table entirely, docs point at the UI"><span><span class="ol">Delete it, point at the UI</span><span class="od">Your original instruction, taken straight. Docs stop restating code; the registry completeness test guarantees the UI actually carries the descriptions.</span></span></label>
+      <label class="opt"><input type="radio" name="docs2" value="generate a minimal table from the registry at build time so there is still one source of truth"><span><span class="ol">Generate a minimal table from the registry</span><span class="od">Still one source of truth, still zero hand-maintenance, and pre-install evaluation keeps working. Costs a small generator and a make target.</span></span></label>
+      <label class="opt"><input type="radio" name="docs2" value="delete the table and instead document only that properties are self-describing in the UI"><span><span class="ol">Delete it, document the concept instead</span><span class="od">The docs explain that properties are self-describing in the UI and what the apply-states mean - complementing the code rather than listing it.</span></span></label>
+    </div>
+    <button type="submit" class="qbtn">Queue this answer</button>
+  </form>
+
+  <form class="q" data-lavish-question="design-open" onsubmit="return queueFree(event,'design-open','Design feedback')">
+    <h3>Anything else on the design</h3>
+    <p class="qsub">Once this settles I'll set up the issue tracker - this project has no <code>docs/issue-tracker.md</code> yet - and persist the design there.</p>
+    <textarea class="qfree" name="design-open" rows="4" placeholder="Architecture, the two bugs, error handling, testing, scope"></textarea>
+    <button type="submit" class="qbtn">Queue this answer</button>
+  </form>
+</section>
+
+</main>
+
+<script type="module">
+  import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11.15.0/dist/mermaid.esm.min.mjs";
+  const darkQuery = window.matchMedia("(prefers-color-scheme: dark)");
+  const paint = document.createElement("canvas").getContext("2d");
+  function toRgba(color) {
+    paint.clearRect(0, 0, 1, 1); paint.fillStyle = "#000"; paint.fillStyle = color; paint.fillRect(0, 0, 1, 1);
+    return paint.getImageData(0, 0, 1, 1).data;
+  }
+  function compositeRgba(fg, bg) {
+    const fa = fg[3] / 255, ba = bg[3] / 255, a = fa + ba * (1 - fa);
+    if (a === 0) return [0, 0, 0, 0];
+    return [ (fg[0]*fa + bg[0]*ba*(1-fa))/a, (fg[1]*fa + bg[1]*ba*(1-fa))/a, (fg[2]*fa + bg[2]*ba*(1-fa))/a, a*255 ];
+  }
+  function pageIsDark() {
+    const root = document.documentElement;
+    const rb = toRgba(getComputedStyle(root).backgroundColor);
+    const bb = document.body ? toRgba(getComputedStyle(document.body).backgroundColor) : [0,0,0,0];
+    const [r, g, b, a] = compositeRgba(bb, rb);
+    if (a > 0) return (0.2126*r + 0.7152*g + 0.0722*b) / 255 < 0.5;
+    return darkQuery.matches;
+  }
+  const diagrams = [...document.querySelectorAll(".mermaid")].map((el) => ({ el, src: el.textContent }));
+  let applied, rendering = false, queued = false;
+  function queueRender() { queued = true; if (rendering) return; void render(); }
+  async function render() {
+    rendering = true;
+    try {
+      while (queued) {
+        queued = false;
+        const theme = pageIsDark() ? "dark" : "default";
+        if (theme === applied) continue;
+        mermaid.initialize({ startOnLoad: false, theme, securityLevel: "strict" });
+        for (const { el, src } of diagrams) { el.removeAttribute("data-processed"); el.textContent = src; }
+        try { await mermaid.run({ nodes: diagrams.map((d) => d.el) }); }
+        catch (error) { console.error("Mermaid diagram render failed:", error); return; }
+        applied = theme;
+      }
+    } finally { rendering = false; if (queued) queueRender(); }
+  }
+  if (document.readyState === "complete") queueRender();
+  else window.addEventListener("load", queueRender, { once: true });
+  const themeObserver = new MutationObserver(queueRender);
+  for (const el of [document.documentElement, document.body]) {
+    if (!el) continue;
+    themeObserver.observe(el, { attributes: true, attributeFilter: ["data-theme", "class", "style"] });
+  }
+  darkQuery.addEventListener("change", queueRender);
+</script>
+<script>
+  function toggleTheme() {
+    var r = document.documentElement;
+    r.setAttribute('data-theme', r.getAttribute('data-theme') === 'dark' ? 'light' : 'dark');
+  }
+  if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    document.documentElement.setAttribute('data-theme', 'dark');
+  }
+  function confirmQueued(form) {
+    var btn = form.querySelector('button[type="submit"]');
+    var old = btn.textContent;
+    btn.textContent = 'Queued ✓';
+    setTimeout(function () { btn.textContent = old; }, 1600);
+  }
+  function queueAnswer(event, key, label) {
+    event.preventDefault();
+    var form = event.currentTarget;
+    var choice = new FormData(form).get(key);
+    if (!choice) return false;
+    window.lavish && window.lavish.queuePrompt(label + ': ' + choice, {
+      tag: 'choice', text: label + ': ' + choice, element: form, queueKey: key,
+      data: { question: key, answer: choice }
+    });
+    confirmQueued(form);
+    return false;
+  }
+  function queueFree(event, key, label) {
+    event.preventDefault();
+    var form = event.currentTarget;
+    var val = (new FormData(form).get(key) || '').toString().trim();
+    if (!val) return false;
+    window.lavish && window.lavish.queuePrompt(label + ': ' + val, {
+      tag: 'feedback', text: label, element: form, queueKey: key,
+      data: { question: key, answer: val }
+    });
+    confirmQueued(form);
+    return false;
+  }
+</script>
+</body>
+</html>

--- a/.lavish/properties-page-redesign.html
+++ b/.lavish/properties-page-redesign.html
@@ -1,0 +1,617 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Properties page redesign - round 2</title>
+<style>
+  *, *::before, *::after { box-sizing: border-box; }
+
+  :root {
+    --bg: #F5F0EB; --paper: #FFFFFF; --paper-2: #FAF7F4;
+    --primary: #D4451A; --primary-light: #ED5125; --primary-dark: #B33612; --on-primary: #FFFFFF;
+    --text: #1A1A1A; --text-2: #5C5C5C; --divider: #D9D0C7; --hover: rgba(212,69,26,0.06);
+    --shadow: 0 1px 3px rgba(0,0,0,0.10), 0 1px 2px rgba(0,0,0,0.06);
+    --ok: #2E7D32; --warn: #B26A00; --err: #C62828; --info: #1565C0; --code-bg: #F1ECE7;
+  }
+  :root[data-theme="dark"] {
+    --bg: #1A1A1A; --paper: #242424; --paper-2: #2C2C2C;
+    --primary: #ED5125; --primary-light: #F47A56; --primary-dark: #C43D18; --on-primary: #FFFFFF;
+    --text: #E8E8E8; --text-2: #A0A0A0; --divider: #333333; --hover: rgba(237,81,37,0.08);
+    --shadow: 0 1px 3px rgba(0,0,0,0.5);
+    --ok: #66BB6A; --warn: #FFB74D; --err: #EF5350; --info: #64B5F6; --code-bg: #1E1E1E;
+  }
+
+  html { background: var(--bg); }
+  body {
+    margin: 0; background: var(--bg); color: var(--text);
+    font-family: Roboto, -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
+    font-size: 15px; line-height: 1.6; -webkit-font-smoothing: antialiased;
+  }
+  main { max-width: 1180px; margin: 0 auto; padding: 32px 20px 120px; }
+  section { margin-bottom: 56px; }
+  h1, h2, h3, h4 { line-height: 1.25; margin: 0; }
+  h1 { font-size: 33px; font-weight: 500; letter-spacing: -0.4px; }
+  h2 { font-size: 23px; font-weight: 500; letter-spacing: -0.2px; }
+  h3 { font-size: 18px; font-weight: 500; }
+  h4 { font-size: 15px; font-weight: 600; }
+  p { margin: 12px 0; }
+  :where(p, li, td, th, h1, h2, h3, h4, .badge) { overflow-wrap: anywhere; }
+  a { color: var(--primary); }
+
+  .eyebrow { text-transform: uppercase; letter-spacing: 1.4px; font-size: 11px; font-weight: 700; color: var(--primary); }
+  .lede { font-size: 17px; color: var(--text-2); max-width: 70ch; }
+  .muted { color: var(--text-2); }
+  .small { font-size: 13px; }
+  .tiny { font-size: 12px; }
+  .mono, .k { font-family: "SF Mono", "Roboto Mono", ui-monospace, Menlo, Consolas, monospace; }
+
+  .rule { display: flex; align-items: center; gap: 14px; margin: 0 0 22px; }
+  .rule h2 { white-space: nowrap; }
+  .rule::after { content: ""; flex: 1; height: 1px; background: var(--divider); }
+
+  .paper { background: var(--paper); border: 1px solid var(--divider); border-radius: 6px; box-shadow: var(--shadow); }
+  .pad { padding: 20px 22px; }
+
+  .grid { display: grid; gap: 16px; }
+  .grid > * { min-width: 0; }
+  .g2 { grid-template-columns: repeat(2, minmax(0,1fr)); }
+  .g3 { grid-template-columns: repeat(3, minmax(0,1fr)); }
+  @media (max-width: 900px) { .g2, .g3 { grid-template-columns: minmax(0,1fr); } }
+
+  code {
+    font-family: "SF Mono", "Roboto Mono", ui-monospace, Menlo, Consolas, monospace;
+    font-size: 0.86em; background: var(--code-bg); border-radius: 3px; padding: 1px 5px; color: var(--text);
+  }
+  pre {
+    background: var(--code-bg); border: 1px solid var(--divider); border-radius: 4px;
+    padding: 14px 16px; overflow-x: auto; font-size: 12.5px; line-height: 1.65; margin: 12px 0;
+  }
+  pre code { background: none; padding: 0; font-size: inherit; }
+
+  .badge {
+    display: inline-block; font-size: 11px; font-weight: 600; letter-spacing: 0.3px;
+    padding: 2px 8px; border-radius: 11px; border: 1px solid currentColor; white-space: nowrap;
+  }
+  .b-ok { color: var(--ok); } .b-warn { color: var(--warn); } .b-err { color: var(--err); }
+  .b-info { color: var(--info); } .b-flat { color: var(--text-2); }
+  .b-rec { color: var(--on-primary); background: var(--primary); border-color: var(--primary); }
+
+  .callout {
+    border: 1px solid var(--divider); border-left: 4px solid var(--primary); background: var(--paper);
+    border-radius: 0 6px 6px 0; padding: 18px 22px; box-shadow: var(--shadow);
+  }
+  .callout.warn { border-left-color: var(--warn); }
+  .callout.info { border-left-color: var(--info); }
+  .callout.ok { border-left-color: var(--ok); }
+
+  table { border-collapse: collapse; width: 100%; font-size: 13.5px; }
+  .tblwrap { overflow-x: auto; border: 1px solid var(--divider); border-radius: 6px; background: var(--paper); }
+  th, td { text-align: left; padding: 9px 14px; border-bottom: 1px solid var(--divider); vertical-align: top; }
+  th { font-weight: 600; font-size: 12px; text-transform: uppercase; letter-spacing: 0.6px; color: var(--text-2); background: var(--paper-2); }
+  tbody tr:last-child td { border-bottom: none; }
+  tbody tr:hover { background: var(--hover); }
+  td.st { white-space: nowrap; }
+
+  /* product mockups */
+  .mock { background: var(--bg); border: 1px solid var(--divider); border-radius: 6px; overflow: hidden; font-size: 13px; }
+  .mock-bar { background: var(--primary); color: var(--on-primary); padding: 8px 12px; font-size: 13px; font-weight: 500; display: flex; align-items: center; gap: 10px; }
+  .mock-body { padding: 14px; }
+  .mock-card { background: var(--paper); border: 1px solid var(--divider); border-radius: 4px; padding: 12px 14px; }
+  .mock-h2 { font-size: 14px; font-weight: 500; margin-bottom: 4px; }
+  .mock-row { display: grid; grid-template-columns: minmax(0,1.25fr) minmax(0,1fr); gap: 10px; align-items: center; padding: 9px 0; border-bottom: 1px solid var(--divider); }
+  .mock-row:last-child { border-bottom: none; }
+  .mock-key { font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 11.5px; }
+  .mock-input { border: 1px solid var(--divider); border-radius: 4px; background: var(--paper); padding: 5px 9px; font-size: 12px; color: var(--text); font-family: "SF Mono", ui-monospace, Menlo, monospace; display: inline-block; }
+  .mock-btn { background: var(--primary); color: var(--on-primary); border: none; border-radius: 4px; padding: 5px 13px; font-size: 12px; font-weight: 500; text-transform: uppercase; letter-spacing: .5px; }
+  .mock-btn.ghost { background: transparent; color: var(--primary); border: 1px solid var(--primary); }
+  .mock-label { font-size: 12.5px; font-weight: 500; display: block; }
+  .mock-desc { font-size: 11.5px; color: var(--text-2); line-height: 1.45; }
+  .mock-toggle { width: 32px; height: 18px; border-radius: 9px; background: var(--primary); position: relative; display: inline-block; flex: none; }
+  .mock-toggle::after { content: ""; position: absolute; right: 2px; top: 2px; width: 14px; height: 14px; border-radius: 50%; background: #fff; }
+  .mock-toggle.off { background: var(--divider); }
+  .mock-toggle.off::after { left: 2px; right: auto; }
+  .mock-search { border: 1px solid var(--divider); border-radius: 4px; background: var(--paper); padding: 6px 10px; font-size: 12px; color: var(--text-2); width: 100%; display: block; }
+  .mock-rail { font-size: 12px; }
+  .mock-rail div { padding: 5px 9px; border-radius: 4px; color: var(--text-2); display: flex; justify-content: space-between; gap: 6px; }
+  .mock-rail div.on { background: var(--hover); color: var(--primary); font-weight: 500; }
+  .mock-rail .n { opacity: .75; font-variant-numeric: tabular-nums; }
+  .mock-undo { color: var(--primary); font-size: 13px; cursor: default; }
+  .mod-row { border-left: 3px solid var(--primary); margin-left: -14px; padding-left: 11px; }
+  .badge-restart { display:inline-block; font-size:10px; font-weight:600; padding:1px 7px; border-radius:10px; border:1px solid var(--warn); color:var(--warn); white-space:nowrap; }
+
+  /* question forms */
+  .q { background: var(--paper); border: 1px solid var(--divider); border-left: 4px solid var(--primary); border-radius: 0 6px 6px 0; padding: 20px 22px; box-shadow: var(--shadow); margin-top: 20px; }
+  .q h3 { margin-bottom: 4px; }
+  .q .qsub { color: var(--text-2); font-size: 13.5px; margin: 0 0 14px; }
+  .opts { display: grid; gap: 8px; margin-bottom: 14px; }
+  .opt { display: grid; grid-template-columns: 20px minmax(0,1fr); gap: 10px; align-items: start; padding: 11px 13px; border: 1px solid var(--divider); border-radius: 5px; cursor: pointer; background: var(--paper-2); }
+  .opt:hover { border-color: var(--primary); }
+  .opt input { margin: 3px 0 0; accent-color: var(--primary); width: 16px; height: 16px; }
+  .opt .ol { font-weight: 600; font-size: 14px; display: block; }
+  .opt .od { font-size: 12.5px; color: var(--text-2); margin-top: 2px; display: block; }
+  .qbtn { background: var(--primary); color: var(--on-primary); border: none; border-radius: 4px; padding: 8px 18px; font-size: 13px; font-weight: 600; letter-spacing: .4px; text-transform: uppercase; cursor: pointer; box-shadow: var(--shadow); }
+  .qbtn:hover { background: var(--primary-dark); }
+  .qnote { font-size: 12px; color: var(--text-2); margin-left: 12px; }
+  .qfree { width: 100%; border: 1px solid var(--divider); border-radius: 4px; background: var(--paper-2); padding: 9px 11px; color: var(--text); font: inherit; font-size: 13px; margin-bottom: 12px; resize: vertical; }
+
+  .themebtn { position: fixed; top: 14px; right: 14px; z-index: 50; background: var(--paper); color: var(--text); border: 1px solid var(--divider); border-radius: 20px; padding: 6px 14px; font-size: 12px; cursor: pointer; box-shadow: var(--shadow); }
+
+  ul.tight { margin: 8px 0; padding-left: 20px; }
+  ul.tight li { margin: 5px 0; }
+
+  .settled { display: grid; grid-template-columns: minmax(0,220px) minmax(0,1fr); gap: 0; font-size: 13.5px; }
+  .settled > div { padding: 10px 14px; border-bottom: 1px solid var(--divider); }
+  .settled > div:nth-child(odd) { font-weight: 600; background: var(--paper-2); }
+  @media (max-width: 720px) { .settled { grid-template-columns: minmax(0,1fr); } .settled > div:nth-child(odd) { border-bottom: none; padding-bottom: 0; background: none; } }
+
+  .statnum { font-size: 30px; font-weight: 500; line-height: 1.1; }
+  .statlbl { font-size: 12px; color: var(--text-2); }
+</style>
+</head>
+<body>
+
+<button class="themebtn" data-lavish-action onclick="toggleTheme()">Light / dark</button>
+
+<main>
+
+<header style="margin-bottom:40px">
+  <div class="eyebrow">Sensor Hub &middot; design interview &middot; round 2</div>
+  <h1 style="margin:10px 0 14px">Your restart challenge was the right one</h1>
+  <p class="lede">
+    You asked whether all this stuff <em>should</em> need a restart, and whether the fact it doesn't apply
+    live is actually a bug. I went and traced all 29 properties to their consumers. Short answer: yes,
+    mostly a bug - and for three of them the fix is smaller than the badge. That changes what we build.
+  </p>
+</header>
+
+<!-- ============ SETTLED ============ -->
+<section>
+  <div class="rule"><h2>Settled from round 1</h2></div>
+  <div class="paper" style="overflow:hidden">
+    <div class="settled">
+      <div>Framing</div>
+      <div>Metadata first now, disperse properties into feature pages as a later phase.</div>
+      <div>Layout</div>
+      <div>B - one grouped page, sticky category rail, global search. No chip overuse: no chip for the previous value, a chip is fine for "requires restart".</div>
+      <div>Metadata home</div>
+      <div>Struct tags on <code>ApplicationConfiguration</code> + a new <code>GET /properties/definitions</code>. <code>GET /properties</code> unchanged, so the CLI and the retention cards keep working.</div>
+      <div>Grouping</div>
+      <div>The seven proposed groups stand.</div>
+      <div><code>database.path</code></div>
+      <div>Not editable. Changing it breaks everything including the RPM upgrade - render it read-only.</div>
+      <div>Sensitive plumbing</div>
+      <div>Remove it. It existed for the MySQL password; nothing needs it under SQLite. <span class="muted">(Checked: no remaining property is a secret - <code>smtp.user</code> is an address and auth is via OAuth.)</span></div>
+      <div>Docs</div>
+      <div>Drop the property table from <code>configuration.md</code> and point users at the UI. Docs complement the code, they don't restate it.</div>
+      <div>Behaviours in scope</div>
+      <div>Typed controls &middot; descriptions &middot; honest apply-state badge &middot; modified marker + reset to default &middot; inline validation.</div>
+      <div>Slicing</div>
+      <div>Dropped. That was me jumping ahead, not the brainstorming skill - it only says to persist the design and offer a spec. No fix needed on your side.</div>
+    </div>
+  </div>
+
+  <div class="callout warn" style="margin-top:18px">
+    <h4>One caveat on deleting the docs table, then I'll stop</h4>
+    <p style="margin-bottom:0" class="small">
+      The docs are the only place someone can read what sensor-hub can be configured to do <em>before</em>
+      they install it - a Docusaurus page is public and indexable, a logged-in properties page is not.
+      Deleting the table removes that. Two ways to keep both: keep a short generated list in the docs
+      (still one source of truth, no hand-maintenance), or accept the loss because evaluation-before-install
+      is not a use case you care about. Your instruction stands either way - say which and I'll design it in.
+    </p>
+  </div>
+</section>
+
+<!-- ============ THE AUDIT ============ -->
+<section>
+  <div class="rule"><h2>The apply-state audit, all 29 properties</h2></div>
+  <p class="muted" style="margin-top:-6px;max-width:74ch">
+    Every property traced to the code that reads it. This is the fact you told me to go and find.
+  </p>
+
+  <div class="grid g3" style="margin:18px 0 4px">
+    <div class="paper pad" style="border-left:3px solid var(--ok)">
+      <div class="statnum" style="color:var(--ok)">18</div>
+      <div class="statlbl">already fully live - read from <code>AppConfig</code> at the point of use, so a PATCH takes effect on the next call</div>
+    </div>
+    <div class="paper pad" style="border-left:3px solid var(--warn)">
+      <div class="statnum" style="color:var(--warn)">10</div>
+      <div class="statlbl">not live - cached at boot in a constructor, a ticker, or a handler. The UI reports success anyway</div>
+    </div>
+    <div class="paper pad" style="border-left:3px solid var(--err)">
+      <div class="statnum" style="color:var(--err)">1</div>
+      <div class="statlbl"><code>database.path</code> - shouldn't be editable at all</div>
+    </div>
+  </div>
+
+  <div class="tblwrap" style="margin-top:16px">
+    <table>
+      <thead><tr><th style="width:38%">Property</th><th style="width:16%">State today</th><th>Why</th></tr></thead>
+      <tbody>
+        <tr><td class="mono tiny">auth.session.cookie.name<br>auth.session.ttl.minutes<br>auth.bcrypt.cost<br>auth.login.backoff.window.minutes<br>auth.login.backoff.threshold<br>auth.login.backoff.base.seconds<br>auth.login.backoff.max.seconds</td>
+          <td class="st"><span class="badge b-ok">live</span></td>
+          <td class="small">Read from <code>AppConfig</code> on every login, session check and hash. <span class="mono tiny">auth_service.go:53,81-91,195 &middot; auth_api.go:47,56</span></td></tr>
+        <tr><td class="mono tiny">sensor.data.retention.days<br>health.history.retention.days<br>failed.login.retention.days<br>alert.history.retention.days</td>
+          <td class="st"><span class="badge b-ok">live</span></td>
+          <td class="small">Read at the top of each cleanup run, so the next run uses the new value. <span class="mono tiny">cleanup_service.go:71-74 &middot; sensor_api.go:23</span></td></tr>
+        <tr><td class="mono tiny">weather.latitude<br>weather.longitude<br>weather.location.name</td>
+          <td class="st"><span class="badge b-ok">live</span></td>
+          <td class="small">No Go consumer at all - the UI reads them straight from the properties websocket, so they update instantly in the browser. <span class="mono tiny">WeatherForecastCard.tsx:22-24</span></td></tr>
+        <tr><td class="mono tiny">sensor.discovery.skip<br>openapi.yaml.location</td>
+          <td class="st"><span class="badge b-ok">live</span></td>
+          <td class="small">Read each time discovery runs. <span class="mono tiny">sensor_service.go:396,403</span></td></tr>
+        <tr><td class="mono tiny">smtp.user</td>
+          <td class="st"><span class="badge b-ok">live</span></td>
+          <td class="small">Read per email send. <span class="mono tiny">smtp/smtp.go:34</span></td></tr>
+        <tr><td class="mono tiny">actuator.command.timeout_seconds</td>
+          <td class="st"><span class="badge b-ok">live</span></td>
+          <td class="small">Read per command. <span class="mono tiny">command_service.go:209</span></td></tr>
+
+        <tr style="border-top:2px solid var(--divider)"><td class="mono tiny">sensor.collection.interval<br>data.cleanup.interval.hours</td>
+          <td class="st"><span class="badge b-err">stale</span></td>
+          <td class="small">Both go into <code>time.NewTicker(cfg.Interval)</code> once, when the task starts. The ticker is never reset. <span class="mono tiny">periodic.go:74 &middot; sensor_service.go:445 &middot; cleanup_service.go:78</span></td></tr>
+        <tr><td class="mono tiny">log.level</td>
+          <td class="st"><span class="badge b-err">stale</span></td>
+          <td class="small">Baked into <code>slog.HandlerOptions{Level: level}</code> as a fixed <code>slog.Level</code> at boot. <span class="mono tiny">serve.go:54 &middot; telemetry/logger.go:76</span></td></tr>
+        <tr><td class="mono tiny">readings.aggregation.enabled<br>readings.aggregation.tiers</td>
+          <td class="st"><span class="badge b-err">stale</span></td>
+          <td class="small">Parsed once and passed to <code>NewReadingsService</code> as constructor arguments. <span class="mono tiny">serve.go:114,123</span></td></tr>
+        <tr><td class="mono tiny">mqtt.broker.enabled<br>mqtt.broker.port</td>
+          <td class="st"><span class="badge b-warn">needs action</span></td>
+          <td class="small">The broker binds its port and is started (or not) at boot. It does have <code>Start()</code>, <code>Stop()</code> and <code>IsRunning()</code>, so it <em>can</em> be bounced - but that drops every connected MQTT client. <span class="mono tiny">serve.go:71,74 &middot; mqtt/broker.go:40,78</span></td></tr>
+        <tr><td class="mono tiny">oauth.credentials.file.path<br>oauth.token.file.path<br>oauth.token.refresh.interval.minutes</td>
+          <td class="st"><span class="badge b-warn">needs action</span></td>
+          <td class="small">The paths are cached at startup, but the existing in-app <strong>Reload</strong> button already re-pulls them from <code>AppConfig</code> (added in the issue #44 recovery). The UI just never tells you to press it. The refresh interval is passed to the constructor and is <em>not</em> re-applied by Reload. <span class="mono tiny">oauth_adapter.go:66 &middot; oauth.go:69,91</span></td></tr>
+        <tr><td class="mono tiny">database.path</td>
+          <td class="st"><span class="badge b-err">read-only</span></td>
+          <td class="small">Opened once at boot. Per your annotation, changing it breaks the app and the RPM upgrade. <span class="mono tiny">db/db.go:24</span></td></tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<!-- ============ FIX VS BADGE ============ -->
+<section>
+  <div class="rule"><h2>So: bug, or badge?</h2></div>
+
+  <div class="callout ok">
+    <h3 style="margin-bottom:8px">My answer: it's a bug for 5 of them, and a genuine lifecycle event for 5</h3>
+    <p style="margin-top:0">
+      A "requires restart" badge on <code>log.level</code> would be documenting a defect rather than fixing
+      it. The whole promise of this feature - PATCH, hot reload, broadcast - is that config applies without
+      a restart, and these properties quietly opt out of it. Where the fix is cheap, fix it. Where an
+      explicit action is genuinely correct, say so honestly and give the user the button.
+    </p>
+    <p style="margin-bottom:0">
+      <strong>Which means the badge is not "restart required".</strong> It's an apply-state, with four
+      values, and most properties never show one at all.
+    </p>
+  </div>
+
+  <div class="grid g2" style="margin-top:18px">
+    <div class="paper pad" style="border-left:3px solid var(--ok)">
+      <h4 style="color:var(--ok)">Fix it - these are bugs</h4>
+      <ul class="tight small">
+        <li>
+          <strong><code>log.level</code></strong> - swap the fixed <code>slog.Level</code> for a
+          <code>slog.LevelVar</code> and call <code>SetLevel</code> from <code>ReloadConfig</code>.
+          Roughly ten lines, no behaviour risk, and it turns the single most useful debugging property
+          into something you can flip from your phone while the fault is happening. That is a
+          <em>better</em> feature than the badge would have been.
+        </li>
+        <li>
+          <strong><code>sensor.collection.interval</code> and <code>data.cleanup.interval.hours</code></strong>
+          - one change to <code>periodic.TaskConfig</code>: take an interval <em>function</em> instead of a
+          value and reset the timer each iteration. Fixes both tasks at once, and any future one.
+          Honest caveat: the new interval takes effect from the next tick, so a change can take up to
+          the <em>old</em> interval to bite. That is "applies next cycle", not "live", and the UI should say so.
+        </li>
+        <li>
+          <strong><code>readings.aggregation.enabled</code> / <code>.tiers</code></strong> - have
+          <code>ReadingsService</code> read tiers from a provider rather than holding constructor args.
+          Bigger than the other two because it touches the aggregation path, and worth its own look at
+          whether re-tiering mid-flight is safe.
+        </li>
+      </ul>
+    </div>
+    <div class="paper pad" style="border-left:3px solid var(--warn)">
+      <h4 style="color:var(--warn)">Badge it - these really are lifecycle events</h4>
+      <ul class="tight small">
+        <li>
+          <strong>MQTT broker port / enabled.</strong> Rebinding a TCP port disconnects every sensor
+          publishing to it. Doing that silently because someone typed in a box would be worse than
+          requiring a restart. This is the one place a badge is the right answer - ideally as an explicit
+          "Apply and restart broker - this disconnects connected clients" action rather than a passive label.
+        </li>
+        <li>
+          <strong>OAuth paths.</strong> Not a restart - the Reload button already exists and already does
+          the right thing. The badge should say "needs OAuth reload" and, better, link straight to the
+          button. The <em>refresh interval</em> is the odd one out: Reload doesn't re-apply it, which is
+          a small genuine bug in the same family as the ticker one.
+        </li>
+        <li>
+          <strong><code>database.path</code>.</strong> Read-only field, with the value shown so it's still
+          discoverable. No badge, no input.
+        </li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="paper pad" style="margin-top:18px">
+    <h4>What that makes the metadata</h4>
+    <p class="small" style="margin-top:6px">
+      Four apply-states instead of one boolean. Only two of them ever render anything in the UI, which
+      keeps the page quiet - 18 of 29 properties would show no badge at all.
+    </p>
+<pre><code>MQTTBrokerPort int `prop:"mqtt.broker.port" default:"1883" file:"application"
+    validate:"positive" group:"mqtt" apply:"action:mqtt-restart"
+    desc:"TCP port the embedded MQTT broker listens on."`
+
+SensorCollectionInterval int `prop:"sensor.collection.interval" default:"300"
+    file:"application" validate:"positive" group:"sensors"
+    unit:"seconds" apply:"next-cycle"
+    desc:"How often every enabled sensor is polled."`
+
+DatabasePath string `prop:"database.path" default:"data/sensor_hub.db"
+    file:"database" validate:"non_empty" group:"advanced" readonly:"true"
+    desc:"SQLite database file. Set at install time."`</code></pre>
+    <div class="tblwrap" style="margin-top:6px">
+      <table>
+        <thead><tr><th style="width:150px">apply</th><th style="width:90px">Count</th><th>What the UI shows</th></tr></thead>
+        <tbody>
+          <tr><td class="mono tiny">live</td><td>18</td><td class="small">Nothing. Silence is the correct signal - it just works.</td></tr>
+          <tr><td class="mono tiny">next-cycle</td><td>3</td><td class="small">Muted helper line under the field: "applies from the next collection cycle".</td></tr>
+          <tr><td class="mono tiny">action:&hellip;</td><td>5</td><td class="small">The one chip you allowed, plus a button that performs the action (restart broker / reload OAuth).</td></tr>
+          <tr><td class="mono tiny">readonly</td><td>1</td><td class="small">Value rendered as text, no input, one line of explanation.</td></tr>
+        </tbody>
+      </table>
+    </div>
+    <p class="small muted" style="margin-bottom:0">
+      Counts assume the fixes land. Without them: 18 live, 5 next-cycle-ish, 5 action, 1 read-only - and
+      the "stale" ones would all have to be badged as needing a full service restart.
+    </p>
+  </div>
+
+  <form class="q" data-lavish-question="apply" onsubmit="return queueAnswer(event,'apply','Apply-state scope')">
+    <h3>How much of the fixing is part of this work?</h3>
+    <p class="qsub">The metadata has to be honest either way - this is about whether we change the truth or just report it.</p>
+    <div class="opts">
+      <label class="opt"><input type="radio" name="apply" value="fix the cheap ones (log.level, periodic intervals) in this work; badge the rest; aggregation and oauth refresh interval as follow-ups">
+        <span><span class="ol">Fix the cheap two, badge the rest <span class="badge b-rec">Recommended</span></span>
+        <span class="od"><code>log.level</code> and the periodic-interval change land here - both are small, contained and independently testable. Aggregation and the OAuth refresh interval get raised as their own issues rather than smuggled into a UI change.</span></span></label>
+      <label class="opt"><input type="radio" name="apply" value="fix everything that can be made live, including aggregation and oauth refresh interval, as part of this work">
+        <span><span class="ol">Fix everything fixable</span>
+        <span class="od">Including the aggregation service and the OAuth refresh interval. Only MQTT and <code>database.path</code> keep a badge. Largest scope; the aggregation change deserves its own thinking about mid-flight re-tiering.</span></span></label>
+      <label class="opt"><input type="radio" name="apply" value="badge only for now, raise the live-apply bugs as separate issues">
+        <span><span class="ol">Badge only, fix later</span>
+        <span class="od">Ship honest metadata now, raise every live-apply bug as its own issue. Keeps this piece of work purely about the page. Cost: we knowingly ship "requires restart" on things that shouldn't require one.</span></span></label>
+      <label class="opt"><input type="radio" name="apply" value="fix the live-apply bugs first as separate work, then design the page against a mostly-live config">
+        <span><span class="ol">Fix first, page second</span>
+        <span class="od">Invert it: the apply-state bugs become their own piece of work, and the page gets designed against a config that is mostly genuinely live. Slower to see anything visual.</span></span></label>
+    </div>
+    <textarea class="qfree" name="note" rows="2" placeholder="Optional: anything about the MQTT bounce-vs-restart call, or the aggregation risk"></textarea>
+    <button type="submit" class="qbtn">Queue this answer</button>
+  </form>
+</section>
+
+<!-- ============ NO-CHIPS LAYOUT ============ -->
+<section>
+  <div class="rule"><h2>Layout B, with the chips taken out</h2></div>
+  <p class="muted" style="margin-top:-6px;max-width:74ch">
+    You agreed on B but called out chip overuse. Here is B rebuilt with exactly one chip on the page -
+    the apply-state one you allowed - and everything else carried by weight, colour and plain text.
+  </p>
+
+  <div class="mock" style="margin-top:16px">
+    <div class="mock-bar"><span>&#9776;</span> Sensor Hub</div>
+    <div class="mock-body">
+      <div style="display:flex;justify-content:space-between;align-items:center;gap:10px;margin-bottom:12px;flex-wrap:wrap">
+        <div style="font-size:18px">Properties</div>
+        <div style="display:flex;gap:8px;align-items:center">
+          <span class="mock-desc">2 unsaved changes</span>
+          <button class="mock-btn ghost">Discard</button>
+          <button class="mock-btn">Save</button>
+        </div>
+      </div>
+      <div style="display:grid;grid-template-columns:150px minmax(0,1fr);gap:14px">
+        <div class="mock-rail">
+          <div style="padding-bottom:8px;display:block"><span class="mock-search">Search</span></div>
+          <div class="on"><span>Sensors</span><span class="n">1</span></div>
+          <div><span>Retention</span><span class="n">1</span></div>
+          <div><span>Security</span></div>
+          <div><span>MQTT</span></div>
+          <div><span>Email &amp; OAuth</span></div>
+          <div><span>Weather</span></div>
+          <div><span>Advanced</span></div>
+        </div>
+        <div style="display:grid;gap:10px">
+          <div class="mock-card">
+            <div class="mock-h2">Sensors &amp; collection</div>
+            <div class="mock-desc" style="margin-bottom:6px">How often sensors are polled and how they are discovered.</div>
+
+            <div class="mock-row mod-row">
+              <span>
+                <span class="mock-label" style="color:var(--primary)">Collection interval</span>
+                <span class="mock-desc">How often every enabled sensor is polled.</span>
+              </span>
+              <span style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
+                <span class="mock-input" style="width:62px;border-color:var(--primary)">120</span>
+                <span class="mock-desc">seconds</span>
+                <span class="mock-undo" title="Reset">&#8630;</span>
+                <span class="mock-desc" style="flex-basis:100%">Saved value 300 &middot; default 300 &middot; applies from the next cycle</span>
+              </span>
+            </div>
+
+            <div class="mock-row">
+              <span>
+                <span class="mock-label">Skip sensor discovery</span>
+                <span class="mock-desc">Don't try to auto-discover sensors at startup.</span>
+              </span>
+              <span><span class="mock-toggle"></span></span>
+            </div>
+
+            <div class="mock-row">
+              <span>
+                <span class="mock-label">Actuator command timeout</span>
+                <span class="mock-desc">How long to wait for a device to acknowledge a command.</span>
+              </span>
+              <span style="display:flex;gap:8px;align-items:center">
+                <span class="mock-input" style="width:56px">10</span><span class="mock-desc">seconds</span>
+              </span>
+            </div>
+          </div>
+
+          <div class="mock-card">
+            <div class="mock-h2">MQTT</div>
+            <div class="mock-row">
+              <span>
+                <span class="mock-label">Broker port <span class="badge-restart">restart broker</span></span>
+                <span class="mock-desc">TCP port the embedded broker listens on.</span>
+              </span>
+              <span style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
+                <span class="mock-input" style="width:70px">1883</span>
+                <span class="mock-desc" style="flex-basis:100%">Changing this disconnects connected sensors.</span>
+              </span>
+            </div>
+          </div>
+
+          <div class="mock-card">
+            <div class="mock-h2">Advanced</div>
+            <div class="mock-row">
+              <span>
+                <span class="mock-label">Log level</span>
+                <span class="mock-desc">Minimum severity written to the log.</span>
+              </span>
+              <span><span class="mock-input" style="padding-right:22px">info &#9662;</span></span>
+            </div>
+            <div class="mock-row">
+              <span>
+                <span class="mock-label">Database file</span>
+                <span class="mock-desc">Set at install time. Not changeable at runtime.</span>
+              </span>
+              <span class="mock-key muted">/var/lib/sensor-hub/sensor_hub.db</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="paper pad" style="margin-top:16px">
+    <h4>What replaced each chip</h4>
+    <div class="grid g2" style="margin-top:8px">
+      <ul class="tight small" style="margin:0">
+        <li><strong>"was 300" chip</strong> &rarr; an accent left-edge on the row, the label in accent colour, and one muted helper line: <em>Saved value 300 &middot; default 300</em>.</li>
+        <li><strong>"3 modified" chip</strong> &rarr; plain text in the header: <em>2 unsaved changes</em>, next to a Discard button that only appears when there are any.</li>
+      </ul>
+      <ul class="tight small" style="margin:0">
+        <li><strong>"default" chip</strong> &rarr; nothing at all. An unmodified property says nothing; the default only appears in the helper line once you've changed something, which is the only moment you care.</li>
+        <li><strong>Per-group counts</strong> &rarr; a right-aligned number in the rail, so you can see which collapsed groups hold your edits without a pill on every row.</li>
+      </ul>
+    </div>
+  </div>
+
+  <form class="q" data-lavish-question="modified" onsubmit="return queueAnswer(event,'modified','Modified-state treatment')">
+    <h3>Is that the right treatment for "you changed this"?</h3>
+    <p class="qsub">Three ways to signal it without a chip. The mock above shows the first.</p>
+    <div class="opts">
+      <label class="opt"><input type="radio" name="modified" value="accent left-edge on the row + accent label + one muted helper line with saved and default values">
+        <span><span class="ol">Accent edge + helper line <span class="badge b-rec">as mocked</span></span>
+        <span class="od">Row gets a coloured left edge, the label turns accent, and one muted line carries saved value, default and apply-state. Reads at a glance, adds one line of height only to rows you touched.</span></span></label>
+      <label class="opt"><input type="radio" name="modified" value="undo icon only, with saved and default values in a tooltip">
+        <span><span class="ol">Undo icon only</span>
+        <span class="od">Quietest possible: a reset arrow appears at the end of a changed row, values live in its tooltip. No layout shift at all. Cost: the old value is hidden behind a hover, which is useless on a phone.</span></span></label>
+      <label class="opt"><input type="radio" name="modified" value="no per-row marker; a review-changes dialog on save lists every change as a diff">
+        <span><span class="ol">No per-row marker, diff on save</span>
+        <span class="od">Rows stay completely clean; pressing Save opens a list of every change as old &rarr; new before it commits. Strongest safety, but you can't see what you've touched while editing.</span></span></label>
+    </div>
+    <textarea class="qfree" name="note" rows="2" placeholder="Optional: or a combination"></textarea>
+    <button type="submit" class="qbtn">Queue this answer</button>
+  </form>
+</section>
+
+<!-- ============ SEARCH ============ -->
+<section>
+  <div class="rule"><h2>One thing your answers contradict</h2></div>
+  <div class="callout info">
+    <p style="margin-top:0">
+      You picked layout <strong>B</strong>, whose main advantage over tabs is that search filters across
+      every group at once - that was the argument that beat A. But <strong>search / filter</strong> wasn't
+      among the five behaviours you ticked. I've mocked it above because I think it was implied by the
+      layout choice rather than rejected, but I'm not going to quietly assume that.
+    </p>
+    <p style="margin-bottom:0" class="small">
+      If search is genuinely out, B loses most of its edge over A and you should probably have tabs. That
+      is the honest version - I'd rather re-open the layout question than build B with its best feature
+      removed.
+    </p>
+  </div>
+
+  <form class="q" data-lavish-question="search" onsubmit="return queueAnswer(event,'search','Search')">
+    <h3>Is global search in?</h3>
+    <div class="opts">
+      <label class="opt"><input type="radio" name="search" value="yes - search is in, it was implied by choosing layout B"><span><span class="ol">In - it was implied by B <span class="badge b-rec">assumed</span></span><span class="od">A search box in the rail that filters rows across every group, matching on key, label and description.</span></span></label>
+      <label class="opt"><input type="radio" name="search" value="no - drop search, B without it is still worth it for the grouping and single-page view"><span><span class="ol">Out - B is still worth it without</span><span class="od">Grouping, the rail and one-page visibility carry it on their own. Ctrl-F still works because everything is on one page - which is a fair point I under-weighted.</span></span></label>
+      <label class="opt"><input type="radio" name="search" value="no search, and reconsider tabs since that was B's main advantage"><span><span class="ol">Out - and reconsider tabs</span><span class="od">If search is gone, revisit whether A was the better call.</span></span></label>
+    </div>
+    <button type="submit" class="qbtn">Queue this answer</button>
+  </form>
+</section>
+
+<section>
+  <div class="rule"><h2>Anything else</h2></div>
+  <form class="q" data-lavish-question="open2" onsubmit="return queueFree(event,'open2','Open feedback')">
+    <h3>Open feedback</h3>
+    <p class="qsub">Once these are answered I'll write the design up and put it in the tracker - which this project doesn't have configured yet, so I'll need to set that up first.</p>
+    <textarea class="qfree" name="open2" rows="4" placeholder="Anything on the audit, the fix-vs-badge call, or the docs caveat"></textarea>
+    <button type="submit" class="qbtn">Queue this answer</button>
+  </form>
+</section>
+
+</main>
+
+<script>
+  function toggleTheme() {
+    var r = document.documentElement;
+    r.setAttribute('data-theme', r.getAttribute('data-theme') === 'dark' ? 'light' : 'dark');
+  }
+  if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    document.documentElement.setAttribute('data-theme', 'dark');
+  }
+  function confirmQueued(form) {
+    var btn = form.querySelector('button[type="submit"]');
+    var old = btn.textContent;
+    btn.textContent = 'Queued ✓';
+    setTimeout(function () { btn.textContent = old; }, 1600);
+  }
+  function queueAnswer(event, key, label) {
+    event.preventDefault();
+    var form = event.currentTarget;
+    var fd = new FormData(form);
+    var choice = fd.get(key);
+    if (!choice) return false;
+    var note = (fd.get('note') || '').toString().trim();
+    var msg = label + ': ' + choice + (note ? '\nNote: ' + note : '');
+    window.lavish && window.lavish.queuePrompt(msg, {
+      tag: 'choice', text: label + ': ' + choice, element: form, queueKey: key,
+      data: { question: key, answer: choice, note: note }
+    });
+    confirmQueued(form);
+    return false;
+  }
+  function queueFree(event, key, label) {
+    event.preventDefault();
+    var form = event.currentTarget;
+    var val = (new FormData(form).get(key) || '').toString().trim();
+    if (!val) return false;
+    window.lavish && window.lavish.queuePrompt(label + ': ' + val, {
+      tag: 'feedback', text: label, element: form, queueKey: key,
+      data: { question: key, answer: val }
+    });
+    confirmQueued(form);
+    return false;
+  }
+</script>
+</body>
+</html>

--- a/.lavish/websocket-first-load.html
+++ b/.lavish/websocket-first-load.html
@@ -1,0 +1,376 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Controllable sensors: slow first-load diagnosis & fix</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<style>
+  :root {
+    --brand: #D4451A;
+    --brand-light: #ED5125;
+    --brand-dark: #B33612;
+    --bg: #F5F0EB;
+    --paper: #FFFFFF;
+    --ink: #1A1A1A;
+    --ink-2: #5C5C5C;
+    --divider: #D9D0C7;
+    --good: #2E7D32;
+    --warn: #B8860B;
+    --bad: #B3261E;
+    --shadow: 0 1px 3px rgba(26,26,26,0.08), 0 8px 24px rgba(26,26,26,0.06);
+    --radius: 14px;
+  }
+  *, *::before, *::after { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    font-family: "Roboto", "Segoe UI", system-ui, -apple-system, sans-serif;
+    background: var(--bg);
+    color: var(--ink);
+    line-height: 1.55;
+    -webkit-font-smoothing: antialiased;
+  }
+  .wrap { max-width: 1040px; margin: 0 auto; padding: 40px 24px 80px; }
+  .eyebrow {
+    text-transform: uppercase; letter-spacing: 0.14em; font-size: 12px;
+    font-weight: 700; color: var(--brand); margin: 0 0 8px;
+  }
+  h1 { font-size: 32px; line-height: 1.2; margin: 0 0 12px; font-weight: 800; letter-spacing: -0.01em; }
+  h2 { font-size: 21px; margin: 0 0 14px; font-weight: 700; letter-spacing: -0.005em; }
+  h3 { font-size: 16px; margin: 0 0 8px; font-weight: 700; }
+  p { margin: 0 0 12px; }
+  .lede { font-size: 17px; color: var(--ink-2); max-width: 70ch; }
+  section { margin-top: 40px; }
+  .card {
+    background: var(--paper); border: 1px solid var(--divider);
+    border-radius: var(--radius); box-shadow: var(--shadow); padding: 24px;
+  }
+  .card + .card { margin-top: 16px; }
+  code, .mono { font-family: "Roboto Mono", ui-monospace, "SF Mono", Menlo, monospace; }
+  code.inl { background: rgba(212,69,26,0.08); color: var(--brand-dark); padding: 1px 6px; border-radius: 5px; font-size: 0.88em; overflow-wrap: anywhere; }
+  pre {
+    background: #20140F; color: #F3E7DF; border-radius: 10px; padding: 16px 18px;
+    overflow-x: auto; font-size: 13px; line-height: 1.5; margin: 0 0 12px;
+  }
+  pre .c { color: #C99A86; }
+  pre .k { color: #ED9B7A; }
+  pre .hl { background: rgba(237,81,37,0.22); display: inline-block; width: 100%; }
+  .pill {
+    display: inline-flex; align-items: center; gap: 6px; font-size: 12px; font-weight: 700;
+    padding: 3px 10px; border-radius: 999px; letter-spacing: 0.02em;
+  }
+  .pill.good { background: rgba(46,125,50,0.12); color: var(--good); }
+  .pill.warn { background: rgba(184,134,11,0.14); color: var(--warn); }
+  .pill.bad  { background: rgba(179,38,30,0.12); color: var(--bad); }
+  .pill.brand{ background: rgba(212,69,26,0.10); color: var(--brand-dark); }
+  .grid2 { display: grid; grid-template-columns: minmax(0,1fr) minmax(0,1fr); gap: 16px; }
+  .grid3 { display: grid; grid-template-columns: repeat(3, minmax(0,1fr)); gap: 16px; }
+  @media (max-width: 760px) { .grid2, .grid3 { grid-template-columns: minmax(0,1fr); } }
+  .stat { background: var(--paper); border: 1px solid var(--divider); border-radius: var(--radius); padding: 18px 20px; }
+  .stat .big { font-size: 28px; font-weight: 800; letter-spacing: -0.01em; }
+  .stat .lbl { font-size: 12px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--ink-2); font-weight: 700; }
+  .stat .sub { font-size: 13px; color: var(--ink-2); margin-top: 4px; }
+  .callout { border-left: 4px solid var(--brand); background: rgba(212,69,26,0.05); padding: 14px 18px; border-radius: 0 10px 10px 0; }
+  .callout.warn { border-left-color: var(--warn); background: rgba(184,134,11,0.07); }
+  .diagram-host { background: var(--paper); border: 1px solid var(--divider); border-radius: var(--radius); padding: 20px; box-shadow: var(--shadow); overflow-x: auto; }
+  .mermaid { display: flex; justify-content: center; }
+  table.cmp { width: 100%; border-collapse: collapse; font-size: 14px; }
+  table.cmp th, table.cmp td { text-align: left; padding: 12px 14px; border-bottom: 1px solid var(--divider); vertical-align: top; }
+  table.cmp th { font-size: 12px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--ink-2); }
+  table.cmp td.opt { font-weight: 700; white-space: nowrap; }
+  .rec-row { background: rgba(212,69,26,0.05); }
+  ul.tight { margin: 6px 0 0; padding-left: 18px; }
+  ul.tight li { margin-bottom: 4px; }
+  .opt-card { background: var(--paper); border: 1px solid var(--divider); border-radius: var(--radius); box-shadow: var(--shadow); padding: 20px; }
+  .opt-card.rec { border: 2px solid var(--brand); }
+  .opt-head { display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-bottom: 8px; }
+  .opt-head .tag { font-size: 12px; font-weight: 800; color: var(--ink-2); }
+  .ratings { display: flex; gap: 14px; flex-wrap: wrap; margin-top: 12px; font-size: 12px; color: var(--ink-2); }
+  .ratings b { color: var(--ink); }
+  form.decide { background: var(--paper); border: 1px solid var(--divider); border-radius: var(--radius); box-shadow: var(--shadow); padding: 24px; }
+  fieldset { border: none; margin: 0 0 18px; padding: 0; }
+  legend { font-weight: 700; font-size: 15px; margin-bottom: 10px; padding: 0; }
+  label.choice { display: flex; gap: 12px; align-items: flex-start; padding: 12px 14px; border: 1px solid var(--divider); border-radius: 10px; margin-bottom: 8px; cursor: pointer; transition: border-color .15s, background .15s; }
+  label.choice:hover { border-color: var(--brand-light); background: rgba(212,69,26,0.03); }
+  label.choice input { margin-top: 3px; accent-color: var(--brand); width: 16px; height: 16px; flex: none; }
+  label.choice .t { font-weight: 700; }
+  label.choice .d { font-size: 13px; color: var(--ink-2); }
+  textarea.notes { width: 100%; border: 1px solid var(--divider); border-radius: 10px; padding: 12px; font-family: inherit; font-size: 14px; resize: vertical; min-height: 70px; }
+  button.submit {
+    background: var(--brand); color: #fff; border: none; border-radius: 10px; padding: 12px 22px;
+    font-size: 15px; font-weight: 700; cursor: pointer; transition: background .15s;
+  }
+  button.submit:hover { background: var(--brand-dark); }
+  .muted { color: var(--ink-2); font-size: 13px; }
+  .filetag { font-size: 12px; color: var(--ink-2); }
+  :where(p, h1, h2, h3, li, td, th) { overflow-wrap: anywhere; }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <p class="eyebrow">Sensor Hub · first-load investigation</p>
+  <h1>Why controllable toggles take 1&ndash;2s to become usable</h1>
+  <p class="lede">You asked me to investigate the WebSocket. The short version: <b>the WebSocket is mostly innocent</b>. It pushes the toggle's state the instant the connection registers. The 1&ndash;2s is a heavy SQLite query that produces that snapshot, queued behind the dashboard's chart-query burst.</p>
+
+  <section>
+    <div class="grid3">
+      <div class="stat">
+        <div class="lbl">Snapshot query · idle</div>
+        <div class="big" style="color:var(--good)">~23ms</div>
+        <div class="sub">A light request when the DB is quiet</div>
+      </div>
+      <div class="stat">
+        <div class="lbl">Snapshot query · under load</div>
+        <div class="big" style="color:var(--bad)">1.3&ndash;2.6s</div>
+        <div class="sub">Same request during the chart-query burst</div>
+      </div>
+      <div class="stat">
+        <div class="lbl">Source of the numbers</div>
+        <div class="big" style="font-size:18px; line-height:1.4">Your own commit</div>
+        <div class="sub mono">e9c0629 (the scheduler)</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============ DIAGNOSIS ============ -->
+  <section>
+    <h2>What actually happens on first load</h2>
+    <div class="diagram-host">
+      <pre class="mermaid">
+sequenceDiagram
+    autonumber
+    participant B as Browser (React)
+    participant A as AuthProvider
+    participant WS as /readings/ws/current
+    participant H as Go handler
+    participant DB as SQLite (single-threaded)
+
+    Note over B,A: Page loads
+    A->>H: GET /auth/me
+    Note over B,WS: WS is gated: enabled = (user != null)<br/>so it cannot open yet
+    H-->>A: user
+    Note over B: every chart widget fires<br/>GET /readings/between (burst)
+    B-)DB: chart queries pile up
+    B->>WS: connect (now user != null)
+    WS->>H: SubscribeCurrentReadings
+    rect rgb(248, 224, 214)
+    H->>DB: ServiceGetLatest()  full-table window query
+    Note over H,DB: queues BEHIND the chart burst<br/>1.3 to 2.6s
+    DB-->>H: latest readings
+    end
+    H->>WS: upgrade + register
+    H-)B: snapshot pushed (immediate, once it has data)
+    Note over B: toggle resolves -> usable
+      </pre>
+    </div>
+    <p class="muted">Steps 8&ndash;9 (the shaded band) are the delay. Everything after is instant. The WebSocket "fires" correctly &mdash; it just has nothing to send until that contended query returns.</p>
+  </section>
+
+  <!-- ============ THE HANDLER ============ -->
+  <section>
+    <h2>The critical path, in one function</h2>
+    <div class="card">
+      <p class="filetag mono">sensor_hub/api/readings_api.go:69</p>
+      <pre><span class="k">func</span> (s *Server) SubscribeCurrentReadings(c *gin.Context) {
+<span class="hl">    currentReadings, err := s.readingsService.ServiceGetLatest(ctx)  <span class="c">// heavy query, runs BEFORE upgrade</span></span>
+    ...
+    createPushWebSocket(c, <span class="k">"current-readings"</span>)          <span class="c">// upgrade + register</span>
+    ws.BroadcastToTopic(<span class="k">"current-readings"</span>, currentReadings) <span class="c">// pushed immediately</span>
+}</pre>
+      <p style="margin-bottom:0"><code class="inl">ServiceGetLatest</code> is a <code class="inl">ROW_NUMBER() OVER (PARTITION BY sensor_id, measurement_type_id ...)</code> window scan over the whole <code class="inl">readings</code> table (<span class="mono">db/readings_repository.go:193</span>). Cheap when idle; serialized behind chart reads on the Pi's single-writer SQLite under load. And because it runs <i>before</i> the upgrade, it delays both the connection opening and the data.</p>
+    </div>
+  </section>
+
+  <!-- ============ WHY THE SCHEDULER DIDN'T WORK ============ -->
+  <section>
+    <h2>Why the request scheduler didn't fix it</h2>
+    <div class="grid2">
+      <div class="card">
+        <span class="pill bad">Structural miss #1</span>
+        <h3 style="margin-top:10px">The snapshot rides the WebSocket, not REST</h3>
+        <p style="margin-bottom:0">The scheduler only meters read-only <b>REST</b> calls. The toggle's state arrives over <code class="inl">/readings/ws/current</code>, which the scheduler never touches. So the one path that matters for the toggle was never governed.</p>
+      </div>
+      <div class="card">
+        <span class="pill bad">Structural miss #2</span>
+        <h3 style="margin-top:10px">The query still contends in SQLite</h3>
+        <p style="margin-bottom:0">Capping REST to 4 concurrent reduced the flood from "unbounded" to "throttled" &mdash; a real win &mdash; but <code class="inl">ServiceGetLatest</code> still competes for the same single-threaded DB, and still runs before the upgrade. The critical path was never on the table the scheduler controls.</p>
+      </div>
+    </div>
+    <div class="callout warn" style="margin-top:16px">
+      <b>Net:</b> the scheduler was a reasonable instinct (contention <i>is</i> the root cause) aimed one layer too high. It made commands more responsive once issued, but couldn't make the <i>initial snapshot</i> fast.
+    </div>
+  </section>
+
+  <!-- ============ THE FIX OPTIONS ============ -->
+  <section>
+    <h2>How to fix it</h2>
+    <p class="lede" style="margin-bottom:20px">You chose <b>server-confirmed state only</b> &mdash; no optimistic last-known render. So the fix must make the real snapshot fast, not paper over it. That points hard at one approach.</p>
+
+    <div class="opt-card rec" style="margin-bottom:16px">
+      <div class="opt-head">
+        <h3 style="margin:0">A · In-memory "latest readings" store, served on connect</h3>
+        <span class="pill brand">Recommended</span>
+      </div>
+      <p>Keep an in-process map <code class="inl">sensorName &rarr; measurementType &rarr; Reading</code>, updated every time a reading flows through (collection, command result). On WS connect, build the snapshot from <b>memory</b> instead of <code class="inl">ServiceGetLatest</code> &mdash; a microsecond read that never touches SQLite. Seed it once at startup from the existing query.</p>
+      <ul class="tight">
+        <li>Removes the toggle's critical-path query from SQLite <b>entirely</b> &mdash; immune to the chart burst by construction, not by throttling.</li>
+        <li>Natural home: wrap "update the store + broadcast" into one <code class="inl">Publish(readings)</code> call so the cache and the live stream can never drift. (Today there are 3 broadcast sites that would each update it.)</li>
+        <li>Memory cost is trivial: bounded by #sensors &times; #measurement-types, last-value-wins.</li>
+      </ul>
+      <div class="ratings">
+        <span>Robustness <b>High</b></span><span>Latency win <b>~1&ndash;2s &rarr; ~0</b></span><span>Effort <b>Medium</b></span><span>Touches <b>Go backend</b></span>
+      </div>
+    </div>
+
+    <div class="grid2">
+      <div class="opt-card">
+        <div class="opt-head"><h3 style="margin:0">B · Upgrade first, then fetch</h3><span class="pill warn">Partial</span></div>
+        <p>Reorder the handler: register the connection <i>before</i> running the query, then push when it returns. The socket opens instantly; the data still waits on the contended query.</p>
+        <p class="muted" style="margin-bottom:0">Cheap and correct, but alone it only fixes "connection opens late," not "controls usable late." Good as a companion to A, weak on its own.</p>
+      </div>
+      <div class="opt-card">
+        <div class="opt-head"><h3 style="margin:0">C · Make the query cheap</h3><span class="pill warn">Weaker</span></div>
+        <p>Add a covering index / dedicated latest-state table so <code class="inl">ServiceGetLatest</code> is fast. Reduces cost, but still hits SQLite and still serializes behind writes under load.</p>
+        <p class="muted" style="margin-bottom:0">Strictly dominated by A: more DB-coupling for less isolation.</p>
+      </div>
+      <div class="opt-card">
+        <div class="opt-head"><h3 style="margin:0">D · Throttle charts harder</h3><span class="pill bad">More of the same</span></div>
+        <p>Lower REST concurrency, defer chart loads until controls resolve, or finally use the unused <code class="inl">high</code> tier. Trades chart speed for control speed and stays on the REST layer.</p>
+        <p class="muted" style="margin-bottom:0">This is the road the scheduler already started down. Diminishing returns.</p>
+      </div>
+      <div class="opt-card">
+        <div class="opt-head"><h3 style="margin:0">+ Secondary · the auth gate</h3><span class="pill brand">Follow-up</span></div>
+        <p>Both sockets are gated on <code class="inl">enabled: user != null</code>, so they can't open until <code class="inl">GET /auth/me</code> resolves. That's a smaller, serial add-on to the delay &mdash; worth a look, but not the 1&ndash;2s.</p>
+        <p class="muted" style="margin-bottom:0">Note as a separate, lower-priority improvement.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============ DECIDED ============ -->
+  <section>
+    <h2>Decided so far</h2>
+    <div class="callout">
+      <b>Toggle latency fix &mdash; locked:</b> <span class="pill brand">A &middot; in-memory store</span> <span class="pill brand">+ B &middot; upgrade-before-query reorder</span> <span class="pill warn">auth gate: ignored</span><br>
+      And you added a second goal: <b>review the data pipeline / indexes</b> &mdash; "indexes are probably missing that really should be there." I measured and audited that next.
+    </div>
+  </section>
+
+  <!-- ============ PIPELINE / INDEX AUDIT ============ -->
+  <section>
+    <h2>Pipeline &amp; index audit &mdash; what I actually found</h2>
+    <p class="lede" style="margin-bottom:18px">I measured your live Pi and mapped every hot query against the existing indexes. The surprising result: the <code class="inl">readings</code> table isn't <i>missing</i> its key index &mdash; it already has the perfect one, but the chart query is written so SQLite <b>can't reach it</b>. Adding indexes is mostly the wrong move; one is redundant and actively slowing your writes.</p>
+
+    <div class="grid3" style="margin-bottom:18px">
+      <div class="stat"><div class="lbl">Live readings rows</div><div class="big">~250k</div><div class="sub">measured just now</div></div>
+      <div class="stat"><div class="lbl">Hottest stream</div><div class="big" style="font-size:20px">office-plug</div><div class="sub">161,181 rows &mdash; 65% of the table</div></div>
+      <div class="stat"><div class="lbl">Existing readings indexes</div><div class="big">4</div><div class="sub">1 redundant, 1 to verify</div></div>
+    </div>
+
+    <div class="opt-card rec" style="margin-bottom:16px">
+      <div class="opt-head"><h3 style="margin:0">Finding 1 &mdash; the composite index exists but is unreachable</h3><span class="pill brand">Biggest win</span></div>
+      <p>You already have <code class="inl">idx_readings_sensor_type_time (sensor_id, measurement_type_id, time DESC)</code> &mdash; exactly the right shape. But the chart query filters by <b>name</b>, after the join, so SQLite can never use it:</p>
+      <div class="grid2">
+        <div>
+          <span class="pill bad">Today &mdash; index unusable</span>
+          <pre><span class="c">-- range-scans ALL sensors in the window,</span>
+<span class="c">-- then discards by name</span>
+WHERE r.time BETWEEN ? AND ?
+  <span class="hl">AND LOWER(s.name) = LOWER(?)</span>
+  <span class="hl">AND LOWER(mt.name) = LOWER(?)</span>
+ORDER BY r.time ASC</pre>
+        </div>
+        <div>
+          <span class="pill good">Rewrite &mdash; composite kicks in</span>
+          <pre><span class="c">-- resolve name -&gt; id first (tiny lookups),</span>
+<span class="c">-- then a tight indexed range scan</span>
+WHERE <span class="hl">r.sensor_id = ?</span>
+  <span class="hl">AND r.measurement_type_id = ?</span>
+  AND r.time BETWEEN ? AND ?
+ORDER BY r.time</pre>
+        </div>
+      </div>
+      <p style="margin-bottom:0">A chart for office-plug power currently scans a time-slice across <i>every</i> sensor (including that 161k stream) and throws most of it away. Filtering by id lets the composite jump straight to the rows. Same fix applies to the aggregation window query (<span class="mono">readings_repository.go:144</span>), which partitions by <code class="inl">s.name, mt.name</code> too.</p>
+    </div>
+
+    <div class="grid2">
+      <div class="opt-card">
+        <div class="opt-head"><h3 style="margin:0">Finding 2 &mdash; drop a redundant index</h3><span class="pill good">Cheap win</span></div>
+        <p><code class="inl">idx_readings_sensor_id (sensor_id)</code> is fully covered by the leftmost column of the composite. It buys nothing on reads and adds write cost to <b>every insert</b> &mdash; worst on the office-plug hot path.</p>
+        <p class="muted" style="margin-bottom:0">Dropping it speeds ingest, which is part of the very contention causing the toggle delay. Reads + writes both win.</p>
+      </div>
+      <div class="opt-card">
+        <div class="opt-head"><h3 style="margin:0">Finding 3 &mdash; verify the ASC time index</h3><span class="pill warn">Confirm first</span></div>
+        <p><code class="inl">idx_readings_time_asc (time ASC)</code> (migration 16) overlaps <code class="inl">idx_readings_time (time DESC)</code> &mdash; SQLite can usually walk a DESC index backwards for ASC order. Likely a second redundant index.</p>
+        <p class="muted" style="margin-bottom:0">I'd confirm with <code class="inl">EXPLAIN QUERY PLAN</code> on the live DB before dropping &mdash; not assume.</p>
+      </div>
+    </div>
+
+    <div class="callout" style="margin-top:16px">
+      <b>The synergy:</b> Finding 1 makes chart reads cheaper, Finding 2 makes ingest writes cheaper. Both shrink the SQLite contention window &mdash; the same root cause behind the toggle delay. The in-memory store (A) removes the toggle from that window entirely; the pipeline work shrinks the window for everything else.
+    </div>
+  </section>
+
+  <!-- ============ FINAL PLAN ============ -->
+  <section>
+    <h2>Final plan</h2>
+    <div class="callout" style="margin-bottom:18px">
+      <b>Scope settled.</b> One cohesive change, two reinforcing workstreams. Query rewrite is <b>in scope</b>; index hygiene = <b>drop redundant + verify-then-drop ASC</b>; audit limited to the <b>readings pipeline</b>.
+    </div>
+
+    <div class="grid2">
+      <div class="opt-card rec">
+        <div class="opt-head"><h3 style="margin:0">Workstream 1 &middot; Toggle first-load</h3><span class="pill brand">Go backend</span></div>
+        <ul class="tight">
+          <li><b>A &mdash; in-memory store.</b> Authoritative <code class="inl">sensorName &rarr; type &rarr; Reading</code> map, last-write-wins. Connect-snapshot reads from memory, not <code class="inl">ServiceGetLatest</code>. Seed once from the existing query at startup.</li>
+          <li><b>Single <code class="inl">Publish(readings)</code></b> that updates the store <i>and</i> broadcasts, so cache and live stream can't drift. Route the 3 existing broadcast sites (<span class="mono">sensor_service.go:298/358/635</span>) + the snapshot handler through it.</li>
+          <li><b>B &mdash; reorder.</b> Upgrade/register before producing the snapshot in <span class="mono">readings_api.go:69</span>.</li>
+          <li>Frontend unchanged; server-confirmed-only preserved.</li>
+        </ul>
+      </div>
+      <div class="opt-card rec">
+        <div class="opt-head"><h3 style="margin:0">Workstream 2 &middot; Readings pipeline</h3><span class="pill brand">SQL + migration</span></div>
+        <ul class="tight">
+          <li><b>F1 &mdash; rewrite by id.</b> Resolve name&rarr;id up front, filter <code class="inl">r.sensor_id = ? AND r.measurement_type_id = ? AND r.time BETWEEN ?</code> in raw + aggregated + last + window queries. Unlocks the composite index.</li>
+          <li><b>F2 &mdash; drop <code class="inl">idx_readings_sensor_id</code></b> (redundant; cuts insert cost).</li>
+          <li><b>F3 &mdash; verify <code class="inl">EXPLAIN QUERY PLAN</code>, then drop <code class="inl">idx_readings_time_asc</code></b> if confirmed redundant.</li>
+          <li>New migration <span class="mono">000020</span> for the index drops; rewrite is code-only.</li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="callout warn" style="margin-top:16px">
+      <b>Out of scope:</b> the WebSocket auth gate (<code class="inl">enabled: user != null</code> &rarr; /auth/me) and index audits of non-readings tables. <b>Validate:</b> first-load time-to-interactive before/after on the live Pi, <code class="inl">EXPLAIN QUERY PLAN</code> on rewritten queries, and the integration suite (<span class="mono">go test -tags integration ./integration/</span>) &mdash; keeping live-Pi load conservative.
+    </div>
+    <p class="muted" style="margin-top:14px">Captured as a <code class="inl">workflow:design</code> GitHub issue &mdash; link in the chat reply.</p>
+  </section>
+
+  <p class="muted" style="margin-top:32px; text-align:center">Design source: matched to the Sensor Hub UI's own MUI theme (brand orange <code class="inl">#D4451A</code>, paper, Roboto). All code claims verified against the repo.</p>
+
+</div>
+
+<script type="module">
+  import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11.15.0/dist/mermaid.esm.min.mjs";
+  mermaid.initialize({
+    startOnLoad: true,
+    securityLevel: "strict",
+    theme: "base",
+    themeVariables: {
+      primaryColor: "#FBEDE6",
+      primaryBorderColor: "#D4451A",
+      primaryTextColor: "#1A1A1A",
+      lineColor: "#B33612",
+      actorBkg: "#FFFFFF",
+      actorBorder: "#D4451A",
+      actorTextColor: "#1A1A1A",
+      signalColor: "#5C5C5C",
+      signalTextColor: "#1A1A1A",
+      noteBkgColor: "#F5F0EB",
+      noteBorderColor: "#D9D0C7",
+      noteTextColor: "#1A1A1A",
+      fontFamily: "Roboto, system-ui, sans-serif"
+    }
+  });
+</script>
+</body>
+</html>

--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -1,0 +1,3 @@
+# Issue Tracker
+
+tracker: github-issues


### PR DESCRIPTION
The .lavish design pages were ignored, so the layout decisions behind a piece of work lived only on the machine that produced them. An issue could describe a layout but never point at it, which is what prompted this - the properties page slices under #265 had to carry the mock in prose because there was nothing to link to.

Unignores the directory and commits the five pages already there, plus docs/issue-tracker.md, which the tracker workflow reads from the repo and which was untracked for the same reason.

One caveat worth knowing: GitHub shows a committed HTML file as source rather than rendering it, so the useful link for a reader is the raw file opened locally, or the docs site if we ever decide these belong under docs/static.

🤖 Generated with [Claude Code](https://claude.com/claude-code)