### PR TITLE
Log level applies on save

### DIFF
--- a/docs/docs/development/troubleshooting.md
+++ b/docs/docs/development/troubleshooting.md
@@ -30,18 +30,16 @@ tail -f /var/log/sensor-hub/sensor-hub.log
 
 ### Debug Logging
 
-Temporarily enable debug logging by updating `log.level` in
+Temporarily enable debug logging by setting `log.level` to `debug` on the
+properties page, or by updating it in
 `/etc/sensor-hub/application.properties`:
 
 ```
 log.level=debug
 ```
 
-Then restart the service:
-
-```bash
-systemctl restart sensor-hub
-```
+The running process picks the new level up without a restart, either
+immediately on save or within a couple of seconds of an external file edit.
 
 Debug logging produces detailed output for every database operation, HTTP
 request, WebSocket event, and periodic task execution.

--- a/docs/docs/telemetry.md
+++ b/docs/docs/telemetry.md
@@ -22,7 +22,9 @@ Set the log level in `application.properties`:
 log.level=info
 ```
 
-Supported values: `debug`, `info`, `warn`, `error`. Default: `info`.
+Supported values: `debug`, `info`, `warn`, `error`. Default: `info`. An
+unrecognised value logs at `info`. The level applies to the running process as
+soon as the change is saved, with no restart.
 
 ### OpenTelemetry Collector
 

--- a/sensor_hub/application_properties/application_configuration.go
+++ b/sensor_hub/application_properties/application_configuration.go
@@ -3,6 +3,8 @@ package appProps
 import (
 	"log/slog"
 	"path/filepath"
+
+	"example/sensorHub/telemetry"
 )
 
 type ApplicationConfiguration struct {
@@ -98,6 +100,8 @@ func ReloadConfig(appProps, smtpProps, dbProps map[string]string) {
 	}
 
 	AppConfig = cfg
+
+	telemetry.SetLogLevel(cfg.LogLevel)
 
 	LogConfig(cfg)
 }

--- a/sensor_hub/cmd/serve.go
+++ b/sensor_hub/cmd/serve.go
@@ -51,12 +51,9 @@ func runServe(cmd *cobra.Command, args []string) error {
 
 	appProps.WatchConfigFiles(ctx)
 
-	logLevel := telemetry.ParseLogLevel(appProps.AppConfig.LogLevel)
-
 	tel, err := telemetry.Init(context.Background(), telemetry.Config{
 		ServiceName: "sensor-hub",
 		Version:     Version,
-		LogLevel:    logLevel,
 		LogFilePath: logFile,
 	})
 	if err != nil {

--- a/sensor_hub/service/properties_service.go
+++ b/sensor_hub/service/properties_service.go
@@ -20,9 +20,10 @@ func NewPropertiesService(logger *slog.Logger) *PropertiesService {
 
 // inBackground runs work the caller is deliberately not made to wait for: a
 // save has already taken effect in memory by the time it starts, so the file
-// write and the broadcast follow behind it. The service tracks them so that
-// anything which does need them settled can join rather than guess at how
-// long they take.
+// write and the broadcast follow behind it. The service tracks them only so
+// that tests can join the work rather than guess at how long it takes.
+// Nothing in production waits, and nothing should: a join running alongside
+// an in-flight save would race the counter back up from zero.
 func (ps *PropertiesService) inBackground(work func()) {
 	ps.background.Add(1)
 	go func() {

--- a/sensor_hub/service/properties_service.go
+++ b/sensor_hub/service/properties_service.go
@@ -6,14 +6,35 @@ import (
 	appProps "example/sensorHub/application_properties"
 	"example/sensorHub/ws"
 	"log/slog"
+	"sync"
 )
 
 type PropertiesService struct {
-	logger *slog.Logger
+	logger     *slog.Logger
+	background sync.WaitGroup
 }
 
 func NewPropertiesService(logger *slog.Logger) *PropertiesService {
 	return &PropertiesService{logger: logger.With("component", "properties_service")}
+}
+
+// inBackground runs work the caller is deliberately not made to wait for: a
+// save has already taken effect in memory by the time it starts, so the file
+// write and the broadcast follow behind it. The service tracks them so that
+// anything which does need them settled can join rather than guess at how
+// long they take.
+func (ps *PropertiesService) inBackground(work func()) {
+	ps.background.Add(1)
+	go func() {
+		defer ps.background.Done()
+		work()
+	}()
+}
+
+// waitForBackgroundWork blocks until the work started by every
+// [PropertiesService.ServiceUpdateProperties] call so far has finished.
+func (ps *PropertiesService) waitForBackgroundWork() {
+	ps.background.Wait()
 }
 
 func (ps *PropertiesService) ServiceUpdateProperties(ctx context.Context, properties map[string]string) error {
@@ -39,21 +60,21 @@ func (ps *PropertiesService) ServiceUpdateProperties(ctx context.Context, proper
 
 	appProps.ReloadConfig(appProperties, smtpProperties, dbProperties)
 
-	go func() {
+	ps.inBackground(func() {
 		err := appProps.SaveConfigurationToFiles()
 		if err != nil {
 			ps.logger.Error("error saving configuration to files", "error", err)
 		}
-	}()
+	})
 
-	go func() {
+	ps.inBackground(func() {
 		properties, err := ps.ServiceGetProperties(context.Background())
 		if err != nil {
 			ps.logger.Error("error fetching updated properties for broadcast", "error", err)
 			return
 		}
 		ws.BroadcastToTopic("properties", properties)
-	}()
+	})
 
 	return nil
 }

--- a/sensor_hub/service/properties_service_test.go
+++ b/sensor_hub/service/properties_service_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"log/slog"
@@ -8,6 +9,7 @@ import (
 	"time"
 
 	appProps "example/sensorHub/application_properties"
+	"example/sensorHub/telemetry"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -236,6 +238,89 @@ func TestPropertiesService_ServiceUpdateProperties_UnknownKey(t *testing.T) {
 	assert.Equal(t, 45, appProps.AppConfig.SensorCollectionInterval)
 
 	// Give async goroutines time to complete
+	time.Sleep(50 * time.Millisecond)
+}
+
+// ============================================================================
+// Log level tests
+// ============================================================================
+
+func TestPropertiesService_ServiceUpdateProperties_LogLevelTakesEffectOnSave(t *testing.T) {
+	cleanup := setupPropertiesServiceTestConfig()
+	defer cleanup()
+
+	appProps.AppConfig.LogLevel = "info"
+	telemetry.SetLogLevel("info")
+
+	var logs bytes.Buffer
+	logger := telemetry.NewLogger(&logs, nil)
+
+	service := NewPropertiesService(slog.Default())
+
+	err := service.ServiceUpdateProperties(context.Background(), map[string]string{
+		"log.level": "debug",
+	})
+
+	assert.NoError(t, err)
+
+	logger.Debug("a line only debug emits")
+	assert.Contains(t, logs.String(), "a line only debug emits")
+
+	time.Sleep(50 * time.Millisecond)
+}
+
+func TestPropertiesService_ServiceUpdateProperties_LogLevelStopsDebugAgainOnSave(t *testing.T) {
+	cleanup := setupPropertiesServiceTestConfig()
+	defer cleanup()
+
+	appProps.AppConfig.LogLevel = "debug"
+	telemetry.SetLogLevel("debug")
+
+	var logs bytes.Buffer
+	logger := telemetry.NewLogger(&logs, nil)
+
+	service := NewPropertiesService(slog.Default())
+
+	err := service.ServiceUpdateProperties(context.Background(), map[string]string{
+		"log.level": "info",
+	})
+
+	assert.NoError(t, err)
+
+	logger.Debug("a line only debug emits")
+	logger.Info("a line info emits")
+
+	assert.NotContains(t, logs.String(), "a line only debug emits")
+	assert.Contains(t, logs.String(), "a line info emits")
+
+	time.Sleep(50 * time.Millisecond)
+}
+
+func TestPropertiesService_ServiceUpdateProperties_UnrecognisedLogLevelSavesAndLogsAtInfo(t *testing.T) {
+	cleanup := setupPropertiesServiceTestConfig()
+	defer cleanup()
+
+	appProps.AppConfig.LogLevel = "debug"
+	telemetry.SetLogLevel("debug")
+
+	var logs bytes.Buffer
+	logger := telemetry.NewLogger(&logs, nil)
+
+	service := NewPropertiesService(slog.Default())
+
+	err := service.ServiceUpdateProperties(context.Background(), map[string]string{
+		"log.level": "loud",
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, "loud", appProps.AppConfig.LogLevel)
+
+	logger.Debug("a line only debug emits")
+	logger.Info("a line info emits")
+
+	assert.NotContains(t, logs.String(), "a line only debug emits")
+	assert.Contains(t, logs.String(), "a line info emits")
+
 	time.Sleep(50 * time.Millisecond)
 }
 

--- a/sensor_hub/service/properties_service_test.go
+++ b/sensor_hub/service/properties_service_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"testing"
-	"time"
 
 	appProps "example/sensorHub/application_properties"
 	"example/sensorHub/telemetry"
@@ -119,7 +118,7 @@ func TestPropertiesService_ServiceUpdateProperties_Success(t *testing.T) {
 	assert.Equal(t, 60, appProps.AppConfig.SensorCollectionInterval)
 	assert.Equal(t, 120, appProps.AppConfig.AuthSessionTTLMinutes)
 
-	time.Sleep(50 * time.Millisecond)
+	service.waitForBackgroundWork()
 }
 
 func TestPropertiesService_ServiceUpdateProperties_StoresTheSuppliedValue(t *testing.T) {
@@ -139,7 +138,7 @@ func TestPropertiesService_ServiceUpdateProperties_StoresTheSuppliedValue(t *tes
 			assert.NoError(t, err)
 			assert.Equal(t, value, appProps.AppConfig.SMTPUser)
 
-			time.Sleep(50 * time.Millisecond)
+			service.waitForBackgroundWork()
 		})
 	}
 }
@@ -159,7 +158,7 @@ func TestPropertiesService_ServiceUpdateProperties_UpdatesDatabasePath(t *testin
 	assert.NoError(t, err)
 	assert.Equal(t, "new/path/sensor_hub.db", appProps.AppConfig.DatabasePath)
 
-	time.Sleep(50 * time.Millisecond)
+	service.waitForBackgroundWork()
 }
 
 func TestPropertiesService_ServiceUpdateProperties_InvalidValue(t *testing.T) {
@@ -178,7 +177,7 @@ func TestPropertiesService_ServiceUpdateProperties_InvalidValue(t *testing.T) {
 	// Should return error for invalid values
 	assert.Error(t, err)
 
-	time.Sleep(50 * time.Millisecond)
+	service.waitForBackgroundWork()
 }
 
 func TestPropertiesService_ServiceUpdateProperties_PartialUpdate(t *testing.T) {
@@ -201,7 +200,7 @@ func TestPropertiesService_ServiceUpdateProperties_PartialUpdate(t *testing.T) {
 	// Other properties should remain unchanged
 	assert.Equal(t, originalSessionTTL, appProps.AppConfig.AuthSessionTTLMinutes)
 
-	time.Sleep(50 * time.Millisecond)
+	service.waitForBackgroundWork()
 }
 
 func TestPropertiesService_ServiceUpdateProperties_EmptyMap(t *testing.T) {
@@ -216,7 +215,7 @@ func TestPropertiesService_ServiceUpdateProperties_EmptyMap(t *testing.T) {
 
 	assert.NoError(t, err)
 
-	time.Sleep(50 * time.Millisecond)
+	service.waitForBackgroundWork()
 }
 
 func TestPropertiesService_ServiceUpdateProperties_UnknownKey(t *testing.T) {
@@ -237,8 +236,7 @@ func TestPropertiesService_ServiceUpdateProperties_UnknownKey(t *testing.T) {
 	// Known property should still be updated
 	assert.Equal(t, 45, appProps.AppConfig.SensorCollectionInterval)
 
-	// Give async goroutines time to complete
-	time.Sleep(50 * time.Millisecond)
+	service.waitForBackgroundWork()
 }
 
 // ============================================================================
@@ -251,6 +249,7 @@ func TestPropertiesService_ServiceUpdateProperties_LogLevelTakesEffectOnSave(t *
 
 	appProps.AppConfig.LogLevel = "info"
 	telemetry.SetLogLevel("info")
+	defer telemetry.SetLogLevel("info")
 
 	var logs bytes.Buffer
 	logger := telemetry.NewLogger(&logs, nil)
@@ -266,7 +265,7 @@ func TestPropertiesService_ServiceUpdateProperties_LogLevelTakesEffectOnSave(t *
 	logger.Debug("a line only debug emits")
 	assert.Contains(t, logs.String(), "a line only debug emits")
 
-	time.Sleep(50 * time.Millisecond)
+	service.waitForBackgroundWork()
 }
 
 func TestPropertiesService_ServiceUpdateProperties_LogLevelStopsDebugAgainOnSave(t *testing.T) {
@@ -275,6 +274,7 @@ func TestPropertiesService_ServiceUpdateProperties_LogLevelStopsDebugAgainOnSave
 
 	appProps.AppConfig.LogLevel = "debug"
 	telemetry.SetLogLevel("debug")
+	defer telemetry.SetLogLevel("info")
 
 	var logs bytes.Buffer
 	logger := telemetry.NewLogger(&logs, nil)
@@ -293,7 +293,7 @@ func TestPropertiesService_ServiceUpdateProperties_LogLevelStopsDebugAgainOnSave
 	assert.NotContains(t, logs.String(), "a line only debug emits")
 	assert.Contains(t, logs.String(), "a line info emits")
 
-	time.Sleep(50 * time.Millisecond)
+	service.waitForBackgroundWork()
 }
 
 func TestPropertiesService_ServiceUpdateProperties_UnrecognisedLogLevelSavesAndLogsAtInfo(t *testing.T) {
@@ -302,6 +302,7 @@ func TestPropertiesService_ServiceUpdateProperties_UnrecognisedLogLevelSavesAndL
 
 	appProps.AppConfig.LogLevel = "debug"
 	telemetry.SetLogLevel("debug")
+	defer telemetry.SetLogLevel("info")
 
 	var logs bytes.Buffer
 	logger := telemetry.NewLogger(&logs, nil)
@@ -321,7 +322,7 @@ func TestPropertiesService_ServiceUpdateProperties_UnrecognisedLogLevelSavesAndL
 	assert.NotContains(t, logs.String(), "a line only debug emits")
 	assert.Contains(t, logs.String(), "a line info emits")
 
-	time.Sleep(50 * time.Millisecond)
+	service.waitForBackgroundWork()
 }
 
 // ============================================================================

--- a/sensor_hub/telemetry/logger.go
+++ b/sensor_hub/telemetry/logger.go
@@ -56,8 +56,19 @@ func (m *multiHandler) WithGroup(name string) slog.Handler {
 	return newMultiHandler(handlers...)
 }
 
-// ParseLogLevel converts a string log level to slog.Level.
-func ParseLogLevel(level string) slog.Level {
+// logLevel is the level every logger built by [NewLogger] consults per record,
+// so a configuration reload can change what the running process logs at
+// without a restart. It reads as info until something sets it.
+var logLevel = new(slog.LevelVar)
+
+// SetLogLevel points every logger in the process at the named level.
+// An unrecognised name falls back to info.
+func SetLogLevel(level string) {
+	logLevel.Set(parseLogLevel(level))
+}
+
+// parseLogLevel converts a string log level to slog.Level.
+func parseLogLevel(level string) slog.Level {
 	switch strings.ToLower(strings.TrimSpace(level)) {
 	case "debug":
 		return slog.LevelDebug
@@ -72,9 +83,11 @@ func ParseLogLevel(level string) slog.Level {
 
 // NewLogger creates a structured slog.Logger.
 // It writes JSON to the provided writer and optionally bridges to an OTel LoggerProvider.
-func NewLogger(level slog.Level, writer io.Writer, logProvider *sdklog.LoggerProvider) *slog.Logger {
+// The logger filters on the process log level, which [SetLogLevel] can change
+// at any point in its life.
+func NewLogger(writer io.Writer, logProvider *sdklog.LoggerProvider) *slog.Logger {
 	opts := &slog.HandlerOptions{
-		Level:     level,
+		Level:     logLevel,
 		AddSource: true,
 	}
 

--- a/sensor_hub/telemetry/logger.go
+++ b/sensor_hub/telemetry/logger.go
@@ -11,16 +11,24 @@ import (
 	sdklog "go.opentelemetry.io/otel/sdk/log"
 )
 
-// multiHandler fans out log records to multiple slog handlers.
+// multiHandler fans out log records to multiple slog handlers, filtering on
+// the process log level first. The filter belongs here rather than in each
+// handler because the OTel bridge accepts every level it is offered, so
+// without it a record below the configured level would still be built and
+// shipped to the collector.
 type multiHandler struct {
+	level    slog.Leveler
 	handlers []slog.Handler
 }
 
-func newMultiHandler(handlers ...slog.Handler) *multiHandler {
-	return &multiHandler{handlers: handlers}
+func newMultiHandler(level slog.Leveler, handlers ...slog.Handler) *multiHandler {
+	return &multiHandler{level: level, handlers: handlers}
 }
 
 func (m *multiHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	if level < m.level.Level() {
+		return false
+	}
 	for _, h := range m.handlers {
 		if h.Enabled(ctx, level) {
 			return true
@@ -45,7 +53,7 @@ func (m *multiHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 	for i, h := range m.handlers {
 		handlers[i] = h.WithAttrs(attrs)
 	}
-	return newMultiHandler(handlers...)
+	return newMultiHandler(m.level, handlers...)
 }
 
 func (m *multiHandler) WithGroup(name string) slog.Handler {
@@ -53,7 +61,7 @@ func (m *multiHandler) WithGroup(name string) slog.Handler {
 	for i, h := range m.handlers {
 		handlers[i] = h.WithGroup(name)
 	}
-	return newMultiHandler(handlers...)
+	return newMultiHandler(m.level, handlers...)
 }
 
 // logLevel is the level every logger built by [NewLogger] consults per record,
@@ -96,7 +104,7 @@ func NewLogger(writer io.Writer, logProvider *sdklog.LoggerProvider) *slog.Logge
 	var handler slog.Handler
 	if logProvider != nil {
 		otelHandler := otelslog.NewHandler("sensor-hub", otelslog.WithLoggerProvider(logProvider))
-		handler = newMultiHandler(jsonHandler, otelHandler)
+		handler = newMultiHandler(logLevel, jsonHandler, otelHandler)
 	} else {
 		handler = jsonHandler
 	}

--- a/sensor_hub/telemetry/logger_test.go
+++ b/sensor_hub/telemetry/logger_test.go
@@ -1,0 +1,70 @@
+package telemetry_test
+
+import (
+	"context"
+	"io"
+	"sync"
+	"testing"
+
+	sdklog "go.opentelemetry.io/otel/sdk/log"
+
+	"example/sensorHub/telemetry"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// recordingExporter stands in for a collector, capturing the message of every
+// record that reaches the export pipeline.
+type recordingExporter struct {
+	mu       sync.Mutex
+	messages []string
+}
+
+func (r *recordingExporter) Export(_ context.Context, records []sdklog.Record) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, record := range records {
+		r.messages = append(r.messages, record.Body().AsString())
+	}
+	return nil
+}
+
+func (r *recordingExporter) Shutdown(context.Context) error { return nil }
+
+func (r *recordingExporter) ForceFlush(context.Context) error { return nil }
+
+func (r *recordingExporter) exported() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.messages...)
+}
+
+func newRecordingProvider(exporter *recordingExporter) *sdklog.LoggerProvider {
+	return sdklog.NewLoggerProvider(sdklog.WithProcessor(sdklog.NewSimpleProcessor(exporter)))
+}
+
+func TestNewLogger_ExportsNothingBelowTheConfiguredLevel(t *testing.T) {
+	telemetry.SetLogLevel("info")
+	defer telemetry.SetLogLevel("info")
+
+	exporter := &recordingExporter{}
+	logger := telemetry.NewLogger(io.Discard, newRecordingProvider(exporter))
+
+	logger.Debug("a line only debug emits")
+	logger.Info("a line info emits")
+
+	assert.Equal(t, []string{"a line info emits"}, exporter.exported())
+}
+
+func TestNewLogger_ExportsDebugOnceTheLevelAllowsIt(t *testing.T) {
+	telemetry.SetLogLevel("info")
+	defer telemetry.SetLogLevel("info")
+
+	exporter := &recordingExporter{}
+	logger := telemetry.NewLogger(io.Discard, newRecordingProvider(exporter))
+
+	telemetry.SetLogLevel("debug")
+	logger.Debug("a line only debug emits")
+
+	assert.Equal(t, []string{"a line only debug emits"}, exporter.exported())
+}

--- a/sensor_hub/telemetry/telemetry.go
+++ b/sensor_hub/telemetry/telemetry.go
@@ -10,9 +10,9 @@ import (
 
 	"go.opentelemetry.io/contrib/instrumentation/runtime"
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc"
-	"go.opentelemetry.io/otel/sdk/resource"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 )
@@ -31,7 +31,6 @@ type Telemetry struct {
 type Config struct {
 	ServiceName string
 	Version     string
-	LogLevel    slog.Level
 	LogFilePath string
 }
 
@@ -75,7 +74,7 @@ func Init(ctx context.Context, cfg Config) (*Telemetry, error) {
 	if err != nil {
 		return nil, err
 	}
-	logger := NewLogger(cfg.LogLevel, writer, logProvider)
+	logger := NewLogger(writer, logProvider)
 
 	// Tracer
 	tp, err := initTracerProvider(ctx, res, exportEnabled)
@@ -97,7 +96,7 @@ func Init(ctx context.Context, cfg Config) (*Telemetry, error) {
 	logger.Info("telemetry initialised",
 		"service", serviceName,
 		"version", cfg.Version,
-		"log_level", cfg.LogLevel.String(),
+		"log_level", logLevel.Level().String(),
 		"otel_export", exportEnabled,
 	)
 


### PR DESCRIPTION
Turning on debug logging meant restarting the service, which is the wrong constraint when a fault is in front of you and you are on a phone. The level was baked into the slog handler as a fixed value at boot, so a save through the properties page reported success and the running process carried on at whatever it started with.

The level now lives in a slog.LevelVar inside the telemetry package, which every logger consults per record, and ReloadConfig sets it. That covers both doors into configuration: a save through the properties API, and an external file edit the config watcher reloads within a couple of seconds. Telemetry no longer takes a level at boot, so configuration is the only thing deciding what the process logs at, and "ParseLogLevel" lost its last external caller and is now unexported.

Two things surfaced during review that were worth taking here rather than leaving.

The first is that the fan-out handler asked its children whether a record was wanted, and the OTel bridge accepts everything it is offered. With a collector configured, every debug record was still being built with its source attached and shipped, whatever the level said - the level governed stdout and the log file alone. That was equally true before this change, but it lands squarely on the criterion about dialling back to info, and the tests could not see it because they passed a nil provider. The filter now sits in the fan-out ahead of both sinks, and the tests exercise the export path against a recording exporter.

The second is that the properties service starts a file write and a broadcast that nothing could observe, so the tests slept 50ms and hoped. Under the race detector that sleep is not a synchronisation edge at all, and the whole ServiceUpdateProperties set reported races against the configuration global. The service now tracks what it starts and the tests join it. The write stays fire-and-forget for real callers, as the spec intends, and nothing in production waits.

Worth knowing: the race detector still reports pre-existing races in the actuation and oauth packages. They pre-date this branch, sit in packages this work does not touch, and CI does not run with race detection, so nothing is failing today.

Two adversarial review rounds ran against the acceptance criteria. Unit tests, race detection over the packages this touches, and the integration suite are all clean on the final tree.

Fixes #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)