### PR TITLE
Remove the sensitive property plumbing

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -110,7 +110,3 @@ Environment variables are defined in `/etc/sensor-hub/environment` and loaded by
 |-----------------------------|----------------------------------------------------------------------------------------|
 | `SENSOR_HUB_INITIAL_ADMIN`  | Creates an initial admin user on first startup; format is `username:password`          |
 | `SENSOR_HUB_ALLOWED_ORIGIN` | The allowed CORS origin for the web UI (e.g., `https://sensor-hub.example.com`)        |
-
-## Sensitive properties
-
-There are currently no sensitive database properties. When updating properties through the API, all values are stored as provided.

--- a/docs/docs/development/configuration-package.md
+++ b/docs/docs/development/configuration-package.md
@@ -30,7 +30,7 @@ The struct tags define the behaviour for this new property:
 - **Default value** — written to the property file if absent on first load
 - **Loading** — parsed from the correct file and typed into the struct field
 - **Saving** — serialised back to the correct file when the API writes changes
-- **Logging** — printed on startup and reload (unless marked `sensitive`)
+- **Logging** — printed on startup and reload
 - **Validation** — checked during loading according to the `validate` tag
 
 ### Struct Tags Reference
@@ -41,7 +41,6 @@ The struct tags define the behaviour for this new property:
 | `default`   | yes      | String representation of the default value    | Written to file if absent; used as fallback           |
 | `file`      | yes      | `application`, `smtp`, or `database`          | Which property file this setting belongs to           |
 | `validate`  | no       | `positive`, `non_negative`, or `non_empty` | Per-field validation applied during loading          |
-| `sensitive` | no       | `true`                                        | Masks value in API responses and log output           |
 
 ### Cross-Field Validation
 

--- a/sensor_hub/api/openapi.yaml
+++ b/sensor_hub/api/openapi.yaml
@@ -1177,9 +1177,7 @@ paths:
       summary: Get current application properties
       description: >-
         Returns a flat object mapping property keys to their current values.
-        Sensitive properties (such as OAuth secrets) are masked in
-        responses as `"*****"` to avoid leaking secrets. Values are returned
-        as strings.
+        Values are returned as strings.
       operationId: getProperties
       x-required-permission: view_properties
       responses:
@@ -1201,10 +1199,7 @@ paths:
       summary: Update application properties
       description: >-
         Update one or more properties. Pass a JSON object where keys are the
-        property names and values are the desired string values. To keep
-        sensitive properties secret when you don't want to change them, pass
-        the literal string `"*****"` as the value; the server will treat this
-        as "do not change" for known sensitive keys.
+        property names and values are the desired string values.
 
         The update will be validated, applied to the in-memory configuration,
         and persisted to configuration files asynchronously. A broadcast is
@@ -4070,7 +4065,6 @@ components:
       type: object
       description: |
         Flat map of configuration keys to values (all values as strings).
-        Sensitive values are masked ("*****") in responses.
       additionalProperties:
         type: string
       example:
@@ -4081,12 +4075,12 @@ components:
 
     UpdatePropertiesRequest:
       type: object
-      description: Map of properties to update. Use the literal string "*****" to indicate no change for sensitive keys.
+      description: Map of properties to update. Every value is written through as supplied.
       additionalProperties:
         type: string
       example:
         smtp.user: "new-user@example.com"
-        oauth.client_secret: "*****"
+        sensor.collection.interval: "300"
 
     PropertiesWebSocketMessage:
       type: object

--- a/sensor_hub/application_properties/application_properties_test.go
+++ b/sensor_hub/application_properties/application_properties_test.go
@@ -681,10 +681,6 @@ func TestReloadConfig_InvalidConfig(t *testing.T) {
 	assert.Equal(t, 100, AppConfig.SensorCollectionInterval)
 }
 
-func TestSensitivePropertiesKeys(t *testing.T) {
-	assert.Empty(t, SensitiveKeys())
-}
-
 func TestApplicationPropertiesDefaults_HasExpectedKeys(t *testing.T) {
 	appDefaults, _, _ := BuildDefaults()
 

--- a/sensor_hub/application_properties/config_engine.go
+++ b/sensor_hub/application_properties/config_engine.go
@@ -21,7 +21,6 @@ type PropertyDef struct {
 	Default    string // default value from `default` tag
 	File       string // "application", "smtp", or "database"
 	Validate   string // "positive", "non_negative", or ""
-	Sensitive  bool   // if true, mask in logs and API responses
 }
 
 var registry []PropertyDef
@@ -49,7 +48,6 @@ func buildRegistry() []PropertyDef {
 			Default:    field.Tag.Get("default"),
 			File:       field.Tag.Get("file"),
 			Validate:   field.Tag.Get("validate"),
-			Sensitive:  field.Tag.Get("sensitive") == "true",
 		})
 	}
 
@@ -203,31 +201,17 @@ func ConvertToMaps(cfg *ApplicationConfiguration) (application map[string]string
 	return application, smtp, database
 }
 
-// LogConfig logs all non-sensitive configuration values.
+// LogConfig logs all configuration values.
 func LogConfig(cfg *ApplicationConfiguration) {
 	val := reflect.ValueOf(cfg).Elem()
 	args := make([]any, 0, len(registry)*2)
 
 	for _, def := range registry {
-		if def.Sensitive {
-			continue
-		}
 		field := val.Field(def.FieldIndex)
 		args = append(args, toSnakeCase(def.FieldName), field.Interface())
 	}
 
 	slog.Info("configuration reloaded", args...)
-}
-
-// SensitiveKeys returns the property keys marked as sensitive.
-func SensitiveKeys() []string {
-	var keys []string
-	for _, def := range registry {
-		if def.Sensitive {
-			keys = append(keys, def.Key)
-		}
-	}
-	return keys
 }
 
 // SaveToFiles writes the current configuration to the property files.

--- a/sensor_hub/gen/types.gen.go
+++ b/sensor_hub/gen/types.gen.go
@@ -838,7 +838,6 @@ type PermissionInfo struct {
 }
 
 // PropertiesMap Flat map of configuration keys to values (all values as strings).
-// Sensitive values are masked ("*****") in responses.
 type PropertiesMap map[string]string
 
 // RateLimitResponse Rate limit exceeded response
@@ -1010,7 +1009,7 @@ type UpdateDashboardRequest struct {
 	Name   *string          `json:"name,omitempty"`
 }
 
-// UpdatePropertiesRequest Map of properties to update. Use the literal string "*****" to indicate no change for sensitive keys.
+// UpdatePropertiesRequest Map of properties to update. Every value is written through as supplied.
 type UpdatePropertiesRequest map[string]string
 
 // User User information

--- a/sensor_hub/integration/properties_test.go
+++ b/sensor_hub/integration/properties_test.go
@@ -3,6 +3,7 @@
 package integration
 
 import (
+	"encoding/json"
 	"net/http"
 	"testing"
 
@@ -26,4 +27,30 @@ func TestProperties_SetAndGet(t *testing.T) {
 	resp, status := client.GetProperties()
 	require.Equal(t, http.StatusOK, status)
 	assert.Contains(t, string(resp), "600")
+}
+
+// Whatever a client writes is what it reads back. No value is reserved, and no
+// value is rewritten on the way out.
+func TestProperties_ValuesRoundTripVerbatim(t *testing.T) {
+	original := readProperty(t, "smtp.user")
+	defer client.SetProperty("smtp.user", original)
+
+	for _, value := range []string{"probe@example.com", "*****", "Mixed Case Value"} {
+		status := client.SetProperty("smtp.user", value)
+		require.Equal(t, http.StatusAccepted, status)
+
+		assert.Equal(t, value, readProperty(t, "smtp.user"))
+	}
+}
+
+func readProperty(t *testing.T, key string) string {
+	t.Helper()
+
+	resp, status := client.GetProperties()
+	require.Equal(t, http.StatusOK, status)
+
+	var properties map[string]string
+	require.NoError(t, json.Unmarshal(resp, &properties))
+
+	return properties[key]
 }

--- a/sensor_hub/service/properties_service.go
+++ b/sensor_hub/service/properties_service.go
@@ -20,21 +20,6 @@ func (ps *PropertiesService) ServiceUpdateProperties(ctx context.Context, proper
 	appProperties, smtpProperties, dbProperties := appProps.ConvertConfigurationToMaps(appProps.AppConfig)
 
 	for key, value := range properties {
-		if value == "*****" {
-			sensitiveKeys := appProps.SensitiveKeys()
-			isSensitive := false
-			for _, sensitiveKey := range sensitiveKeys {
-				if key == sensitiveKey {
-					isSensitive = true
-					break
-				}
-			}
-			if isSensitive {
-				continue
-				// unchanged sensitive property, skip updating
-			}
-		}
-
 		if _, ok := appProperties[key]; ok {
 			appProperties[key] = value
 		} else if _, ok := dbProperties[key]; ok {
@@ -86,14 +71,6 @@ func (ps *PropertiesService) ServiceGetProperties(ctx context.Context) (map[stri
 	}
 	for key, value := range smtpProperties {
 		propertiesMap[key] = value
-	}
-
-	for key := range propertiesMap {
-		for _, sensitiveKey := range appProps.SensitiveKeys() {
-			if key == sensitiveKey {
-				propertiesMap[key] = "*****"
-			}
-		}
 	}
 
 	return propertiesMap, nil

--- a/sensor_hub/service/properties_service_test.go
+++ b/sensor_hub/service/properties_service_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"testing"
 	"time"
@@ -59,22 +60,18 @@ func TestPropertiesService_ServiceGetProperties_Success(t *testing.T) {
 	assert.Contains(t, result, "auth.session.ttl.minutes")
 }
 
-func TestPropertiesService_ServiceGetProperties_MasksSensitiveData(t *testing.T) {
+func TestPropertiesService_ServiceGetProperties_ReturnsTheStoredValue(t *testing.T) {
 	cleanup := setupPropertiesServiceTestConfig()
 	defer cleanup()
+
+	appProps.AppConfig.SMTPUser = "admin@example.com"
 
 	service := NewPropertiesService(slog.Default())
 
 	result, err := service.ServiceGetProperties(context.Background())
 
 	assert.NoError(t, err)
-
-	// Verify sensitive properties are masked
-	for _, key := range appProps.SensitiveKeys() {
-		if val, ok := result[key]; ok {
-			assert.Equal(t, "*****", val, "Sensitive key %s should be masked", key)
-		}
-	}
+	assert.Equal(t, "admin@example.com", result["smtp.user"])
 }
 
 func TestPropertiesService_ServiceGetProperties_IncludesAllPropertyTypes(t *testing.T) {
@@ -123,27 +120,26 @@ func TestPropertiesService_ServiceUpdateProperties_Success(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 }
 
-func TestPropertiesService_ServiceUpdateProperties_SkipsMaskedSensitive(t *testing.T) {
-	cleanup := setupPropertiesServiceTestConfig()
-	defer cleanup()
+func TestPropertiesService_ServiceUpdateProperties_StoresTheSuppliedValue(t *testing.T) {
+	values := []string{"admin@example.com", "*****", "", "  spaced  "}
 
-	originalPath := appProps.AppConfig.DatabasePath
+	for _, value := range values {
+		t.Run(fmt.Sprintf("%q", value), func(t *testing.T) {
+			cleanup := setupPropertiesServiceTestConfig()
+			defer cleanup()
 
-	service := NewPropertiesService(slog.Default())
+			service := NewPropertiesService(slog.Default())
 
-	// No sensitive properties exist, so "*****" for a non-sensitive key will update it
-	properties := map[string]string{
-		"database.path": "*****",
+			err := service.ServiceUpdateProperties(context.Background(), map[string]string{
+				"smtp.user": value,
+			})
+
+			assert.NoError(t, err)
+			assert.Equal(t, value, appProps.AppConfig.SMTPUser)
+
+			time.Sleep(50 * time.Millisecond)
+		})
 	}
-
-	err := service.ServiceUpdateProperties(context.Background(), properties)
-
-	assert.NoError(t, err)
-	// DatabasePath is not sensitive, so it gets updated to the literal value
-	assert.NotEqual(t, originalPath, appProps.AppConfig.DatabasePath)
-	assert.Equal(t, "*****", appProps.AppConfig.DatabasePath)
-
-	time.Sleep(50 * time.Millisecond)
 }
 
 func TestPropertiesService_ServiceUpdateProperties_UpdatesDatabasePath(t *testing.T) {

--- a/sensor_hub/ui/sensor_hub_ui/src/gen/schema.d.ts
+++ b/sensor_hub/ui/sensor_hub_ui/src/gen/schema.d.ts
@@ -547,7 +547,7 @@ export interface paths {
         };
         /**
          * Get current application properties
-         * @description Returns a flat object mapping property keys to their current values. Sensitive properties (such as OAuth secrets) are masked in responses as `"*****"` to avoid leaking secrets. Values are returned as strings.
+         * @description Returns a flat object mapping property keys to their current values. Values are returned as strings.
          */
         get: operations["getProperties"];
         put?: never;
@@ -557,7 +557,7 @@ export interface paths {
         head?: never;
         /**
          * Update application properties
-         * @description Update one or more properties. Pass a JSON object where keys are the property names and values are the desired string values. To keep sensitive properties secret when you don't want to change them, pass the literal string `"*****"` as the value; the server will treat this as "do not change" for known sensitive keys.
+         * @description Update one or more properties. Pass a JSON object where keys are the property names and values are the desired string values.
          *     The update will be validated, applied to the in-memory configuration, and persisted to configuration files asynchronously. A broadcast is sent to the properties WebSocket topic after the update. Note: there is no separate endpoint for editing `smtp.properties` or `database.properties` — they are updated by key through this same API.
          */
         patch: operations["updateProperties"];
@@ -2087,7 +2087,6 @@ export interface components {
         SensorHealthStatus: "bad" | "good" | "unknown";
         /**
          * @description Flat map of configuration keys to values (all values as strings).
-         *     Sensitive values are masked ("*****") in responses.
          * @example {
          *       "smtp.user": "admin@example.com",
          *       "smtp.recipient": "alerts@example.com",
@@ -2099,10 +2098,10 @@ export interface components {
             [key: string]: string;
         };
         /**
-         * @description Map of properties to update. Use the literal string "*****" to indicate no change for sensitive keys.
+         * @description Map of properties to update. Every value is written through as supplied.
          * @example {
          *       "smtp.user": "new-user@example.com",
-         *       "oauth.client_secret": "*****"
+         *       "sensor.collection.interval": "300"
          *     }
          */
         UpdatePropertiesRequest: {


### PR DESCRIPTION
Fixes #267

No property in the registry holds a secret. "smtp.user" is an address and mail authentication goes through OAuth, so the masking machinery was protecting nothing while still shaping both the read and the write path, and the API was documenting a convention it no longer honoured in any meaningful case.

This takes it out. PropertyDef loses its Sensitive field, SensitiveKeys goes, and with them the masking branch in the properties read path, the skip-on-write branch in the update path and the exclusion in LogConfig, so the reload log now carries every property. The OpenAPI descriptions that documented the five-asterisk convention are rewritten and the Go and TypeScript clients regenerated. The struct tag reference in the developer docs no longer lists a "sensitive" tag that does not exist.

The separate masking mechanism for sensor and driver configuration fields is untouched. That one still carries real secrets.

## On the tests

The machinery was already inert on main, since nothing carried the tag, so a test written against it passes either way and proves nothing. Each behaviour here was checked by temporarily marking "smtp.user" sensitive, watching the test fail, then deleting the plumbing and watching it pass with the tag still applied. The first integration test written this way turned out to be vacuous - it asserted that five asterisks read back as five asterisks, which the old masking code also satisfied, since it masked everything to exactly that value. It has been replaced with a round-trip over several values, and the unit tests are framed as the contract that survives rather than as the absence of the deleted feature.

## Two things carried forward, both pre-existing

Under "go test -race", every ServiceUpdateProperties test fails, including five this change does not touch. The fire-and-forget save and broadcast goroutines read the configuration while the test writes it. CI does not run with the race detector so nothing fails today, though the new table case exercises the pattern more often than the single test it replaced. Making the async work waitable is a change to production code that would sit oddly in this slice.

The PropertiesMap example in the OpenAPI document still advertises "smtp.recipient", which is not a registered property. It is the same class of error as the "oauth.client_secret" example corrected one schema below it, and it can be picked up cheaply by whichever change next regenerates the clients.

## Verification

Unit tests, the integration suite per CLAUDE.md, the UI build and the frontend tests all pass. An adversarial review against the acceptance criteria ran from an isolated context and raised nothing actionable, having independently regenerated both client artifacts and confirmed they match what is committed.